### PR TITLE
Tiled Improvements

### DIFF
--- a/Source/MonoGame.Extended/Maps/Tiled/SpriteBatchExtensions.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/SpriteBatchExtensions.cs
@@ -10,9 +10,28 @@ namespace MonoGame.Extended.Maps.Tiled
             tiledMap.Draw(spriteBatch, camera, useMapBackgroundColor);
         }
 
+        public static void Draw(this SpriteBatch spriteBatch, TiledTileLayer tileLayer, Rectangle? visibleRectangle = null)
+        {
+            visibleRectangle = visibleRectangle ?? new Rectangle (0, 0, tileLayer.Width * tileLayer.TileWidth, tileLayer.Height * tileLayer.TileHeight);
+
+            tileLayer.Draw(spriteBatch, (Rectangle)visibleRectangle);
+        }
+
         public static void Draw(this SpriteBatch spriteBatch, TiledTileLayer tileLayer, Rectangle visibleRectangle)
         {
             tileLayer.Draw(spriteBatch, visibleRectangle);
+        }
+
+        public static void Draw(this SpriteBatch spriteBatch, TiledMap tileMap, Rectangle? visibleRectangle = null)
+        {
+            visibleRectangle = visibleRectangle ?? new Rectangle (0, 0, tileMap.Width * tileMap.TileWidth, tileMap.Height * tileMap.TileHeight);
+
+            tileMap.Draw(spriteBatch, (Rectangle)visibleRectangle);
+        }
+
+        public static void Draw(this SpriteBatch spriteBatch, TiledMap tileMap, Rectangle visibleRectangle)
+        {
+            tileMap.Draw(spriteBatch, visibleRectangle);
         }
     }
 }

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledImageLayer.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledImageLayer.cs
@@ -8,29 +8,23 @@ namespace MonoGame.Extended.Maps.Tiled
     public class TiledImageLayer : TiledLayer, IMovable
     {
         private readonly Texture2D _texture;
-        private readonly SpriteBatch _spriteBatch;
 
-        public TiledImageLayer(GraphicsDevice graphicsDevice, string name, Texture2D texture, Vector2 position)
+        public TiledImageLayer(string name, Texture2D texture, Vector2 position)
             : base(name)
         {
             Position = position;
 
             _texture = texture;
-            _spriteBatch = new SpriteBatch(graphicsDevice);
-        }
-
-        public override void Dispose()
-        {
-            _spriteBatch.Dispose();
         }
 
         public Vector2 Position { get; set; }
 
-        public override void Draw(Rectangle visibleRectangle)
+        public override void Draw(SpriteBatch spriteBatch, Rectangle visibleRectangle)
         {
-            _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp);
-            _spriteBatch.Draw(_texture, Position, Color.White);
-            _spriteBatch.End();
+            if (!Visible)
+                return;
+
+            spriteBatch.Draw(_texture, Position, Color.White);
         }
     }
 }

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledLayer.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledLayer.cs
@@ -1,21 +1,23 @@
 using System;
+
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.Maps.Tiled
 {
-    public abstract class TiledLayer : IDisposable
+    public abstract class TiledLayer
     {
         protected TiledLayer(string name)
         {
             Name = name;
+            Visible = true;
             Properties = new TiledProperties();
         }
 
-        public abstract void Dispose();
-
         public string Name { get; private set; }
+        public bool Visible { get; set; }
         public TiledProperties Properties { get; private set; }
 
-        public abstract void Draw(Rectangle visibleRectangle);
+        public abstract void Draw(SpriteBatch spriteBatch, Rectangle visibleRectangle);
     }
 }


### PR DESCRIPTION
Stuff done:
 - new overrides for spriteBatch
 - added Visible property to TileLayer
 - made map drawing code for spriteBatch actually use the spriteBatch that you give them instead of creating a new one... what would the point of giving a spriteBatch if you are just gonna render a renderTarget onto it...
 - TiledLayer no longer has it's own spriteBatch, but instead uses the one given to it from TiledMap, PS. It's not smart calling spriteBatch.Begin thousands of times for no good reason, looses performance.

I haven't tested the code with the Camera, I write stuff on Linux, and your demos are Windows only... 

Please think about using the same coding policies as MonoGame, or at least use the same coding policies as Microsoft or Mono... 