### PR TITLE
Remove DotNetZip dependancy in favor of .NET 4.5 DeflateStream. 

### DIFF
--- a/Source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
+++ b/Source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
@@ -31,10 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip, Version=1.9.6.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.9.6\lib\net20\Ionic.Zip.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="MonoGame.Framework, Version=3.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MonoGame.Framework.Portable.3.2.99.1-Beta\lib\portable-net45+win+wpa81+Xamarin.iOS10+MonoAndroid10+MonoTouch10\MonoGame.Framework.dll</HintPath>
       <Private>True</Private>

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapProcessor.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapProcessor.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using Ionic.Zlib;
 using Microsoft.Xna.Framework.Content.Pipeline;
 
 namespace MonoGame.Extended.Content.Pipeline.Tiled
@@ -73,7 +73,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                 return new GZipStream(memoryStream, CompressionMode.Decompress);
 
             if (compressionMode == "zlib")
-                return new ZlibStream(memoryStream, CompressionMode.Decompress);
+                return new DeflateStream(memoryStream, CompressionMode.Decompress);
 
             return memoryStream;
         }

--- a/Source/MonoGame.Extended.Content.Pipeline/packages.config
+++ b/Source/MonoGame.Extended.Content.Pipeline/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.9.6" targetFramework="net45" />
   <package id="MonoGame.Framework.Content.Pipeline.Portable" version="3.2.99.1-Beta" targetFramework="net452" />
   <package id="MonoGame.Framework.Portable" version="3.2.99.1-Beta" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -13,7 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile14</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile24</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Source/MonoGame.Extended/packages.config
+++ b/Source/MonoGame.Extended/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable-net40+sl50+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable-net40+sl50+MonoAndroid10+xamarinios10+MonoTouch10" requireReinstallation="True" />
 </packages>


### PR DESCRIPTION
Removed the DotNetZip dependancy in favor of .NET 4.5's DeflateStream. Since .NET 4.5, DeflateStream is using zlib. [MSDN / DeflateStream](https://msdn.microsoft.com/en-us/library/system.io.compression.deflatestream%28v=vs.100%29.aspx#Anchor_5).

Configured the solution to target .NET 4.5 including the portable library by switching to Profile 24 (portable-net45 + sl50).

Haven't had the chance to test it, since I upgraded the MonoGame devbuild and Xamarin Studio, and I'm missing some symlinks that prevent me from building the solution.