### PR TITLE
Angle struct

### DIFF
--- a/Source/MonoGame.Extended.Tests/AngleTest.cs
+++ b/Source/MonoGame.Extended.Tests/AngleTest.cs
@@ -7,11 +7,11 @@ namespace MonoGame.Extended.Tests
     [TestFixture]
     public class AngleTest
     {
-        private const double DELTA = 0.000000000001;
+        private const float DELTA = 0.0000001f;
         [Test]
         public void ConstructorTest()
         {
-            var value = 0.5;
+            var value = 0.5f;
             var radians = new Angle(value);
             var degrees = new Angle(value, AngleType.Degree);
             var gradians = new Angle(value, AngleType.Gradian);
@@ -26,35 +26,35 @@ namespace MonoGame.Extended.Tests
         public void ConversionTest()
         {
             //from radians
-            var radians = new Angle(Math.PI);
+            var radians = new Angle(MathHelper.Pi);
             Assert.AreEqual(180d, radians.Degrees, DELTA);
             Assert.AreEqual(200d, radians.Gradians, DELTA);
             Assert.AreEqual(0.5, radians.Revolutions, DELTA);
             //to radians
-            var degrees = new Angle(180d, AngleType.Degree);
-            var gradians = new Angle(200d, AngleType.Gradian);
-            var revolutions = new Angle(0.5, AngleType.Revolution);
-            Assert.AreEqual(Math.PI, degrees.Radians, DELTA);
-            Assert.AreEqual(Math.PI, gradians.Radians, DELTA);
-            Assert.AreEqual(Math.PI, revolutions.Radians, DELTA);
+            var degrees = new Angle(180f, AngleType.Degree);
+            var gradians = new Angle(200f, AngleType.Gradian);
+            var revolutions = new Angle(0.5f, AngleType.Revolution);
+            Assert.AreEqual(MathHelper.Pi, degrees.Radians, DELTA);
+            Assert.AreEqual(MathHelper.Pi, gradians.Radians, DELTA);
+            Assert.AreEqual(MathHelper.Pi, revolutions.Radians, DELTA);
         }
 
         [Test]
         public void WrapTest()
         {
-            for (var d = -10d; d < 10d; d += 0.1d)
+            for (var f = -10f; f < 10f; f += 0.1f)
             {
-                var wrappositive = new Angle(d);
+                var wrappositive = new Angle(f);
                 wrappositive.WrapPositive();
 
-                var wrap = new Angle(d);
+                var wrap = new Angle(f);
                 wrap.Wrap();
 
                 Assert.GreaterOrEqual(wrappositive.Radians, 0);
-                Assert.Less(wrappositive.Radians, 2d * Math.PI);
+                Assert.Less(wrappositive.Radians, 2d * MathHelper.Pi);
 
-                Assert.GreaterOrEqual(wrap.Radians, -Math.PI);
-                Assert.Less(wrap.Radians, Math.PI);
+                Assert.GreaterOrEqual(wrap.Radians, -MathHelper.Pi);
+                Assert.Less(wrap.Radians, MathHelper.Pi);
             }
         }
 
@@ -62,7 +62,7 @@ namespace MonoGame.Extended.Tests
         public void VectorTest()
         {
             var angle = Angle.FromVector(Vector2.One);
-            Assert.AreEqual(-Math.PI / 4d, angle.Radians, DELTA);
+            Assert.AreEqual(-MathHelper.Pi / 4d, angle.Radians, DELTA);
             Assert.AreEqual(10f, angle.ToVector(10f).Length());
 
             angle = Angle.FromVector(Vector2.UnitX);
@@ -70,7 +70,7 @@ namespace MonoGame.Extended.Tests
             Assert.IsTrue(Vector2.UnitX.EqualsWithTolerance(angle.ToUnitVector()));
 
             angle = Angle.FromVector(-Vector2.UnitY);
-            Assert.AreEqual(Math.PI / 2d, angle.Radians, DELTA);
+            Assert.AreEqual(MathHelper.Pi / 2d, angle.Radians, DELTA);
             Assert.IsTrue((-Vector2.UnitY).EqualsWithTolerance(angle.ToUnitVector()));
         }
 
@@ -78,9 +78,9 @@ namespace MonoGame.Extended.Tests
         public void EqualsTest()
         {
             var angle1 = new Angle(0);
-            var angle2 = new Angle(Math.PI * 2d);
+            var angle2 = new Angle(MathHelper.Pi * 2f);
             Assert.IsTrue(angle1 == angle2);
-            angle2.Radians = Math.PI * 4d;
+            angle2.Radians = MathHelper.Pi * 4f;
             Assert.IsTrue(angle1.Equals(angle2));
         }
 

--- a/Source/MonoGame.Extended.Tests/AngleTest.cs
+++ b/Source/MonoGame.Extended.Tests/AngleTest.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using NUnit.Framework;
+
+namespace MonoGame.Extended.Tests
+{
+    [TestFixture]
+    public class AngleTest
+    {
+        private const double DELTA = 0.000000000001;
+        [Test]
+        public void ConstructorTest()
+        {
+            var value = 0.5;
+            var radians = new Angle(value);
+            var degrees = new Angle(value, AngleType.Degree);
+            var gradians = new Angle(value, AngleType.Gradian);
+            var revolutions = new Angle(value, AngleType.Revolution);
+            Assert.AreEqual(value, radians.Radians, DELTA);
+            Assert.AreEqual(value, degrees.Degrees, DELTA);
+            Assert.AreEqual(value, gradians.Gradians, DELTA);
+            Assert.AreEqual(value, revolutions.Revolutions, DELTA);
+        }
+
+        [Test]
+        public void ConversionTest()
+        {
+            //from radians
+            var radians = new Angle(Math.PI);
+            Assert.AreEqual(180d, radians.Degrees, DELTA);
+            Assert.AreEqual(200d, radians.Gradians, DELTA);
+            Assert.AreEqual(0.5, radians.Revolutions, DELTA);
+            //to radians
+            var degrees = new Angle(180d, AngleType.Degree);
+            var gradians = new Angle(200d, AngleType.Gradian);
+            var revolutions = new Angle(0.5, AngleType.Revolution);
+            Assert.AreEqual(Math.PI, degrees.Radians, DELTA);
+            Assert.AreEqual(Math.PI, gradians.Radians, DELTA);
+            Assert.AreEqual(Math.PI, revolutions.Radians, DELTA);
+        }
+
+        [Test]
+        public void WrapTest()
+        {
+            for (var d = -10d; d < 10d; d += 0.1d)
+            {
+                var wrappositive = new Angle(d);
+                wrappositive.WrapPositive();
+
+                var wrap = new Angle(d);
+                wrap.Wrap();
+
+                Assert.GreaterOrEqual(wrappositive.Radians, 0);
+                Assert.Less(wrappositive.Radians, 2d * Math.PI);
+
+                Assert.GreaterOrEqual(wrap.Radians, -Math.PI);
+                Assert.Less(wrap.Radians, Math.PI);
+            }
+        }
+
+        [Test]
+        public void VectorTest()
+        {
+            var angle = Angle.FromVector(Vector2.One);
+            Assert.AreEqual(-Math.PI / 4d, angle.Radians, DELTA);
+            Assert.AreEqual(10f, angle.ToVector(10f).Length());
+
+            angle = Angle.FromVector(Vector2.UnitX);
+            Assert.AreEqual(0, angle.Radians, DELTA);
+            Assert.IsTrue(Vector2.UnitX.EqualsWithTolerance(angle.ToUnitVector()));
+
+            angle = Angle.FromVector(-Vector2.UnitY);
+            Assert.AreEqual(Math.PI / 2d, angle.Radians, DELTA);
+            Assert.IsTrue((-Vector2.UnitY).EqualsWithTolerance(angle.ToUnitVector()));
+        }
+
+        [Test]
+        public void EqualsTest()
+        {
+            var angle1 = new Angle(0);
+            var angle2 = new Angle(Math.PI * 2d);
+            Assert.IsTrue(angle1 == angle2);
+            angle2.Radians = Math.PI * 4d;
+            Assert.IsTrue(angle1.Equals(angle2));
+        }
+
+    }
+}

--- a/Source/MonoGame.Extended.Tests/MonoGame.Extended.Tests.csproj
+++ b/Source/MonoGame.Extended.Tests/MonoGame.Extended.Tests.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AngleTest.cs" />
     <Compile Include="Collections\DequeTests.cs" />
     <Compile Include="Collections\PoolTests.cs" />
     <Compile Include="MockGameWindow.cs" />

--- a/Source/MonoGame.Extended/Angle.cs
+++ b/Source/MonoGame.Extended/Angle.cs
@@ -1,6 +1,26 @@
-﻿using System;
+﻿/*
+* Copyright (c) 2007-2010 SlimDX Group
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+using System;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 using Microsoft.Xna.Framework;
 

--- a/Source/MonoGame.Extended/Angle.cs
+++ b/Source/MonoGame.Extended/Angle.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.Serialization;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended
+{
+    public enum AngleType : byte
+    {
+        Radian = 0,
+        Degree,
+        Revolution, //or Turn / cycle
+        Gradian // or Gon
+    }
+    [DataContract]
+    [DebuggerDisplay("{ToString(),nq}")]
+    public struct Angle : IComparable<Angle>, IEquatable<Angle>
+    {
+        private const double TAU = Math.PI * 2.0;
+        private const double TAU_INV = 0.5 / Math.PI;
+        private const double DEGREE_RADIAN = Math.PI / 180.0;
+        private const double RADIAN_DEGREE = 180.0 / Math.PI;
+        private const double GRADIAN_RADIAN = Math.PI / 200.0;
+        private const double RADIAN_GRADIAN = 200.0 / Math.PI;
+
+        [DataMember]
+        public double Radians { get; set; }
+
+        public double Degrees
+        {
+            get { return Radians * RADIAN_DEGREE; }
+            set { Radians = value * DEGREE_RADIAN; }
+        }
+
+        public double Gradians
+        {
+            get { return Radians * RADIAN_GRADIAN; }
+            set { Radians = value * GRADIAN_RADIAN; }
+        }
+
+        public double Revolutions
+        {
+            get { return Radians * TAU_INV; }
+            set { Radians = value * TAU; }
+        }
+
+        public Angle(double value, AngleType angleType = AngleType.Radian)
+        {
+            switch (angleType)
+            {
+                default:
+                    Radians = 0d;
+                    break;
+                case AngleType.Radian:
+                    Radians = value;
+                    break;
+                case AngleType.Degree:
+                    Radians = value * DEGREE_RADIAN;
+                    break;
+                case AngleType.Revolution:
+                    Radians = value * TAU;
+                    break;
+                case AngleType.Gradian:
+                    Radians = value * GRADIAN_RADIAN;
+                    break;
+            }
+        }
+
+        public double GetValue(AngleType angleType)
+        {
+            switch (angleType)
+            {
+                default:
+                    return 0;
+                case AngleType.Radian:
+                    return Radians;
+                case AngleType.Degree:
+                    return Degrees;
+                case AngleType.Revolution:
+                    return Revolutions;
+                case AngleType.Gradian:
+                    return Gradians;
+            }
+        }
+
+        public void Wrap()
+        {
+            var angle = Radians % TAU;
+            if (angle <= Math.PI) angle += TAU;
+            if (angle > Math.PI) angle -= TAU;
+            Radians = angle;
+        }
+
+        public void WrapPositive()
+        {
+            Radians %= TAU;
+            if (Radians < 0d) Radians += TAU;
+            Radians = Radians;
+        }
+
+        public static Angle FromVector(Vector2 vector)
+        {
+            return new Angle(Math.Atan2(-vector.Y, vector.X));
+        }
+
+        public Vector2 ToUnitVector() => ToVector(1);
+
+        public Vector2 ToVector(float length)
+        {
+            return new Vector2(length * (float)Math.Cos(Radians), -length * (float)Math.Sin(Radians));
+        }
+
+        public static bool IsBetween(Angle value, Angle min, Angle end)
+        {
+            return end < min ?
+                value >= min || value <= end :
+                value >= min && value <= end;
+        }
+
+        public int CompareTo(Angle other)
+        {
+            WrapPositive();
+            other.WrapPositive();
+            return Radians.CompareTo(other.Radians);
+        }
+
+        public bool Equals(Angle other)
+        {
+            WrapPositive();
+            other.WrapPositive();
+            return Radians == other.Radians;
+        }
+
+        #region operators
+        public static implicit operator double(Angle angle)
+        {
+            return angle.Radians;
+        }
+        public static implicit operator float(Angle angle)
+        {
+            return (float)angle.Radians;
+        }
+        public static explicit operator Angle(double angle)
+        {
+            return new Angle(angle);
+        }
+        public static explicit operator Angle(float angle)
+        {
+            return new Angle(angle);
+        }
+        public static Angle operator -(Angle angle)
+        {
+            return new Angle(-angle.Radians);
+        }
+        public static bool operator ==(Angle a, Angle b)
+        {
+            return a.Equals(a);
+        }
+
+        public static bool operator !=(Angle a, Angle b)
+        {
+            return !a.Equals(a);
+        }
+
+        public static Angle operator -(Angle left, Angle right)
+        {
+            return new Angle(left.Radians - right.Radians);
+        }
+        public static Angle operator *(Angle left, double right)
+        {
+            return new Angle(left.Radians * right);
+        }
+        public static Angle operator *(double left, Angle right)
+        {
+            return new Angle(right.Radians * left);
+        }
+        public static Angle operator +(Angle left, Angle right)
+        {
+            return new Angle(left.Radians + right.Radians);
+        }
+        #endregion
+
+
+        public override string ToString()
+        {
+            return $"{Radians} Radians";
+        }
+    }
+}

--- a/Source/MonoGame.Extended/Angle.cs
+++ b/Source/MonoGame.Extended/Angle.cs
@@ -17,40 +17,41 @@ namespace MonoGame.Extended
     [DebuggerDisplay("{ToString(),nq}")]
     public struct Angle : IComparable<Angle>, IEquatable<Angle>
     {
-        private const double TAU = Math.PI * 2.0;
-        private const double TAU_INV = 0.5 / Math.PI;
-        private const double DEGREE_RADIAN = Math.PI / 180.0;
-        private const double RADIAN_DEGREE = 180.0 / Math.PI;
-        private const double GRADIAN_RADIAN = Math.PI / 200.0;
-        private const double RADIAN_GRADIAN = 200.0 / Math.PI;
+
+        private const float TAU = (float) (Math.PI * 2.0);
+        private const float TAU_INV = (float) (0.5 / Math.PI);
+        private const float DEGREE_RADIAN = (float) (Math.PI / 180.0);
+        private const float RADIAN_DEGREE = (float) (180.0 / Math.PI);
+        private const float GRADIAN_RADIAN = (float) (Math.PI / 200.0);
+        private const float RADIAN_GRADIAN = (float) (200.0 / Math.PI);
 
         [DataMember]
-        public double Radians { get; set; }
+        public float Radians { get; set; }
 
-        public double Degrees
+        public float Degrees
         {
             get { return Radians * RADIAN_DEGREE; }
             set { Radians = value * DEGREE_RADIAN; }
         }
 
-        public double Gradians
+        public float Gradians
         {
             get { return Radians * RADIAN_GRADIAN; }
             set { Radians = value * GRADIAN_RADIAN; }
         }
 
-        public double Revolutions
+        public float Revolutions
         {
             get { return Radians * TAU_INV; }
             set { Radians = value * TAU; }
         }
 
-        public Angle(double value, AngleType angleType = AngleType.Radian)
+        public Angle(float value, AngleType angleType = AngleType.Radian)
         {
             switch (angleType)
             {
                 default:
-                    Radians = 0d;
+                    Radians = 0f;
                     break;
                 case AngleType.Radian:
                     Radians = value;
@@ -67,12 +68,12 @@ namespace MonoGame.Extended
             }
         }
 
-        public double GetValue(AngleType angleType)
+        public float GetValue(AngleType angleType)
         {
             switch (angleType)
             {
                 default:
-                    return 0;
+                    return 0f;
                 case AngleType.Radian:
                     return Radians;
                 case AngleType.Degree:
@@ -101,7 +102,7 @@ namespace MonoGame.Extended
 
         public static Angle FromVector(Vector2 vector)
         {
-            return new Angle(Math.Atan2(-vector.Y, vector.X));
+            return new Angle((float)Math.Atan2(-vector.Y, vector.X));
         }
 
         public Vector2 ToUnitVector() => ToVector(1);
@@ -131,24 +132,27 @@ namespace MonoGame.Extended
             other.WrapPositive();
             return Radians == other.Radians;
         }
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is Angle && Equals((Angle)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Radians.GetHashCode();
+        }
 
         #region operators
-        public static implicit operator double(Angle angle)
-        {
-            return angle.Radians;
-        }
         public static implicit operator float(Angle angle)
         {
-            return (float)angle.Radians;
-        }
-        public static explicit operator Angle(double angle)
-        {
-            return new Angle(angle);
+            return angle.Radians;
         }
         public static explicit operator Angle(float angle)
         {
             return new Angle(angle);
         }
+
         public static Angle operator -(Angle angle)
         {
             return new Angle(-angle.Radians);
@@ -167,11 +171,11 @@ namespace MonoGame.Extended
         {
             return new Angle(left.Radians - right.Radians);
         }
-        public static Angle operator *(Angle left, double right)
+        public static Angle operator *(Angle left, float right)
         {
             return new Angle(left.Radians * right);
         }
-        public static Angle operator *(double left, Angle right)
+        public static Angle operator *(float left, Angle right)
         {
             return new Angle(right.Radians * left);
         }

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -36,6 +36,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Angle.cs" />
     <Compile Include="Animations\SpriteSheetAnimation.cs" />
     <Compile Include="Animations\SpriteSheetAnimationData.cs" />
     <Compile Include="Animations\SpriteSheetAnimationFactory.cs" />

--- a/Source/MonoGame.Extended/Particles/Modifiers/Interpolators/ColorInterpolator.cs
+++ b/Source/MonoGame.Extended/Particles/Modifiers/Interpolators/ColorInterpolator.cs
@@ -18,7 +18,7 @@ namespace MonoGame.Extended.Particles.Modifiers.Interpolators
         public HslColor FinalColor { get; set; }
         
         public unsafe void Update(float amount, Particle* particle) {
-            particle->Color = HslColor.Lerp(InitialColor, FinalColor, particle->Age);
+            particle->Color = HslColor.Lerp(InitialColor, FinalColor, amount);
         }
     }
 }

--- a/Source/MonoGame.Extended/Particles/Modifiers/Interpolators/HueInterpolator.cs
+++ b/Source/MonoGame.Extended/Particles/Modifiers/Interpolators/HueInterpolator.cs
@@ -13,7 +13,7 @@
 
         public unsafe void Update(float amount, Particle* particle) {
             particle->Color = new HslColor(
-                    particle->Age * _delta + StartValue,
+                    amount * _delta + StartValue,
                     particle->Color.S,
                     particle->Color.L);
         }


### PR DESCRIPTION
This struct is based on the one from xenko engine, it allows you to use the unit type you want for angles. Supported unit types are: radians, degrees, gradians and revolutions.
It has methods to wrap (between -pi and pi) or to wrap positive (between 0 and 2*pi).
It also has methods to get the angle from a vector, and to create a vector (unit or specified length) from an angle.
Reasoning behind using a double for the value is because all the .net angle math functions use doubles, this will allow for less casts and higher precision.