### PR TITLE
Support Unicode emoji characters in BitmapFont

### DIFF
--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -14,14 +14,30 @@ namespace MonoGame.Extended.BitmapFonts
             LineHeight = lineHeight;
         }
 
-        private readonly Dictionary<char, BitmapFontRegion> _characterMap;
+        private readonly Dictionary<int, BitmapFontRegion> _characterMap;
 
         public int LineHeight { get; private set; }
 
-        public BitmapFontRegion GetCharacterRegion(char character)
+        public BitmapFontRegion GetCharacterRegion(int character)
         {
             BitmapFontRegion region;
             return _characterMap.TryGetValue(character, out region) ? region : null;
+        }
+
+        internal static IEnumerable<int> GetUnicodeCodePoints(string s)
+        {
+            if (!String.IsNullOrEmpty(s))
+            {
+                for (int i = 0; i < s.Length; i += 1)
+                {
+                    if (Char.IsLowSurrogate(s, i))
+                    {
+                        continue;
+                    }
+
+                    yield return Char.ConvertToUtf32(s, i);
+                }
+            }
         }
 
         public Size GetSize(string text)
@@ -29,7 +45,7 @@ namespace MonoGame.Extended.BitmapFonts
             var width = 0;
             var height = 0;
 
-            foreach (var c in text)
+            foreach (int c in GetUnicodeCodePoints(text))
             {
                 BitmapFontRegion fontRegion;
 

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
@@ -12,7 +12,7 @@ namespace MonoGame.Extended.BitmapFonts
             var dx = position.X;
             var dy = position.Y;
 
-            foreach (var character in text)
+            foreach (var character in BitmapFont.GetUnicodeCodePoints(text))
             {
                 var fontRegion = bitmapFont.GetCharacterRegion(character);
 

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
@@ -9,6 +9,11 @@ namespace MonoGame.Extended.BitmapFonts
     {
         public static void DrawString(this SpriteBatch spriteBatch, BitmapFont bitmapFont, string text, Vector2 position, Color color)
         {
+            DrawString(spriteBatch, bitmapFont, text, position, color, 0, Vector2.Zero, Vector2.One, SpriteEffects.None, 0);
+        }
+
+        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont bitmapFont, string text, Vector2 position, Color color, float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
+        {
             var dx = position.X;
             var dy = position.Y;
 
@@ -20,7 +25,7 @@ namespace MonoGame.Extended.BitmapFonts
                 {
                     var charPosition = new Vector2(dx + fontRegion.XOffset, dy + fontRegion.YOffset);
 
-                    spriteBatch.Draw(fontRegion.TextureRegion, charPosition, color);
+                    spriteBatch.Draw(fontRegion.TextureRegion, charPosition, color, rotation, origin, scale, effects, layerDepth);
                     dx += fontRegion.XAdvance;
                 }
 

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontReader.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontReader.cs
@@ -30,7 +30,7 @@ namespace MonoGame.Extended.BitmapFonts
 
             for (var r = 0; r < regionCount; r++)
             {
-                var character = (char)reader.ReadInt32();
+                var character = reader.ReadInt32();
                 var textureIndex = reader.ReadInt32();
                 var x = reader.ReadInt32();
                 var y = reader.ReadInt32();

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontRegion.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontRegion.cs
@@ -4,7 +4,7 @@ namespace MonoGame.Extended.BitmapFonts
 {
     public class BitmapFontRegion
     {
-        public BitmapFontRegion(TextureRegion2D textureRegion, char character, int xOffset, int yOffset, int xAdvance)
+        public BitmapFontRegion(TextureRegion2D textureRegion, int character, int xOffset, int yOffset, int xAdvance)
         {
             TextureRegion = textureRegion;
             Character = character;
@@ -13,7 +13,7 @@ namespace MonoGame.Extended.BitmapFonts
             XAdvance = xAdvance;
         }
         
-        public char Character { get; set; }
+        public int Character { get; set; }
         public TextureRegion2D TextureRegion { get; }
         public int XOffset { get; set; }
         public int YOffset { get; set; }

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -179,10 +179,6 @@
     <Reference Include="MonoGame.Framework">
       <HintPath>..\..\Dependencies\MonoGame.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
The .NET Char type currently used to identify a glyph in a BitmapFont is
limited to 16 bits, while some Unicode characters (surrogate pairs,
which include Emoji) require 32 bits.

The fix is to use the Int32 type to represent a Unicode character, and
to parse UTF-16 .NET input strings as 32-bit Unicode code point
sequences.