### PR TITLE
Draw method update for TiledLayer and TiledTileLayer

### DIFF
--- a/Source/MonoGame.Extended/Maps/Tiled/TiledLayer.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledLayer.cs
@@ -18,7 +18,6 @@ namespace MonoGame.Extended.Maps.Tiled
 
         public abstract void Draw();
 
-        [Obsolete("The camera is no longer required for drawing Tiled layers")]
         public abstract void Draw(Camera2D camera);
     }
 }

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Vector2Extensions.cs" />
     <Compile Include="ViewportAdapters\BoxingViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\DefaultViewportAdapter.cs" />
+    <Compile Include="ViewportAdapters\WindowViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\ScalingViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\ViewportAdapter.cs" />
     <Compile Include="FramesPerSecondCounter.cs" />

--- a/Source/MonoGame.Extended/ViewportAdapters/WindowViewportAdapter.cs
+++ b/Source/MonoGame.Extended/ViewportAdapters/WindowViewportAdapter.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace MonoGame.Extended.ViewportAdapters
 {

--- a/Source/MonoGame.Extended/ViewportAdapters/WindowViewportAdapter.cs
+++ b/Source/MonoGame.Extended/ViewportAdapters/WindowViewportAdapter.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MonoGame.Extended.ViewportAdapters
+{
+    public class WindowViewportAdapter : ViewportAdapter
+    {
+        public WindowViewportAdapter(GameWindow window, GraphicsDevice graphicsDevice)
+        {
+            GraphicsDevice = graphicsDevice;
+            Window = window;
+            window.ClientSizeChanged += OnClientSizeChanged;
+        }
+
+        protected readonly GameWindow Window;
+        protected GraphicsDevice GraphicsDevice;
+
+        public override int ViewportWidth
+        {
+            get { return Window.ClientBounds.Width; }
+        }
+        public override int ViewportHeight
+        {
+            get { return Window.ClientBounds.Height; }
+        }
+
+        public override int VirtualWidth
+        {
+            get { return Window.ClientBounds.Width; }
+        }
+
+        public override int VirtualHeight
+        {
+            get { return Window.ClientBounds.Height; }
+        }
+
+        public override Matrix GetScaleMatrix()
+        {
+            return Matrix.Identity;
+        }
+
+        private void OnClientSizeChanged(object sender, EventArgs eventArgs)
+        {
+            var x = Window.ClientBounds.Width;
+            var y = Window.ClientBounds.Height;
+
+            GraphicsDevice.Viewport = new Viewport(0, 0, x, y);
+        }
+
+    }
+}


### PR DESCRIPTION
I use <kbd>Ctrl + K, D</kbd> a lot out of habit, so it added a little formatting to a couple of things.

TiledTileLayer:
* The obsolete method `Draw(Camera2D camera)` no longer obsolete


TiledLayer:
* The obsolete method `Draw(Camera2D camera)` no longer obsolete.
* Implemented `Draw(Camera2D camera)` so that it only renders tiles within the camera's bounds.
