### PR TITLE
Make FPS counter a GameComponent

### DIFF
--- a/Source/Demos/Demo.SpriteSheetAnimations/Game1.cs
+++ b/Source/Demos/Demo.SpriteSheetAnimations/Game1.cs
@@ -28,13 +28,11 @@ namespace Demo.SpriteSheetAnimations
             _graphicsDeviceManager = new GraphicsDeviceManager(this);
             Content.RootDirectory = "Content";
             IsMouseVisible = true;
-            Window.Title = $"MonoGame.Extended - {GetType().Name}";
-            Window.Position = Point.Zero;
         }
 
         protected override void Initialize()
         {
-            _fpsCounter = new FramesPerSecondCounter();
+            Components.Add(_fpsCounter = new FramesPerSecondCounter(this));
             _viewportAdapter = new BoxingViewportAdapter(Window, GraphicsDevice, 800, 480);
             _camera = new Camera2D(_viewportAdapter)
             {
@@ -45,6 +43,8 @@ namespace Demo.SpriteSheetAnimations
                 Position = new Vector2(408, 270)
             };
 
+            Window.Title = $"MonoGame.Extended - {GetType().Name}";
+            Window.Position = Point.Zero;
             Window.AllowUserResizing = true;
 
             base.Initialize();
@@ -126,8 +126,6 @@ namespace Demo.SpriteSheetAnimations
 
         protected override void Draw(GameTime gameTime)
         {
-            _fpsCounter.Update(gameTime);
-
             GraphicsDevice.Clear(Color.CornflowerBlue);
 
             _spriteBatch.Begin(transformMatrix: _camera.GetViewMatrix());

--- a/Source/Demos/Demo.SpriteSheetAnimations/Game1.cs
+++ b/Source/Demos/Demo.SpriteSheetAnimations/Game1.cs
@@ -16,7 +16,7 @@ namespace Demo.SpriteSheetAnimations
         // ReSharper disable once NotAccessedField.Local
         private readonly GraphicsDeviceManager _graphicsDeviceManager;
         private Camera2D _camera;
-        private FramesPerSecondCounter _fpsCounter;
+        private FramesPerSecondCounterComponent _fpsCounter;
         private SpriteBatch _spriteBatch;
         private TiledMap _tiledMap;
         private ViewportAdapter _viewportAdapter;
@@ -32,7 +32,7 @@ namespace Demo.SpriteSheetAnimations
 
         protected override void Initialize()
         {
-            Components.Add(_fpsCounter = new FramesPerSecondCounter(this));
+            Components.Add(_fpsCounter = new FramesPerSecondCounterComponent(this));
             _viewportAdapter = new BoxingViewportAdapter(Window, GraphicsDevice, 800, 480);
             _camera = new Camera2D(_viewportAdapter)
             {

--- a/Source/Demos/Demo.TiledMaps/Game1.cs
+++ b/Source/Demos/Demo.TiledMaps/Game1.cs
@@ -11,7 +11,7 @@ namespace Demo.TiledMaps
 {
     public class Game1 : Game
     {
-        private FramesPerSecondCounter _fpsCounter;
+        private FramesPerSecondCounterComponent _fpsCounter;
         private BitmapFont _bitmapFont;
         private Camera2D _camera;
         // ReSharper disable once NotAccessedField.Local
@@ -32,7 +32,7 @@ namespace Demo.TiledMaps
 
         protected override void Initialize()
         {
-            Components.Add(_fpsCounter = new FramesPerSecondCounter(this));
+            Components.Add(_fpsCounter = new FramesPerSecondCounterComponent(this));
             _viewportAdapter = new BoxingViewportAdapter(Window, GraphicsDevice, 800, 480);
             _camera = new Camera2D(_viewportAdapter);
 

--- a/Source/Demos/Demo.TiledMaps/Game1.cs
+++ b/Source/Demos/Demo.TiledMaps/Game1.cs
@@ -11,7 +11,7 @@ namespace Demo.TiledMaps
 {
     public class Game1 : Game
     {
-        private readonly FramesPerSecondCounter _fpsCounter = new FramesPerSecondCounter();
+        private FramesPerSecondCounter _fpsCounter;
         private BitmapFont _bitmapFont;
         private Camera2D _camera;
         // ReSharper disable once NotAccessedField.Local
@@ -27,16 +27,23 @@ namespace Demo.TiledMaps
             _graphicsDeviceManager = new GraphicsDeviceManager(this) {SynchronizeWithVerticalRetrace = false};
             Content.RootDirectory = "Content";
             IsMouseVisible = true;
+            IsFixedTimeStep = false;
+        }
+
+        protected override void Initialize()
+        {
+            Components.Add(_fpsCounter = new FramesPerSecondCounter(this));
+            _viewportAdapter = new BoxingViewportAdapter(Window, GraphicsDevice, 800, 480);
+            _camera = new Camera2D(_viewportAdapter);
+
             Window.AllowUserResizing = true;
             Window.Position = Point.Zero;
-            IsFixedTimeStep = false;
+
+            base.Initialize();
         }
 
         protected override void LoadContent()
         {
-            _viewportAdapter = new BoxingViewportAdapter(Window, GraphicsDevice, 800, 480);
-            _camera = new Camera2D(_viewportAdapter);
-
             _spriteBatch = new SpriteBatch(GraphicsDevice);
             _texture = Content.Load<Texture2D>("monogame-extended-logo");
             _bitmapFont = Content.Load<BitmapFont>("montserrat-32");
@@ -103,8 +110,6 @@ namespace Demo.TiledMaps
             //}
 
             _spriteBatch.End();
-
-            _fpsCounter.Update(gameTime);
 
             var textColor = Color.Black;
             _spriteBatch.Begin(samplerState: SamplerState.PointClamp, blendState: BlendState.AlphaBlend);

--- a/Source/MonoGame.Extended/FramesPerSecondCounter.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounter.cs
@@ -4,10 +4,9 @@ using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended
 {
-    public class FramesPerSecondCounter : DrawableGameComponent
+    public class FramesPerSecondCounter : IUpdate
     {
-        public FramesPerSecondCounter(Game game, int maximumSamples = 100)
-            :base(game)
+        public FramesPerSecondCounter(int maximumSamples = 100)
         {
             MaximumSamples = maximumSamples;
         }
@@ -16,7 +15,7 @@ namespace MonoGame.Extended
 
         public long TotalFrames { get; private set; }
         public float AverageFramesPerSecond { get; private set; }
-        public float CurrentFramesPerSecond { get; private set; } 
+        public float CurrentFramesPerSecond { get; private set; }
         public int MaximumSamples { get; }
 
         public void Reset()
@@ -25,7 +24,7 @@ namespace MonoGame.Extended
             _sampleBuffer.Clear();
         }
 
-        public void UpdateFPS(float deltaTime)
+        public void Update(float deltaTime)
         {
             CurrentFramesPerSecond = 1.0f / deltaTime;
 
@@ -35,7 +34,7 @@ namespace MonoGame.Extended
             {
                 _sampleBuffer.Dequeue();
                 AverageFramesPerSecond = _sampleBuffer.Average(i => i);
-            } 
+            }
             else
             {
                 AverageFramesPerSecond = CurrentFramesPerSecond;
@@ -44,16 +43,9 @@ namespace MonoGame.Extended
             TotalFrames++;
         }
 
-        public override void Update(GameTime gameTime)
+        public void Update(GameTime gameTime)
         {
-            base.Update(gameTime);
-        }
-
-        public override void Draw(GameTime gameTime)
-        {
-            UpdateFPS((float)gameTime.ElapsedGameTime.TotalSeconds);
-            base.Draw(gameTime);
+            Update((float)gameTime.ElapsedGameTime.TotalSeconds);
         }
     }
 }
-

--- a/Source/MonoGame.Extended/FramesPerSecondCounter.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounter.cs
@@ -4,9 +4,10 @@ using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended
 {
-    public class FramesPerSecondCounter : IUpdate
+    public class FramesPerSecondCounter : DrawableGameComponent
     {
-        public FramesPerSecondCounter(int maximumSamples = 100)
+        public FramesPerSecondCounter(Game game, int maximumSamples = 100)
+            :base(game)
         {
             MaximumSamples = maximumSamples;
         }
@@ -24,7 +25,7 @@ namespace MonoGame.Extended
             _sampleBuffer.Clear();
         }
 
-        public void Update(float deltaTime)
+        public void UpdateFPS(float deltaTime)
         {
             CurrentFramesPerSecond = 1.0f / deltaTime;
 
@@ -43,9 +44,15 @@ namespace MonoGame.Extended
             TotalFrames++;
         }
 
-        public void Update(GameTime gameTime)
+        public override void Update(GameTime gameTime)
         {
-            Update((float)gameTime.ElapsedGameTime.TotalSeconds);
+            base.Update(gameTime);
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            UpdateFPS((float)gameTime.ElapsedGameTime.TotalSeconds);
+            base.Draw(gameTime);
         }
     }
 }

--- a/Source/MonoGame.Extended/FramesPerSecondCounterComponent.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounterComponent.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended
+{
+    public class FramesPerSecondCounterComponent : DrawableGameComponent
+    {
+        FramesPerSecondCounter fpsCounter;
+
+        public FramesPerSecondCounterComponent(Game game, int maximumSamples = 100)
+            : base(game)
+        {
+            fpsCounter = new FramesPerSecondCounter(maximumSamples);
+        }
+
+        public long TotalFrames
+        {
+            get { return fpsCounter.TotalFrames; }
+        }
+
+        public float AverageFramesPerSecond
+        {
+            get { return fpsCounter.AverageFramesPerSecond; }
+        }
+
+        public float CurrentFramesPerSecond
+        {
+            get { return fpsCounter.CurrentFramesPerSecond; }
+        }
+
+        public int MaximumSamples
+        {
+            get { return fpsCounter.MaximumSamples; }
+        }
+
+        public void Reset()
+        {
+            fpsCounter.Reset();
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            fpsCounter.Update((float)gameTime.ElapsedGameTime.TotalSeconds);
+            base.Draw(gameTime);
+        }
+    }
+}
+

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -168,7 +168,8 @@
     <Compile Include="ViewportAdapters\WindowViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\ScalingViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\ViewportAdapter.cs" />
-    <Compile Include="FramesPerSecondCounter.cs" />
+	<Compile Include="FramesPerSecondCounter.cs" />
+    <Compile Include="FramesPerSecondCounterComponent.cs" />
     <Compile Include="Sprites\SpriteAnimator.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -168,7 +168,7 @@
     <Compile Include="ViewportAdapters\WindowViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\ScalingViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\ViewportAdapter.cs" />
-	<Compile Include="FramesPerSecondCounter.cs" />
+    <Compile Include="FramesPerSecondCounter.cs" />
     <Compile Include="FramesPerSecondCounterComponent.cs" />
     <Compile Include="Sprites\SpriteAnimator.cs" />
   </ItemGroup>


### PR DESCRIPTION
I find it confusing to call `fpsCounter.Update()` in a Draw loop.
As a GameComponent, the user doesn't have to worry about forgetting to call `fpsCounter.Update`, or calling Update in the wrong loop.
