### PR TITLE
Tiled map: Fix for Tile Id and Tile animation.

### DIFF
--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
@@ -10,7 +10,7 @@ namespace MonoGame.Extended.Maps.Tiled
         protected override TiledMap Read(ContentReader reader, TiledMap existingInstance)
         {
             var backgroundColor = reader.ReadColor();
-            var renderOrder = (TiledRenderOrder) Enum.Parse(typeof (TiledRenderOrder), reader.ReadString(), true);
+            var renderOrder = (TiledRenderOrder)Enum.Parse(typeof(TiledRenderOrder), reader.ReadString(), true);
             var tiledMap = new TiledMap(
                 graphicsDevice: reader.ContentManager.GetGraphicsDevice(),
                 width: reader.ReadInt32(),
@@ -41,11 +41,15 @@ namespace MonoGame.Extended.Maps.Tiled
                 var tileSetTileCount = reader.ReadInt32();
                 for (var j = 0; j < tileSetTileCount; j++)
                 {
-                    var tileSetTile = tileset.CreateTileSetTile(id: reader.ReadInt32());
+                    var tileId = reader.ReadInt32();
+                    tileId = tileset.FirstId + tileId - 1;
+                    var tileSetTile = tileset.CreateTileSetTile(tileId);
                     var tileSetTileFrameCount = reader.ReadInt32();
-                    for (var k=0;k<tileSetTileFrameCount; k++)
+                    for (var k = 0; k < tileSetTileFrameCount; k++)
                     {
-                        tileSetTile.CreateTileSetTileFrame(order: k, tileId: reader.ReadInt32(), duration: reader.ReadInt32());
+                        var frameId = reader.ReadInt32();
+                        frameId = tileset.FirstId + frameId - 1;
+                        tileSetTile.CreateTileSetTileFrame(order: k, tileId: frameId, duration: reader.ReadInt32());
                     }
                     ReadCustomProperties(reader, tileSetTile.Properties);
                 }
@@ -81,7 +85,7 @@ namespace MonoGame.Extended.Maps.Tiled
 
             for (var i = 0; i < count; i++)
             {
-                var objectType = (TiledObjectType) reader.ReadInt32();
+                var objectType = (TiledObjectType)reader.ReadInt32();
                 var id = reader.ReadInt32();
                 var gid = reader.ReadInt32();
                 var x = reader.ReadSingle();
@@ -93,7 +97,7 @@ namespace MonoGame.Extended.Maps.Tiled
                 var type = reader.ReadString();
                 var isVisible = reader.ReadBoolean();
 
-                objects[i] = new TiledObject(objectType, id, gid >= 0 ? gid : (int?) null, x, y, width, height)
+                objects[i] = new TiledObject(objectType, id, gid >= 0 ? gid : (int?)null, x, y, width, height)
                 {
                     IsVisible = isVisible,
                     Opacity = opacity,

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
@@ -92,7 +92,10 @@ namespace MonoGame.Extended.Maps.Tiled
                         {
                             _animatedTiles.Add(tile);
                         }
-                        UpdateRenderTarget(_renderTargetSpriteBatch, tileLocationFunction, tile, tileId);
+                        else
+                        {
+                            UpdateRenderTarget(_renderTargetSpriteBatch, tileLocationFunction, tile, tileId);
+                        }
                     }
 
                     _renderTargetSpriteBatch.End();


### PR DESCRIPTION
- Calculate correct TiledTileSetTile id inside TileSet. (Due to documentation Tile id is local id inside TileSet http://doc.mapeditor.org/reference/tmx-map-format/), this will correctly render animation if several tilesets used in map.

- Fix tile animation rendering. Prevent first frame of the animation tile to be always rendered.