### PR TITLE
fix FramesPerSecondCounter

### DIFF
--- a/Source/Demos/Demo.TiledMaps/Game1.cs
+++ b/Source/Demos/Demo.TiledMaps/Game1.cs
@@ -112,7 +112,7 @@ namespace Demo.TiledMaps
             _spriteBatch.Begin(samplerState: SamplerState.PointClamp, blendState: BlendState.AlphaBlend);
             _spriteBatch.DrawString(_bitmapFont, "WASD/Arrows: move", new Vector2(5, 32), textColor);
             _spriteBatch.DrawString(_bitmapFont, "RF: zoom", new Vector2(5, 32 + _bitmapFont.LineHeight), textColor);
-            _spriteBatch.DrawString(_bitmapFont, $"FPS: {_fpsCounter.AverageFramesPerSecond:0}", Vector2.One, Color.Black);
+            _spriteBatch.DrawString(_bitmapFont, $"FPS: {_fpsCounter.FramesPerSecond:0}", Vector2.One, Color.Black);
             _spriteBatch.DrawString(_bitmapFont, $"Camera: {_camera.Position}", new Vector2(5, 32 + _bitmapFont.LineHeight * 2), Color.Black);
             _spriteBatch.End();
 

--- a/Source/MonoGame.Extended/FramesPerSecondCounter.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounter.cs
@@ -9,7 +9,7 @@ namespace MonoGame.Extended
         private TimeSpan _timer = OneSecondTimeSpan;
         private int _framesCounter;
 
-        public float FramesPerSecond { get; private set; }
+        public int FramesPerSecond { get; private set; }
 
         public FramesPerSecondCounter()
         {

--- a/Source/MonoGame.Extended/FramesPerSecondCounter.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounter.cs
@@ -1,51 +1,55 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using Microsoft.Xna.Framework;
+using MonoGame.Extended.Collections;
 
 namespace MonoGame.Extended
 {
     public class FramesPerSecondCounter : IUpdate
     {
-        public FramesPerSecondCounter(int maximumSamples = 100)
-        {
-            MaximumSamples = maximumSamples;
-        }
+        private static readonly TimeSpan OneSecondTimeSpan = new TimeSpan(0, 0, 1);
+        private TimeSpan _timer = OneSecondTimeSpan;
+        private int _framesCounter;
+        private readonly Deque<float> _sampleBuffer;
 
-        private readonly Queue<float> _sampleBuffer = new Queue<float>();
-
-        public long TotalFrames { get; private set; }
         public float AverageFramesPerSecond { get; private set; }
         public float CurrentFramesPerSecond { get; private set; }
         public int MaximumSamples { get; }
 
-        public void Reset()
+        public FramesPerSecondCounter(int maximumSamples = 1)
         {
-            TotalFrames = 0;
-            _sampleBuffer.Clear();
-        }
-
-        public void Update(float deltaTime)
-        {
-            CurrentFramesPerSecond = 1.0f / deltaTime;
-
-            _sampleBuffer.Enqueue(CurrentFramesPerSecond);
-
-            if (_sampleBuffer.Count > MaximumSamples)
+            if (maximumSamples < 0)
             {
-                _sampleBuffer.Dequeue();
-                AverageFramesPerSecond = _sampleBuffer.Average(i => i);
-            }
-            else
-            {
-                AverageFramesPerSecond = CurrentFramesPerSecond;
+                throw new ArgumentOutOfRangeException(nameof(maximumSamples));
             }
 
-            TotalFrames++;
+            MaximumSamples = maximumSamples;
+            _sampleBuffer = new Deque<float>(maximumSamples);
         }
 
         public void Update(GameTime gameTime)
         {
-            Update((float)gameTime.ElapsedGameTime.TotalSeconds);
+            _timer += gameTime.ElapsedGameTime;
+            if (_timer <= OneSecondTimeSpan)
+                return;
+
+            CurrentFramesPerSecond = _framesCounter;
+            _framesCounter = 0;
+            _timer = TimeSpan.Zero;
+
+            if (_sampleBuffer.Count >= MaximumSamples)
+            {
+                _sampleBuffer.RemoveFromFront();
+            }
+
+            _sampleBuffer.AddToBack(CurrentFramesPerSecond);
+
+            AverageFramesPerSecond = _sampleBuffer.Average(i => i);
+        }
+
+        public void Draw(GameTime gameTime)
+        {
+            _framesCounter++;
         }
     }
 }

--- a/Source/MonoGame.Extended/FramesPerSecondCounter.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounter.cs
@@ -10,7 +10,6 @@ namespace MonoGame.Extended
         private int _framesCounter;
 
         public float FramesPerSecond { get; private set; }
-        public int MaximumSamples { get; }
 
         public FramesPerSecondCounter()
         {

--- a/Source/MonoGame.Extended/FramesPerSecondCounter.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.Xna.Framework;
-using MonoGame.Extended.Collections;
 
 namespace MonoGame.Extended
 {
@@ -10,21 +8,12 @@ namespace MonoGame.Extended
         private static readonly TimeSpan OneSecondTimeSpan = new TimeSpan(0, 0, 1);
         private TimeSpan _timer = OneSecondTimeSpan;
         private int _framesCounter;
-        private readonly Deque<float> _sampleBuffer;
 
-        public float AverageFramesPerSecond { get; private set; }
-        public float CurrentFramesPerSecond { get; private set; }
+        public float FramesPerSecond { get; private set; }
         public int MaximumSamples { get; }
 
-        public FramesPerSecondCounter(int maximumSamples = 1)
+        public FramesPerSecondCounter()
         {
-            if (maximumSamples < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumSamples));
-            }
-
-            MaximumSamples = maximumSamples;
-            _sampleBuffer = new Deque<float>(maximumSamples);
         }
 
         public void Update(GameTime gameTime)
@@ -33,18 +22,9 @@ namespace MonoGame.Extended
             if (_timer <= OneSecondTimeSpan)
                 return;
 
-            CurrentFramesPerSecond = _framesCounter;
+            FramesPerSecond = _framesCounter;
             _framesCounter = 0;
             _timer = TimeSpan.Zero;
-
-            if (_sampleBuffer.Count >= MaximumSamples)
-            {
-                _sampleBuffer.RemoveFromFront();
-            }
-
-            _sampleBuffer.AddToBack(CurrentFramesPerSecond);
-
-            AverageFramesPerSecond = _sampleBuffer.Average(i => i);
         }
 
         public void Draw(GameTime gameTime)

--- a/Source/MonoGame.Extended/FramesPerSecondCounter.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounter.cs
@@ -23,7 +23,7 @@ namespace MonoGame.Extended
 
             FramesPerSecond = _framesCounter;
             _framesCounter = 0;
-            _timer = TimeSpan.Zero;
+            _timer -= OneSecondTimeSpan;
         }
 
         public void Draw(GameTime gameTime)

--- a/Source/MonoGame.Extended/FramesPerSecondCounterComponent.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounterComponent.cs
@@ -6,17 +6,13 @@ namespace MonoGame.Extended
     {
         private readonly FramesPerSecondCounter _fpsCounter;
 
-        public FramesPerSecondCounterComponent(Game game, int maximumSamples = 1)
+        public FramesPerSecondCounterComponent(Game game)
             : base(game)
         {
-            _fpsCounter = new FramesPerSecondCounter(maximumSamples);
+            _fpsCounter = new FramesPerSecondCounter();
         }
 
-        public float AverageFramesPerSecond => _fpsCounter.AverageFramesPerSecond;
-
-        public float CurrentFramesPerSecond => _fpsCounter.CurrentFramesPerSecond;
-
-        public int MaximumSamples => _fpsCounter.MaximumSamples;
+        public float FramesPerSecond => _fpsCounter.FramesPerSecond;
 
         public override void Update(GameTime gameTime)
         {

--- a/Source/MonoGame.Extended/FramesPerSecondCounterComponent.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounterComponent.cs
@@ -1,53 +1,31 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended
 {
     public class FramesPerSecondCounterComponent : DrawableGameComponent
     {
-        FramesPerSecondCounter fpsCounter;
+        private readonly FramesPerSecondCounter _fpsCounter;
 
-        public FramesPerSecondCounterComponent(Game game, int maximumSamples = 100)
+        public FramesPerSecondCounterComponent(Game game, int maximumSamples = 1)
             : base(game)
         {
-            fpsCounter = new FramesPerSecondCounter(maximumSamples);
+            _fpsCounter = new FramesPerSecondCounter(maximumSamples);
         }
 
-        public long TotalFrames
-        {
-            get { return fpsCounter.TotalFrames; }
-        }
+        public float AverageFramesPerSecond => _fpsCounter.AverageFramesPerSecond;
 
-        public float AverageFramesPerSecond
-        {
-            get { return fpsCounter.AverageFramesPerSecond; }
-        }
+        public float CurrentFramesPerSecond => _fpsCounter.CurrentFramesPerSecond;
 
-        public float CurrentFramesPerSecond
-        {
-            get { return fpsCounter.CurrentFramesPerSecond; }
-        }
-
-        public int MaximumSamples
-        {
-            get { return fpsCounter.MaximumSamples; }
-        }
-
-        public void Reset()
-        {
-            fpsCounter.Reset();
-        }
+        public int MaximumSamples => _fpsCounter.MaximumSamples;
 
         public override void Update(GameTime gameTime)
         {
-            base.Update(gameTime);
+            _fpsCounter.Update(gameTime);
         }
 
         public override void Draw(GameTime gameTime)
         {
-            fpsCounter.Update((float)gameTime.ElapsedGameTime.TotalSeconds);
-            base.Draw(gameTime);
+            _fpsCounter.Draw(gameTime);
         }
     }
 }

--- a/Source/MonoGame.Extended/FramesPerSecondCounterComponent.cs
+++ b/Source/MonoGame.Extended/FramesPerSecondCounterComponent.cs
@@ -12,7 +12,7 @@ namespace MonoGame.Extended
             _fpsCounter = new FramesPerSecondCounter();
         }
 
-        public float FramesPerSecond => _fpsCounter.FramesPerSecond;
+        public int FramesPerSecond => _fpsCounter.FramesPerSecond;
 
         public override void Update(GameTime gameTime)
         {


### PR DESCRIPTION
-Update the logic based off [Shawn's blog](https://blogs.msdn.microsoft.com/shawnhar/2007/06/08/displaying-the-framerate/) so the frames per second is really the number of frames _per second_, not the game time budget of the frame.
-Removed averaging. It's not used in the TiledMaps.Demo and is a small waste of CPU time and memory resources.
-Update `FramesPerSecondCounterComponent`.
-Tested TiledMaps.Demo. Works correctly.

EDIT: From the comments section on Shawn's blog post
> > Surely 1 / gameTime.ElapsedRealTime.TotalSeconds 
> > will therefore give the current framerate.
> 
> That will tell you how long it was since the previous call to Update, but that is not the same thing as your framerate!

> a) If the game is dropping frames, Update will be called more frequently in order to catch up. You want to time the number of actual draws that are taking place, not just these extra catch-up logic frames.
> 
> b) The time for a single Update can fluctuate widely, so the figure you get out of that will be too flickery to be easily readable.