### PR TITLE
Add support for defining bleed areas in BoxingViewportAdapter

### DIFF
--- a/Source/Demos/Demo.ViewportAdapters/Game1.cs
+++ b/Source/Demos/Demo.ViewportAdapters/Game1.cs
@@ -48,7 +48,7 @@ namespace Demo.ViewportAdapters
 
             // the boxing viewport adapter uses letterboxing or pillarboxing to maintain aspect ratio
             // it's a little more complicated and needs to listen to the window client size changing event
-            _boxingViewportAdapter = new BoxingViewportAdapter(Window, GraphicsDevice, 800, 480);
+            _boxingViewportAdapter = new BoxingViewportAdapter(Window, GraphicsDevice, 800, 480, 88, 70);
 
             // typically you'll only ever want to use one viewport adapter for a game, but in this sample we'll be 
             // switching between them.
@@ -109,17 +109,17 @@ namespace Demo.ViewportAdapters
             _spriteBatch.Begin(transformMatrix: _currentViewportAdapter.GetScaleMatrix());
             _spriteBatch.Draw(_backgroundTexture, destinationRectangle, Color.White);
 
-            _spriteBatch.DrawString(_bitmapFont, $"Press D: {typeof (DefaultViewportAdapter).Name}", new Vector2(5, 5), Color.White);
+            _spriteBatch.DrawString(_bitmapFont, $"Press D: {typeof (DefaultViewportAdapter).Name}", new Vector2(49, 40), Color.White);
 
-            _spriteBatch.DrawString(_bitmapFont, $"Press S: {typeof (ScalingViewportAdapter).Name}", new Vector2(5, 5 + _bitmapFont.LineHeight * 1), Color.White);
+            _spriteBatch.DrawString(_bitmapFont, $"Press S: {typeof (ScalingViewportAdapter).Name}", new Vector2(49, 40 + _bitmapFont.LineHeight * 1), Color.White);
 
-            _spriteBatch.DrawString(_bitmapFont, $"Press B: {typeof (BoxingViewportAdapter).Name}", new Vector2(5, 5 + _bitmapFont.LineHeight * 2), Color.White);
+            _spriteBatch.DrawString(_bitmapFont, $"Press B: {typeof (BoxingViewportAdapter).Name}", new Vector2(49, 40 + _bitmapFont.LineHeight * 2), Color.White);
 
-            _spriteBatch.DrawString(_bitmapFont, $"Current: {_currentViewportAdapter.GetType().Name}", new Vector2(5, 5 + _bitmapFont.LineHeight * 4), Color.Black);
+            _spriteBatch.DrawString(_bitmapFont, $"Current: {_currentViewportAdapter.GetType().Name}", new Vector2(49, 40 + _bitmapFont.LineHeight * 4), Color.Black);
 
-            _spriteBatch.DrawString(_bitmapFont, @"Try resizing the window", new Vector2(5, 5 + _bitmapFont.LineHeight * 6), Color.Black);
+            _spriteBatch.DrawString(_bitmapFont, @"Try resizing the window", new Vector2(49, 40 + _bitmapFont.LineHeight * 6), Color.Black);
 
-            _spriteBatch.DrawString(_bitmapFont, $"Mouse: {_mousePosition}", new Vector2(5, 5 + _bitmapFont.LineHeight * 8), Color.Black);
+            _spriteBatch.DrawString(_bitmapFont, $"Mouse: {_mousePosition}", new Vector2(49, 40 + _bitmapFont.LineHeight * 8), Color.Black);
 
             _spriteBatch.End();
 

--- a/Source/MonoGame.Extended/ViewportAdapters/BoxingViewportAdapter.cs
+++ b/Source/MonoGame.Extended/ViewportAdapters/BoxingViewportAdapter.cs
@@ -7,7 +7,7 @@ namespace MonoGame.Extended.ViewportAdapters
 {
     public enum BoxingMode
     {
-        Letterbox, Pillarbox
+        None, Letterbox, Pillarbox
     }
 
     public class BoxingViewportAdapter : ScalingViewportAdapter
@@ -16,15 +16,47 @@ namespace MonoGame.Extended.ViewportAdapters
         private readonly GameWindow _window;
 
         /// <summary>
+        /// Size of horizontal bleed areas (from left and right edges) which can be safely cut off
+        /// </summary>
+        public int HorizontalBleed { get; }
+
+        /// <summary>
+        /// Size of vertical bleed areas (from top and bottom edges) which can be safely cut off
+        /// </summary>
+        public int VerticalBleed { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoxingViewportAdapter"/>. 
+        /// Note: If you're using DirectX please use the other constructor due to a bug in MonoGame.
+        /// https://github.com/mono/MonoGame/issues/4018
+        /// </summary>
+        public BoxingViewportAdapter(GameWindow window, GraphicsDevice graphicsDevice, int virtualWidth, int virtualHeight, int horizontalBleed, int verticalBleed)
+            : base(graphicsDevice, virtualWidth, virtualHeight) {
+            _window = window;
+            window.ClientSizeChanged += OnClientSizeChanged;
+            HorizontalBleed = horizontalBleed;
+            VerticalBleed = verticalBleed;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BoxingViewportAdapter"/>. 
         /// Note: If you're using DirectX please use the other constructor due to a bug in MonoGame.
         /// https://github.com/mono/MonoGame/issues/4018
         /// </summary>
         public BoxingViewportAdapter(GameWindow window, GraphicsDevice graphicsDevice, int virtualWidth, int virtualHeight)
-            : base(graphicsDevice, virtualWidth, virtualHeight)
+            : this(window, graphicsDevice, virtualWidth, virtualHeight, 0, 0) {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoxingViewportAdapter"/>. 
+        /// Use this constructor only if you're using DirectX due to a bug in MonoGame.
+        /// https://github.com/mono/MonoGame/issues/4018
+        /// This constructor will be made obsolete and eventually removed once the bug has been fixed.
+        /// </summary>
+        public BoxingViewportAdapter(GameWindow window, GraphicsDeviceManager graphicsDeviceManager, int virtualWidth, int virtualHeight, int horizontalBleed, int verticalBleed)
+            : this(window, graphicsDeviceManager.GraphicsDevice, virtualWidth, virtualHeight, horizontalBleed, verticalBleed)
         {
-            _window = window;
-            window.ClientSizeChanged += OnClientSizeChanged;
+            _graphicsDeviceManager = graphicsDeviceManager;
         }
 
         /// <summary>
@@ -34,9 +66,7 @@ namespace MonoGame.Extended.ViewportAdapters
         /// This constructor will be made obsolete and eventually removed once the bug has been fixed.
         /// </summary>
         public BoxingViewportAdapter(GameWindow window, GraphicsDeviceManager graphicsDeviceManager, int virtualWidth, int virtualHeight)
-            : this(window, graphicsDeviceManager.GraphicsDevice, virtualWidth, virtualHeight)
-        {
-            _graphicsDeviceManager = graphicsDeviceManager;
+            : this(window, graphicsDeviceManager, virtualWidth, virtualHeight, 0, 0) {
         }
 
         public BoxingMode BoxingMode { get; private set; }
@@ -44,19 +74,31 @@ namespace MonoGame.Extended.ViewportAdapters
         private void OnClientSizeChanged(object sender, EventArgs eventArgs)
         {
             var viewport = GraphicsDevice.Viewport;
-            var aspectRatio = (float) VirtualWidth / VirtualHeight;
-            var width = viewport.Width;
-            var height = (int)(width / aspectRatio + 0.5f);
 
-            if (height > viewport.Height)
+            var worldScaleX = (float)viewport.Width / VirtualWidth;
+            var worldScaleY = (float)viewport.Height / VirtualHeight;
+
+            var safeScaleX = (float)viewport.Width / (VirtualWidth - HorizontalBleed);
+            var safeScaleY = (float)viewport.Height / (VirtualHeight - VerticalBleed);
+
+            float worldScale = MathHelper.Max(worldScaleX, worldScaleY);
+            float safeScale = MathHelper.Min(safeScaleX, safeScaleY);
+            float scale = MathHelper.Min(worldScale, safeScale);
+
+            var width = (int)(scale * VirtualWidth + 0.5f);
+            var height = (int)(scale * VirtualHeight + 0.5f);
+
+            if (height >= viewport.Height && width < viewport.Width)
             {
                 BoxingMode = BoxingMode.Pillarbox;
-                height = viewport.Height;
-                width = (int) (height * aspectRatio + 0.5f);
             }
-            else
+            else if (width >= viewport.Height && height < viewport.Height)
             {
                 BoxingMode = BoxingMode.Letterbox;
+            }
+            else 
+            {
+                BoxingMode = BoxingMode.None;
             }
 
             var x = (viewport.Width / 2) - (width / 2);


### PR DESCRIPTION
This PR adds support for bleed areas as discussed in #159.

Both constructors are overloaded with additional horizontal/vertical bleed parameters. 
I have also added None value to the BoxingMode enum which is set when no letterboxing (or pillarboxing) occurs.