### PR TITLE
Fixed BoxingViewportAdapter for DirectX Rendering

### DIFF
--- a/Source/MonoGame.Extended/ViewportAdapters/BoxingViewportAdapter.cs
+++ b/Source/MonoGame.Extended/ViewportAdapters/BoxingViewportAdapter.cs
@@ -12,14 +12,20 @@ namespace MonoGame.Extended.ViewportAdapters
 
     public class BoxingViewportAdapter : ScalingViewportAdapter
     {
-        public BoxingViewportAdapter(GameWindow window, GraphicsDevice graphicsDevice, int virtualWidth, int virtualHeight)
-            : base(graphicsDevice, virtualWidth, virtualHeight)
+        private readonly GraphicsDeviceManager _graphicsDeviceManager;
+        private readonly GameWindow _window;
+
+        public BoxingViewportAdapter(GameWindow window, GraphicsDeviceManager graphicsDeviceManager, int virtualWidth, int virtualHeight)
+            : base(graphicsDeviceManager.GraphicsDevice, virtualWidth, virtualHeight)
         {
+            _graphicsDeviceManager = graphicsDeviceManager;
+            _window = window;
+
             window.ClientSizeChanged += OnClientSizeChanged;
         }
 
         public BoxingMode BoxingMode { get; private set; }
-        
+
         private void OnClientSizeChanged(object sender, EventArgs eventArgs)
         {
             var viewport = GraphicsDevice.Viewport;
@@ -41,6 +47,15 @@ namespace MonoGame.Extended.ViewportAdapters
             var x = (viewport.Width / 2) - (width / 2);
             var y = (viewport.Height / 2) - (height / 2);
             GraphicsDevice.Viewport = new Viewport(x, y, width, height);
+
+			// Needed for DirectX rendering
+			// see http://gamedev.stackexchange.com/questions/68914/issue-with-monogame-resizing
+			if (_graphicsDeviceManager.PreferredBackBufferWidth != _window.ClientBounds.Width || _graphicsDeviceManager.PreferredBackBufferHeight != _window.ClientBounds.Height)
+			{
+				_graphicsDeviceManager.PreferredBackBufferWidth = _window.ClientBounds.Width;
+				_graphicsDeviceManager.PreferredBackBufferHeight = _window.ClientBounds.Height;
+				_graphicsDeviceManager.ApplyChanges();
+            }
         }
 
         public override Point PointToScreen(int x, int y)


### PR DESCRIPTION
Hi,

I managed to find a bug in the `BoxingViewportAdapter` with DirectX rendering, annoyingly it works with MonoGame.Linux and MonoGame.OpenGL without problems.
But with MonoGame.DirectX the PrefferedBackBufferSize isn't correctly updated when the window is resized, which results in a distortion of the rendering.
 *(see: http://gfycat.com/BasicLegalHerculesbeetle)*

To fix this the PrefferedBackBufferSize has to be manually updated.
*(http://gamedev.stackexchange.com/questions/68914/issue-with-monogame-resizing)*


The `BoxingViewportAdapter` now needs to get a `GraphicsDeviceManager` in its constructor instead of an `GraphicsDevice`. Perhaps that should be changed in the other Adapters too. So that the interface stays symmetrical? If you want I can change that in this pull request too.

&nbsp;

Greetings,
Mike

PS: Nice library you're doing here. I'm planning to do a few games for android and looking forward to use it :D