### PR TITLE
Tilset importer fix for external .tsx tilesets

### DIFF
--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapImporter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapImporter.cs
@@ -12,7 +12,23 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
             using (var reader = new StreamReader(filename))
             {
                 var serializer = new XmlSerializer(typeof(TmxMap));
-                return (TmxMap)serializer.Deserialize(reader);
+                var map = (TmxMap)serializer.Deserialize(reader);
+
+                XmlSerializer xml = new XmlSerializer(typeof(TmxTileset));
+                for (int i = 0; i < map.Tilesets.Count; i++)
+                {
+                    var tileset = map.Tilesets[i];
+                    if (!string.IsNullOrWhiteSpace(tileset.Source))
+                    {
+                        string dir = Path.GetDirectoryName(filename);
+                        string tilesetLocation = tileset.Source.Replace('/', Path.DirectorySeparatorChar);
+                        string filePath = Path.Combine(dir, tilesetLocation);
+                        using (FileStream file = new FileStream(filePath, FileMode.Open))
+                            map.Tilesets[i] = (TmxTileset)xml.Deserialize(file);
+                    }
+                }
+
+                return map;
             }
         }
     }


### PR DESCRIPTION
The content pipeline extension was throwing an exception when one tried to build a .tmx Tiled map file with a tileset that pointed to an external .tsx file. The fix checks for such tilesets, deserializes the external file and replaces the one in the main map instance.