### PR TITLE
Add LetterSpacing to BitmapFont

### DIFF
--- a/Source/Demos/Demo.BitmapFonts/Game1.cs
+++ b/Source/Demos/Demo.BitmapFonts/Game1.cs
@@ -65,12 +65,14 @@ namespace Demo.BitmapFonts
 
             _spriteBatch.Begin(transformMatrix: _camera.GetViewMatrix());
             _spriteBatch.Draw(_backgroundTexture, _viewportAdapter.BoundingRectangle, Color.White);
+            _bitmapFont.LetterSpacing = 3;
             _spriteBatch.DrawString(_bitmapFont, "MonoGame.Extended BitmapFont Sample", new Vector2(50, 10), Color.White);
+            _bitmapFont.LetterSpacing = 0;
             _spriteBatch.DrawString(_bitmapFont, "Contrary to popular belief, Lorem Ipsum is not simply random text.\n\n" + 
                 "It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard " + 
                 "McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin " + 
                 "words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, " + 
-                "discovered the undoubtable source.", new Vector2(50, 50), new Color(Color.Black, 0.5f), 750);
+                "discovered the undoubtable source.", new Vector2(50, 60), new Color(Color.Black, 0.5f), 750);
             _spriteBatch.DrawString(_bitmapFont, _labelText, _labelPosition, Color.Black);
             _spriteBatch.End();
 

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -20,6 +20,7 @@ namespace MonoGame.Extended.BitmapFonts
 
         public string Name { get; }
         public int LineHeight { get; private set; }
+        public int LetterSpacing { get; set; } = 0;
 
         public BitmapFontRegion GetCharacterRegion(int character)
         {
@@ -55,7 +56,7 @@ namespace MonoGame.Extended.BitmapFonts
                 if (_characterMap.TryGetValue(c, out fontRegion))
                 {
                     if (i != text.Length - 1)
-                        width += fontRegion.XAdvance;
+                        width += fontRegion.XAdvance + LetterSpacing;
                     else
                         width += fontRegion.XOffset + fontRegion.Width;
 

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
@@ -40,7 +40,7 @@ namespace MonoGame.Extended.BitmapFonts
 
                     var spaceCharRegion = bitmapFont.GetCharacterRegion(' ');
                     if (i != words.Length - 1)
-                        dx += spaceCharRegion.XAdvance;
+                        dx += spaceCharRegion.XAdvance + bitmapFont.LetterSpacing;
                     else
                         dx += spaceCharRegion.XOffset + spaceCharRegion.Width;
                 }
@@ -70,7 +70,7 @@ namespace MonoGame.Extended.BitmapFonts
                     spriteBatch.Draw(fontRegion.TextureRegion, charPosition, color, 0, Vector2.Zero, Vector2.One, SpriteEffects.None, layerDepth);
 
                     if (i != text.Length - 1)
-                        dx += fontRegion.XAdvance;
+                        dx += fontRegion.XAdvance + bitmapFont.LetterSpacing;
                     else
                         dx += fontRegion.XOffset + fontRegion.Width;
                 }


### PR DESCRIPTION
As mentioned in https://github.com/craftworkgames/MonoGame.Extended/pull/225.

Adds letter spacing support to the BitmapFont class through a public `LetterSpacing` property, defaulting to 0 and thus backwards compatible.

LetterSpacing indicates inter-character space in addition to the default space between characters.