### PR TITLE
SceneNode & Transform2D

### DIFF
--- a/Source/Demos/Demo.SceneGraphs/Game1.cs
+++ b/Source/Demos/Demo.SceneGraphs/Game1.cs
@@ -33,7 +33,6 @@ namespace Demo.SceneGraphs
             Content.RootDirectory = "Content";
             Window.Title = "MonoGame.Extended Game";
             Window.AllowUserResizing = true;
-            Window.Position = Point.Zero;
             IsMouseVisible = true;
         }
 
@@ -92,11 +91,6 @@ namespace Demo.SceneGraphs
             var keyboardState = Keyboard.GetState();
             var mouseState = Mouse.GetState();
 
-            if (keyboardState.IsKeyDown(Keys.Escape))
-            {
-                Exit();
-            }
-
             if (keyboardState.IsKeyDown(Keys.W))
             {
                 _speed += deltaTime * 0.5f;
@@ -154,7 +148,12 @@ namespace Demo.SceneGraphs
 
             if (_hoveredNode != null)
             {
-                _spriteBatch.DrawString(_bitmapFont, _hoveredNode.Name, new Vector2(14, 2), Color.White);
+                var textPosition = new Vector2(14, 2);
+                var textLineHeight = new Vector2(0, _bitmapFont.LineHeight);
+                _spriteBatch.DrawString(_bitmapFont, $"Name: {_hoveredNode.Name}", textPosition, Color.White);
+                _spriteBatch.DrawString(_bitmapFont, $"Position: {_hoveredNode.WorldPosition}", textPosition + textLineHeight, Color.White);
+                _spriteBatch.DrawString(_bitmapFont, $"Rotation: {MathHelper.ToDegrees(_hoveredNode.WorldRotation)} degrees", textPosition + 2 * textLineHeight, Color.White);
+                _spriteBatch.DrawString(_bitmapFont, $"Scale: {_hoveredNode.WorldScale}", textPosition + 3 * textLineHeight, Color.White);
             }
 
             _spriteBatch.End();

--- a/Source/MonoGame.Extended/Matrix2D.cs
+++ b/Source/MonoGame.Extended/Matrix2D.cs
@@ -57,7 +57,7 @@ namespace MonoGame.Extended
         /// <value>
         ///     The translation.
         /// </value>
-        /// <remarks>The <see cref="Translation" /> corresponds to the fields <see cref="M31" /> and <see cref="M32" />.</remarks>
+        /// <remarks>The <see cref="Translation" /> is equal to the vector <code>(M31, M32)</code>.</remarks>
         public Vector2 Translation
         {
             get { return new Vector2(M31, M32); }
@@ -70,8 +70,7 @@ namespace MonoGame.Extended
         ///     The rotation angle in radians.
         /// </value>
         /// <remarks>
-        ///     The <see cref="Rotation" /> corresponds to the inverse tangent function (atan2) of the fields
-        ///     <see cref="M21" /> and <see cref="M11" />.
+        ///     The <see cref="Rotation" /> is equal to <code>Atan2(M21, M11)</code>.
         /// </remarks>
         public float Rotation
         {
@@ -84,10 +83,15 @@ namespace MonoGame.Extended
         /// <value>
         ///     The scale.
         /// </value>
-        /// <remarks>The <see cref="Scale" /> corresponds to the fields <see cref="M11" /> and <see cref="M22" />.</remarks>
+        /// <remarks>The <see cref="Scale" /> is equal to the vector <code>(Sqrt(M11 * M11 + M21 * M21), Sqrt(M12 * M12 + M22 * M22))</code>.</remarks>
         public Vector2 Scale
         {
-            get { return new Vector2(M11, M22); }
+            get
+            {
+                var scaleX = (float)Math.Sqrt(M11 * M11 + M21 * M21);
+                var scaleY = (float)Math.Sqrt(M12 * M12 + M22 * M22);
+                return new Vector2(scaleX, scaleY);
+            }
         }
 
         /// <summary>
@@ -845,7 +849,7 @@ namespace MonoGame.Extended
         /// </value>
         internal string DebugDisplayString
         {
-            get { return this == Identity ? "Identity" : $"T:({Translation.X:0.##},{Translation.Y:0.##}), R:{Rotation:0.##}, S:({Scale.X:0.##},{Scale.Y:0.##})"; }
+            get { return this == Identity ? "Identity" : $"T:({Translation.X:0.##},{Translation.Y:0.##}), R:{MathHelper.ToDegrees(Rotation):0.##}°, S:({Scale.X:0.##},{Scale.Y:0.##})"; }
         }
 
         /// <summary>

--- a/Source/MonoGame.Extended/Matrix2D.cs
+++ b/Source/MonoGame.Extended/Matrix2D.cs
@@ -71,11 +71,11 @@ namespace MonoGame.Extended
         /// </value>
         /// <remarks>
         ///     The <see cref="Rotation" /> corresponds to the inverse tangent function (atan2) of the fields
-        ///     <see cref="M21" /> and <see cref="M22" />.
+        ///     <see cref="M21" /> and <see cref="M11" />.
         /// </remarks>
         public float Rotation
         {
-            get { return new Vector2(M21, M22).ToAngle(); }
+            get { return (float)Math.Atan2(M21, M11); }
         }
 
         /// <summary>

--- a/Source/MonoGame.Extended/SceneGraphs/SceneNode.cs
+++ b/Source/MonoGame.Extended/SceneGraphs/SceneNode.cs
@@ -5,7 +5,7 @@ using MonoGame.Extended.Shapes;
 
 namespace MonoGame.Extended.SceneGraphs
 {
-    public class SceneNode : Transform2D
+    public class SceneNode : Transform2D<SceneNode>
     {
         public SceneNode(string name)
             : this(name, Vector2.Zero, 0, Vector2.One)
@@ -31,12 +31,6 @@ namespace MonoGame.Extended.SceneGraphs
         public SceneNode()
             : this(null, Vector2.Zero, 0, Vector2.One)
         {
-        }
-
-        public new SceneNode Parent
-        {
-            get { return (SceneNode)base.Parent; }
-            set { base.Parent = value; }
         }
 
         public string Name { get; set; }

--- a/Source/MonoGame.Extended/SceneGraphs/SceneNode.cs
+++ b/Source/MonoGame.Extended/SceneGraphs/SceneNode.cs
@@ -5,7 +5,7 @@ using MonoGame.Extended.Shapes;
 
 namespace MonoGame.Extended.SceneGraphs
 {
-    public class SceneNode : IMovable, IRotatable, IScalable
+    public class SceneNode : Transform2D
     {
         public SceneNode(string name)
             : this(name, Vector2.Zero, 0, Vector2.One)
@@ -33,26 +33,25 @@ namespace MonoGame.Extended.SceneGraphs
         {
         }
 
+        public new SceneNode Parent
+        {
+            get { return (SceneNode)base.Parent; }
+            set { base.Parent = value; }
+        }
+
         public string Name { get; set; }
-        public Vector2 Position { get; set; }
-        public float Rotation { get; set; }
-        public Vector2 Scale { get; set; }
-        public SceneNode Parent { get; internal set; }
+
         public SceneNodeCollection Children { get; }
         public SceneEntityCollection Entities { get; }
         public object Tag { get; set; }
 
         public RectangleF GetBoundingRectangle()
         {
-            Vector2 position, scale;
-            float rotation;
-            GetWorldTransform().Decompose(out position, out rotation, out scale);
-
             var rectangles = Entities
                 .Select(e =>
                 {
                     var r = e.GetBoundingRectangle();
-                    r.Offset(position);
+                    r.Offset(WorldPosition);
                     return r;
                 })
                 .Concat(Children.Select(i => i.GetBoundingRectangle()))
@@ -65,36 +64,17 @@ namespace MonoGame.Extended.SceneGraphs
             return new RectangleF(x0, y0, x1 - x0, y1 - y0);
         }
 
-        public Matrix GetWorldTransform()
-        {
-            return Parent == null ? Matrix.Identity : Matrix.Multiply(GetLocalTransform(), Parent.GetWorldTransform());
-        }
-
-        public Matrix GetLocalTransform()
-        {
-            var rotationMatrix = Matrix.CreateRotationZ(Rotation);
-            var scaleMatrix = Matrix.CreateScale(new Vector3(Scale.X, Scale.Y, 1));
-            var translationMatrix = Matrix.CreateTranslation(new Vector3(Position.X, Position.Y, 0));
-            var tempMatrix = Matrix.Multiply(scaleMatrix, rotationMatrix);
-            return Matrix.Multiply(tempMatrix, translationMatrix);
-        }
-
         public void Draw(SpriteBatch spriteBatch)
         {
-            Vector2 offsetPosition, offsetScale;
-            float offsetRotation;
-            var worldTransform = GetWorldTransform();
-            worldTransform.Decompose(out offsetPosition, out offsetRotation, out offsetScale);
-
             foreach (var drawable in Entities.OfType<ISpriteBatchDrawable>())
             {
                 if (drawable.IsVisible)
                 {
                     var texture = drawable.TextureRegion.Texture;
                     var sourceRectangle = drawable.TextureRegion.Bounds;
-                    var position = offsetPosition + drawable.Position;
-                    var rotation = offsetRotation + drawable.Rotation;
-                    var scale = offsetScale * drawable.Scale;
+                    var position = WorldPosition;
+                    var rotation = WorldRotation;
+                    var scale = WorldScale;
 
                     spriteBatch.Draw(texture, position, sourceRectangle, drawable.Color, rotation, drawable.Origin, scale, drawable.Effect, 0);
                 }

--- a/Source/MonoGame.Extended/SceneGraphs/SceneNode.cs
+++ b/Source/MonoGame.Extended/SceneGraphs/SceneNode.cs
@@ -72,9 +72,9 @@ namespace MonoGame.Extended.SceneGraphs
                 {
                     var texture = drawable.TextureRegion.Texture;
                     var sourceRectangle = drawable.TextureRegion.Bounds;
-                    var position = WorldPosition;
-                    var rotation = WorldRotation;
-                    var scale = WorldScale;
+                    var position = WorldPosition + drawable.Position;
+                    var rotation = WorldRotation + drawable.Rotation;
+                    var scale = WorldScale + drawable.Scale;
 
                     spriteBatch.Draw(texture, position, sourceRectangle, drawable.Color, rotation, drawable.Origin, scale, drawable.Effect, 0);
                 }

--- a/Source/MonoGame.Extended/Transform.cs
+++ b/Source/MonoGame.Extended/Transform.cs
@@ -19,7 +19,7 @@ namespace MonoGame.Extended
     ///     three-dimensions.
     /// </summary>
     /// <typeparam name="TMatrix">The type of the matrix.</typeparam>
-    /// <typeparam name="TParentTransform">The type of the parent transform.</typeparam>
+    /// <typeparam name="TParent">The type of the parent transform.</typeparam>
     /// <remarks>
     ///     <para>
     ///         Every game object has a transform which is used to store and manipulate the position, rotation and scale
@@ -32,13 +32,13 @@ namespace MonoGame.Extended
     ///     </para>
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public abstract class BaseTransform<TMatrix, TParentTransform>
-        where TMatrix : struct where TParentTransform : BaseTransform<TMatrix, TParentTransform>
+    public abstract class BaseTransform<TMatrix, TParent>
+        where TMatrix : struct where TParent : BaseTransform<TMatrix, TParent>
     {
         private TransformFlags _flags = TransformFlags.All; // dirty flags, set all dirty flags when created
         private TMatrix _localMatrix; // model space to local space
         private TMatrix _worldMatrix; // local space to world space
-        private TParentTransform _parent; // parent
+        private TParent _parent; // parent
 
         public event Action TransformBecameDirty; // observer pattern for when the world (or local) matrix became dirty
         public event Action TranformUpdated; // observer pattern for after the world (or local) matrix was re-calculated
@@ -74,10 +74,10 @@ namespace MonoGame.Extended
         }
 
         /// <summary>
-        ///     Gets or sets the parent transform.
+        ///     Gets or sets the parent instance.
         /// </summary>
         /// <value>
-        ///     The parent transform.
+        ///     The parent instance.
         /// </value>
         /// <remarks>
         ///     <para>
@@ -86,7 +86,7 @@ namespace MonoGame.Extended
         ///         <code>null</code> disables the inheritance altogether for this instance.
         ///     </para>
         /// </remarks>
-        public TParentTransform Parent
+        public TParent Parent
         {
             get { return _parent; }
             set
@@ -136,7 +136,7 @@ namespace MonoGame.Extended
             TransformBecameDirty?.Invoke();
         }
 
-        private void OnParentChanged(TParentTransform oldParent, TParentTransform newParent)
+        private void OnParentChanged(TParent oldParent, TParent newParent)
         {
             var parent = oldParent;
             while (parent != null)
@@ -188,7 +188,11 @@ namespace MonoGame.Extended
     /// <summary>
     ///     Represents the position, rotation, and scale of a two-dimensional game object.
     /// </summary>
-    /// <seealso cref="Extended.BaseTransform{Matrix2D, Transform2D}" />
+    /// <typeparam name="TParent">The type of the parent.</typeparam>
+    /// <seealso cref="BaseTransform{Matrix2D, TParent}" />
+    /// <seealso cref="IMovable" />
+    /// <seealso cref="IRotatable" />
+    /// <seealso cref="IScalable" />
     /// <remarks>
     ///     <para>
     ///         Every game object has a transform which is used to store and manipulate the position, rotation and scale
@@ -196,7 +200,8 @@ namespace MonoGame.Extended
     ///         objects hierarchically.
     ///     </para>
     /// </remarks>
-    public class Transform2D : BaseTransform<Matrix2D, Transform2D>, IMovable, IRotatable, IScalable
+    public class Transform2D<TParent> : BaseTransform<Matrix2D, TParent>, IMovable, IRotatable, IScalable
+        where TParent : Transform2D<TParent>
     {
         private Vector2 _position;
         private Vector2 _scale = Vector2.One;

--- a/Source/MonoGame.Extended/Transform.cs
+++ b/Source/MonoGame.Extended/Transform.cs
@@ -141,21 +141,21 @@ namespace MonoGame.Extended
             var parent = oldParent;
             while (parent != null)
             {
-                parent.TransformBecameDirty -= ParentTransformOnTransformBecameDirty;
+                parent.TransformBecameDirty -= ParentOnTransformBecameDirty;
                 parent = parent.Parent;
             }
 
             parent = newParent;
             while (parent != null)
             {
-                parent.TransformBecameDirty += ParentTransformOnTransformBecameDirty;
+                parent.TransformBecameDirty += ParentOnTransformBecameDirty;
                 parent = parent.Parent;
             }
         }
 
-        private void ParentTransformOnTransformBecameDirty()
+        private void ParentOnTransformBecameDirty()
         {
-            _flags |= TransformFlags.WorldMatrixIsDirty;
+            _flags |= TransformFlags.All;
         }
 
         private void RecalculateWorldMatrixIfNecessary()
@@ -231,6 +231,17 @@ namespace MonoGame.Extended
         }
 
         /// <summary>
+        ///     Gets the world scale.
+        /// </summary>
+        /// <value>
+        ///     The world scale.
+        /// </value>
+        public Vector2 WorldScale
+        {
+            get { return WorldMatrix.Scale; }
+        }
+
+        /// <summary>
         ///     Gets or sets the local scale.
         /// </summary>
         /// <value>
@@ -245,6 +256,17 @@ namespace MonoGame.Extended
                 LocalMatrixBecameDirty();
                 WorldMatrixBecameDirty();
             }
+        }
+
+        /// <summary>
+        ///     Gets the world rotation angle in radians.
+        /// </summary>
+        /// <value>
+        ///     The world rotation angle in radians.
+        /// </value>
+        public float WorldRotation
+        {
+            get { return WorldMatrix.Rotation; }
         }
 
         /// <summary>
@@ -264,7 +286,7 @@ namespace MonoGame.Extended
             }
         }
 
-        protected override void RecalculateWorldMatrix(ref Matrix2D localMatrix, out Matrix2D matrix)
+        protected internal override void RecalculateWorldMatrix(ref Matrix2D localMatrix, out Matrix2D matrix)
         {
             if (Parent != null)
             {
@@ -277,7 +299,7 @@ namespace MonoGame.Extended
             }
         }
 
-        protected override void RecalculateLocalMatrix(out Matrix2D matrix)
+        protected internal override void RecalculateLocalMatrix(out Matrix2D matrix)
         {
             if (Parent != null)
             {

--- a/Source/MonoGame.Extended/Transform.cs
+++ b/Source/MonoGame.Extended/Transform.cs
@@ -106,7 +106,7 @@ namespace MonoGame.Extended
         }
 
         /// <summary>
-        ///     Gets model-to-local space <see cref="Matrix2D" />.
+        ///     Gets the model-to-local space <see cref="Matrix2D" />.
         /// </summary>
         /// <param name="matrix">The model-to-local space <see cref="Matrix2D" />.</param>
         public void GetLocalMatrix(out TMatrix matrix)
@@ -116,7 +116,7 @@ namespace MonoGame.Extended
         }
 
         /// <summary>
-        ///     Gets local-to-world space <see cref="Matrix2D" />.
+        ///     Gets the local-to-world space <see cref="Matrix2D" />.
         /// </summary>
         /// <param name="matrix">The local-to-world space <see cref="Matrix2D" />.</param>
         public void GetWorldMatrix(out TMatrix matrix)
@@ -125,12 +125,12 @@ namespace MonoGame.Extended
             matrix = _worldMatrix;
         }
 
-        protected void LocalMatrixBecameDirty()
+        protected internal void LocalMatrixBecameDirty()
         {
             _flags |= TransformFlags.LocalMatrixIsDirty;
         }
 
-        protected void WorldMatrixBecameDirty()
+        protected internal void WorldMatrixBecameDirty()
         {
             _flags |= TransformFlags.WorldMatrixIsDirty;
             TransformBecameDirty?.Invoke();
@@ -169,7 +169,7 @@ namespace MonoGame.Extended
             TranformUpdated?.Invoke();
         }
 
-        protected abstract void RecalculateWorldMatrix(ref TMatrix localMatrix, out TMatrix matrix);
+        protected internal abstract void RecalculateWorldMatrix(ref TMatrix localMatrix, out TMatrix matrix);
 
         private void RecalculateLocalMatrixIfNecessary()
         {
@@ -182,7 +182,7 @@ namespace MonoGame.Extended
             WorldMatrixBecameDirty();
         }
 
-        protected abstract void RecalculateLocalMatrix(out TMatrix matrix);
+        protected internal abstract void RecalculateLocalMatrix(out TMatrix matrix);
     }
 
     /// <summary>


### PR DESCRIPTION
- Fix bug in `Transform2D` where local matrix wouldn't be updated if the parent's local matrix updated.
- Fix `Scale` and `Rotation` property in `Matrix2D`.
- Add `WorldPosition`, `WorldRotation`, and `WorldScale` to `Transform2D`.
- Update `SceneNode` to use `Transform2D` as base class.
- Update SceneGraph demo; works as expected.