### PR TITLE
correct width calculation for bitmap fonts

### DIFF
--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -45,14 +45,19 @@ namespace MonoGame.Extended.BitmapFonts
         {
             var width = 0;
             var height = 0;
+            var codePoints = GetUnicodeCodePoints(text).ToArray();
 
-            foreach (int c in GetUnicodeCodePoints(text))
+            for (int i = 0, l = codePoints.Length; i < l; i++)
             {
                 BitmapFontRegion fontRegion;
+                var c = codePoints[i];
 
                 if (_characterMap.TryGetValue(c, out fontRegion))
                 {
-                    width += fontRegion.XAdvance;
+                    if (i != text.Length - 1)
+                        width += fontRegion.XAdvance;
+                    else
+                        width += fontRegion.XOffset + fontRegion.Width;
 
                     if (fontRegion.Height + fontRegion.YOffset > height)
                         height = fontRegion.Height + fontRegion.YOffset;

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.TextureAtlases;
+using System.Linq;
 
 namespace MonoGame.Extended.BitmapFonts
 {
@@ -35,7 +36,13 @@ namespace MonoGame.Extended.BitmapFonts
                     }
 
                     DrawString(spriteBatch, bitmapFont, word, new Vector2(dx, dy), color, layerDepth);
-                    dx += size.Width + bitmapFont.GetCharacterRegion(' ').XAdvance;
+                    dx += size.Width;
+
+                    var spaceCharRegion = bitmapFont.GetCharacterRegion(' ');
+                    if (i != words.Length - 1)
+                        dx += spaceCharRegion.XAdvance;
+                    else
+                        dx += spaceCharRegion.XOffset + spaceCharRegion.Width;
                 }
 
                 dx = position.X;
@@ -49,9 +56,11 @@ namespace MonoGame.Extended.BitmapFonts
         {
             var dx = position.X;
             var dy = position.Y;
+            var codePoints = BitmapFont.GetUnicodeCodePoints(text).ToArray();
 
-            foreach (var character in BitmapFont.GetUnicodeCodePoints(text))
+            for (int i = 0, l = codePoints.Length; i < l; i++)
             {
+                var character = codePoints[i];
                 var fontRegion = bitmapFont.GetCharacterRegion(character);
 
                 if (fontRegion != null)
@@ -59,7 +68,11 @@ namespace MonoGame.Extended.BitmapFonts
                     var charPosition = new Vector2(dx + fontRegion.XOffset, dy + fontRegion.YOffset);
 
                     spriteBatch.Draw(fontRegion.TextureRegion, charPosition, color, 0, Vector2.Zero, Vector2.One, SpriteEffects.None, layerDepth);
-                    dx += fontRegion.XAdvance;
+
+                    if (i != text.Length - 1)
+                        dx += fontRegion.XAdvance;
+                    else
+                        dx += fontRegion.XOffset + fontRegion.Width;
                 }
 
                 if (character == '\n')


### PR DESCRIPTION
I found an issue while trying to position text according to its width. There would be an extra amount of width, coming from the `XAdvance` property for the last character. Since the last character is not advancing to another we should use the sum of the character region's `XOffset` and `Width` instead.