### PR TITLE
Support to Object Layers

### DIFF
--- a/Source/Demo.TiledMaps/Content/level01.tmx
+++ b/Source/Demo.TiledMaps/Content/level01.tmx
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="10" tilewidth="128" tileheight="128" backgroundcolor="#7d7d7d" nextobjectid="1">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="10" tilewidth="128" tileheight="128" backgroundcolor="#7d7d7d" nextobjectid="7">
  <properties>
   <property name="awesome" value="42"/>
  </properties>
- <tileset firstgid="1" name="free-tileset" tilewidth="128" tileheight="128" spacing="2" margin="2" tilecount="30">
+ <tileset firstgid="1" name="free-tileset" tilewidth="128" tileheight="128" spacing="2" margin="2" tilecount="30" columns="5">
   <image source="free-tileset.png" width="652" height="782"/>
   <tile id="7">
    <properties>
@@ -232,7 +232,7 @@
    <property name="customlayerprop2" value="2"/>
   </properties>
   <data>
-   <tile gid="0"/>
+   <tile gid="27"/>
    <tile gid="0"/>
    <tile gid="0"/>
    <tile gid="0"/>
@@ -434,4 +434,8 @@
    <tile gid="5"/>
   </data>
  </layer>
+ <objectgroup name="Objects Layer 1">
+  <object id="5" gid="26" x="117" y="751" width="128" height="128"/>
+  <object id="6" gid="1" x="232" y="630." width="128" height="128"/>
+ </objectgroup>
 </map>

--- a/Source/Demo.TiledMaps/Content/level01.tmx
+++ b/Source/Demo.TiledMaps/Content/level01.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="10" tilewidth="128" tileheight="128" backgroundcolor="#7d7d7d" nextobjectid="7">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="20" height="10" tilewidth="128" tileheight="128" backgroundcolor="#7d7d7d" nextobjectid="11">
  <properties>
   <property name="awesome" value="42"/>
  </properties>
@@ -232,7 +232,7 @@
    <property name="customlayerprop2" value="2"/>
   </properties>
   <data>
-   <tile gid="27"/>
+   <tile gid="0"/>
    <tile gid="0"/>
    <tile gid="0"/>
    <tile gid="0"/>
@@ -435,7 +435,16 @@
   </data>
  </layer>
  <objectgroup name="Objects Layer 1">
-  <object id="5" gid="26" x="117" y="751" width="128" height="128"/>
-  <object id="6" gid="1" x="232" y="630." width="128" height="128"/>
+  <properties>
+   <property name="objLayerProp" value="true"/>
+  </properties>
+  <object id="5" gid="26" x="128" y="896" width="297" height="342">
+   <properties>
+    <property name="othe" value="nope"/>
+    <property name="test" value="true"/>
+   </properties>
+  </object>
+  <object id="9" gid="2" x="0" y="512" width="128" height="128"/>
+  <object id="10" gid="2" x="256" y="640" width="128" height="128"/>
  </objectgroup>
 </map>

--- a/Source/Demo.TiledMaps/Game1.cs
+++ b/Source/Demo.TiledMaps/Game1.cs
@@ -36,6 +36,7 @@ namespace Demo.TiledMaps
             _sprite = new Sprite(_texture) { Position = new Vector2(600, 240) };
 
             _tiledMap = Content.Load<TiledMap>("level01");
+            var objs = _tiledMap.ObjectGroups[0];
             _camera.LookAt(new Vector2(_tiledMap.WidthInPixels, _tiledMap.HeightInPixels) * 0.5f);
         }
 

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
@@ -72,6 +72,26 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 
                 WriteCustomProperties(writer, layer.Properties);
             }
+
+            writer.Write(map.ObjectGroups.Count);
+
+            foreach (var objectGroup in map.ObjectGroups)
+            {
+                writer.Write(objectGroup.Name);
+                writer.Write(objectGroup.Visible);
+                writer.Write(objectGroup.Opacity);
+
+                writer.Write(objectGroup.Objects.Count);
+
+                foreach (var objectG in objectGroup.Objects)
+                {
+                    writer.Write(objectG.Gid);
+                    writer.Write(objectG.X);
+                    writer.Write(objectG.Y);
+                    writer.Write(objectG.Width);
+                    writer.Write(objectG.Height);
+                }
+            }
         }
 
         private static void WriteCustomProperties(ContentWriter writer, List<TmxProperty> properties)

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
@@ -90,7 +90,10 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                     writer.Write(objectG.Y);
                     writer.Write(objectG.Width);
                     writer.Write(objectG.Height);
+                    WriteCustomProperties(writer, objectG.Properties);
                 }
+
+                WriteCustomProperties(writer, objectGroup.Properties);
             }
         }
 

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TmxObject.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TmxObject.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace MonoGame.Extended.Content.Pipeline.Tiled
@@ -33,6 +34,10 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 
         [XmlElement(ElementName = "image")]
         public TmxImage Image { get; set; }
+        
+        [XmlArray("properties")]
+        [XmlArrayItem("property")]
+        public List<TmxProperty> Properties { get; set; }
 
         //[XmlElement(ElementName = "ellipse")]
         //public TmxEllipse Ellipse { get; set; }

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
@@ -16,6 +16,7 @@ namespace MonoGame.Extended.Maps.Tiled
             _renderTarget = new RenderTarget2D(graphicsDevice, width*tileWidth, height*tileHeight);
             //_spriteBatch = new SpriteBatch(graphicsDevice);
             _layers = new List<TiledLayer>();
+            _objectGroups = new List<TiledObjectGroup>();
             _tilesets = new List<TiledTileset>();
 
             Width = width;
@@ -35,6 +36,7 @@ namespace MonoGame.Extended.Maps.Tiled
         private readonly List<TiledTileset> _tilesets;
         private readonly GraphicsDevice _graphicsDevice;
         private readonly List<TiledLayer> _layers;
+        private readonly List<TiledObjectGroup> _objectGroups;
         private readonly RenderTarget2D _renderTarget;
         //private readonly SpriteBatch _spriteBatch;
 
@@ -47,6 +49,7 @@ namespace MonoGame.Extended.Maps.Tiled
         public TiledProperties Properties { get; private set; }
         public TiledMapOrientation Orientation { get; private set; }
 
+        public List<TiledObjectGroup> ObjectGroups => _objectGroups;
         public IEnumerable<TiledLayer> Layers => _layers;
         public IEnumerable<TiledImageLayer> ImageLayers => _layers.OfType<TiledImageLayer>();
         public IEnumerable<TiledTileLayer> TileLayers => _layers.OfType<TiledTileLayer>();
@@ -72,6 +75,13 @@ namespace MonoGame.Extended.Maps.Tiled
             var layer = new TiledImageLayer(_graphicsDevice, name, texture, position);
             _layers.Add(layer);
             return layer;
+        }
+
+        public TiledObjectGroup CreateObjectGroup(string name, TiledObject[] objects)
+        {
+            var objectGroup = new TiledObjectGroup(name, objects);
+            _objectGroups.Add(objectGroup);
+            return objectGroup;
         }
 
         public TiledLayer GetLayer(string name)

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
@@ -54,6 +54,7 @@ namespace MonoGame.Extended.Maps.Tiled
             for (var i = 0; i < objectGroupsCount; i++)
             {
                 var objectGroup = ReadObjectGroup(reader, tiledMap);
+                ReadCustomProperties(reader, objectGroup.Properties);
             }
 
             return tiledMap;
@@ -74,6 +75,7 @@ namespace MonoGame.Extended.Maps.Tiled
                                                 reader.ReadInt32(),
                                                 reader.ReadInt32(),
                                                 reader.ReadInt32());
+                ReadCustomProperties(reader, objects[i].Properties);
             }
 
             return tiledMap.CreateObjectGroup(groupName, objects);

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
@@ -49,7 +49,34 @@ namespace MonoGame.Extended.Maps.Tiled
                 ReadCustomProperties(reader, layer.Properties);
             }
 
+            var objectGroupsCount = reader.ReadInt32();
+
+            for (var i = 0; i < objectGroupsCount; i++)
+            {
+                var objectGroup = ReadObjectGroup(reader, tiledMap);
+            }
+
             return tiledMap;
+        }
+
+        private static TiledObjectGroup ReadObjectGroup(ContentReader reader, TiledMap tiledMap)
+        {
+            var groupName = reader.ReadString();
+            var visible = reader.ReadBoolean();
+            var opacity = reader.ReadSingle();
+
+            var objCount = reader.ReadInt32();
+            var objects = new TiledObject[objCount];
+            for (var i = 0; i < objCount; i++)
+            {
+                objects[i] = new TiledObject(   reader.ReadInt32(),
+                                                reader.ReadInt32(),
+                                                reader.ReadInt32(),
+                                                reader.ReadInt32(),
+                                                reader.ReadInt32());
+            }
+
+            return tiledMap.CreateObjectGroup(groupName, objects);
         }
 
         private static void ReadCustomProperties(ContentReader reader, TiledProperties properties)

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MonoGame.Extended.Maps.Tiled
+{
+    public class TiledObject
+    {
+        public TiledObject(int id, int x, int y, int width, int height)
+        {
+            Id = id;
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+        }
+
+        public int Id { get; private set; }
+        public int X { get; private set; }
+        public int Y { get; private set; }
+        public int Width { get; private set; }
+        public int Height { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("{0}", Id);
+        }
+    }
+}

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
@@ -14,6 +14,7 @@ namespace MonoGame.Extended.Maps.Tiled
             Y = y;
             Width = width;
             Height = height;
+            Properties = new TiledProperties();
         }
 
         public int Id { get; private set; }
@@ -21,6 +22,7 @@ namespace MonoGame.Extended.Maps.Tiled
         public int Y { get; private set; }
         public int Width { get; private set; }
         public int Height { get; private set; }
+        public TiledProperties Properties { get; private set; }
 
         public override string ToString()
         {

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledObjectGroup.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledObjectGroup.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using MonoGame.Extended.Shapes;
+
+namespace MonoGame.Extended.Maps.Tiled
+{
+    public class TiledObjectGroup
+    {
+        public TiledObjectGroup(string name, TiledObject[] objects)
+        {
+            Name = name;
+            Objects = objects;
+            Properties = new TiledProperties();
+        }
+
+        public string Name { get; private set; }
+        public TiledObject[] Objects { get; private set; }
+        public TiledProperties Properties { get; private set; }
+    }
+}

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledTileSet.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledTileSet.cs
@@ -8,9 +8,6 @@ namespace MonoGame.Extended.Maps.Tiled
     {
         public TiledTileset(Texture2D texture, int firstId, int tileWidth, int tileHeight, int spacing = 2, int margin = 2)
         {
-            if (texture.Width % tileWidth != 0 || texture.Height % tileHeight != 0)
-                throw new System.InvalidOperationException("The tileset file size is not multiple of the tile size. Make sure the tile grid is correct.");
-
             Texture = texture;
             FirstId = firstId;
             TileWidth = tileWidth;

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -76,6 +76,8 @@
     <Compile Include="IUpdate.cs" />
     <Compile Include="Maps\Tiled\CollisionWorldExtensions.cs" />
     <Compile Include="Maps\Tiled\TiledMapOrientation.cs" />
+    <Compile Include="Maps\Tiled\TiledObject.cs" />
+    <Compile Include="Maps\Tiled\TiledObjectGroup.cs" />
     <Compile Include="Shapes\SpriteBatchExtensions.cs" />
     <Compile Include="Shapes\CircleF.cs" />
     <Compile Include="Shapes\PolygonF.cs" />

--- a/Source/Sandbox/SandboxGame.cs
+++ b/Source/Sandbox/SandboxGame.cs
@@ -128,9 +128,9 @@ namespace Sandbox
             //_zombie.Draw(_spriteBatch);
             //_spriteBatch.End();
 
-            _spriteBatch.Begin();
-            _spriteBatch.DrawString(_bitmapFont, string.Format("FPS: {0} Zoom: {1}", _fpsCounter.AverageFramesPerSecond, _camera.Zoom), new Vector2(5, 5), new Color(0.5f, 0.5f, 0.5f));
-            _spriteBatch.End();
+            //_spriteBatch.Begin();
+            //_spriteBatch.DrawString(_bitmapFont, string.Format("FPS: {0} Zoom: {1}", _fpsCounter.AverageFramesPerSecond, _camera.Zoom), new Vector2(5, 5), new Color(0.5f, 0.5f, 0.5f));
+            //_spriteBatch.End();
 
             base.Draw(gameTime);
         }

--- a/Source/Sandbox/SandboxGame.cs
+++ b/Source/Sandbox/SandboxGame.cs
@@ -128,10 +128,10 @@ namespace Sandbox
             //_zombie.Draw(_spriteBatch);
             //_spriteBatch.End();
 
-            //_spriteBatch.Begin();            
-            //_spriteBatch.DrawString(_bitmapFont, string.Format("FPS: {0} Zoom: {1}", _fpsCounter.AverageFramesPerSecond, _camera.Zoom), new Vector2(5, 5), new Color(0.5f, 0.5f, 0.5f));
-            //_spriteBatch.End();
-            
+            _spriteBatch.Begin();
+            _spriteBatch.DrawString(_bitmapFont, string.Format("FPS: {0} Zoom: {1}", _fpsCounter.AverageFramesPerSecond, _camera.Zoom), new Vector2(5, 5), new Color(0.5f, 0.5f, 0.5f));
+            _spriteBatch.End();
+
             base.Draw(gameTime);
         }
     }


### PR DESCRIPTION
Which features it supports at the moment:

- Get Object Groups
- Get objects from Object Groups
- Get the `GID`, `X`, `Y`, `Width` and `Height` from an object
- Read properties from Object Layers and Objects

Known issues:

- The values from XML can't contains points.

Example:

    <object id="5" gid="26" x="128" y="896" width="297" height="342">

Acceptable.

    <object id="5" gid="26" x="88.6061" y="880.848" width="297" height="342">

Unnaceptable, raises an error. I know the error comes from `TmxObject.cs`, the values aren't integers. If I change from integer to double or float, the values comes wrong. Changing the type of `y` from int to float:

        [XmlAttribute(DataType = "float", AttributeName = "y")]
        public float Y { get; set; }

Result:

![Type conversion fail](https://cloud.githubusercontent.com/assets/11896398/12971469/9d9e2e74-d082-11e5-8af7-d9aa86ff3382.png)