### PR TITLE
Objectgroups in Tiles (fixed)

### DIFF
--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
@@ -47,6 +47,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                         writer.Write(frame.Duration);
                     }
                     WriteCustomProperties(writer, tile.Properties);
+
+                    WriteObjectGroups(writer, tile.ObjectGroups);
                 }
                 WriteCustomProperties(writer, tileset.Properties);
             }
@@ -86,44 +88,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                 WriteCustomProperties(writer, layer.Properties);
             }
 
-            writer.Write(map.ObjectGroups.Count);
+            WriteObjectGroups(writer, map.ObjectGroups);
 
-            foreach (var objectGroup in map.ObjectGroups)
-            {
-                writer.Write(objectGroup.Name);
-                writer.Write(objectGroup.Visible);
-                writer.Write(objectGroup.Opacity);
-
-                writer.Write(objectGroup.Objects.Count);
-
-                foreach (var tmxObject in objectGroup.Objects)
-                {
-                    var objectType = GetObjectType(tmxObject);
-
-                    writer.Write((int)objectType);
-                    writer.Write(tmxObject.Id);
-                    writer.Write(tmxObject.Gid);
-                    writer.Write(tmxObject.X);
-                    writer.Write(tmxObject.Y);
-                    writer.Write(tmxObject.Width);
-                    writer.Write(tmxObject.Height);
-                    writer.Write(tmxObject.Rotation);
-
-                    writer.Write(tmxObject.Name ?? string.Empty);
-                    writer.Write(tmxObject.Type ?? string.Empty);
-                    writer.Write(tmxObject.Visible);
-
-                    if (objectType == TiledObjectType.Polygon)
-                        WritePolyPoints(writer, tmxObject.Polygon.Points);
-
-                    if (objectType == TiledObjectType.Polyline)
-                        WritePolyPoints(writer, tmxObject.Polyline.Points);
-
-                    WriteCustomProperties(writer, tmxObject.Properties);
-                }
-
-                WriteCustomProperties(writer, objectGroup.Properties);
-            }
         }
 
         private static void WritePolyPoints(ContentWriter writer, string polyPointsString)
@@ -159,6 +125,52 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                 return TiledObjectType.Polyline;
             
             return TiledObjectType.Rectangle;
+        }
+
+        private void WriteObjectGroups(ContentWriter writer, IReadOnlyCollection<TmxObjectGroup> groups)
+        {
+            writer.Write(groups.Count);
+
+            foreach (var objectGroup in groups) {
+                WriteObjectGroup(writer, objectGroup);
+            }
+        }
+
+        private void WriteObjectGroup(ContentWriter writer, TmxObjectGroup group)
+        {
+            writer.Write(group.Name ?? string.Empty);
+            writer.Write(group.Visible);
+            writer.Write(group.Opacity);
+
+            writer.Write(group.Objects.Count);
+
+            foreach (var tmxObject in group.Objects)
+            {
+                var objectType = GetObjectType(tmxObject);
+
+                writer.Write((int)objectType);
+                writer.Write(tmxObject.Id);
+                writer.Write(tmxObject.Gid);
+                writer.Write(tmxObject.X);
+                writer.Write(tmxObject.Y);
+                writer.Write(tmxObject.Width);
+                writer.Write(tmxObject.Height);
+                writer.Write(tmxObject.Rotation);
+
+                writer.Write(tmxObject.Name ?? string.Empty);
+                writer.Write(tmxObject.Type ?? string.Empty);
+                writer.Write(tmxObject.Visible);
+
+                if (objectType == TiledObjectType.Polygon)
+                    WritePolyPoints(writer, tmxObject.Polygon.Points);
+
+                if (objectType == TiledObjectType.Polyline)
+                    WritePolyPoints(writer, tmxObject.Polyline.Points);
+
+                WriteCustomProperties(writer, tmxObject.Properties);
+            }
+
+            WriteCustomProperties(writer, group.Properties);
         }
 
         private static void WriteCustomProperties(ContentWriter writer, IReadOnlyCollection<TmxProperty> properties)

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
@@ -47,6 +47,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                         writer.Write(frame.Duration);
                     }
                     WriteCustomProperties(writer, tile.Properties);
+
+                    WriteObjectGroups(writer, tile.ObjectGroups);
                 }
                 WriteCustomProperties(writer, tileset.Properties);
             }
@@ -86,44 +88,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                 WriteCustomProperties(writer, layer.Properties);
             }
 
-            writer.Write(map.ObjectGroups.Count);
+            WriteObjectGroups(writer, map.ObjectGroups);
 
-            foreach (var objectGroup in map.ObjectGroups)
-            {
-                writer.Write(objectGroup.Name);
-                writer.Write(objectGroup.Visible);
-                writer.Write(objectGroup.Opacity);
-
-                writer.Write(objectGroup.Objects.Count);
-
-                foreach (var tmxObject in objectGroup.Objects)
-                {
-                    var objectType = GetObjectType(tmxObject);
-
-                    writer.Write((int)objectType);
-                    writer.Write(tmxObject.Id);
-                    writer.Write(tmxObject.Gid);
-                    writer.Write(tmxObject.X);
-                    writer.Write(tmxObject.Y);
-                    writer.Write(tmxObject.Width);
-                    writer.Write(tmxObject.Height);
-                    writer.Write(tmxObject.Rotation);
-
-                    writer.Write(tmxObject.Name ?? string.Empty);
-                    writer.Write(tmxObject.Type ?? string.Empty);
-                    writer.Write(tmxObject.Visible);
-
-                    if (objectType == TiledObjectType.Polygon)
-                        WritePolyPoints(writer, tmxObject.Polygon.Points);
-
-                    if (objectType == TiledObjectType.Polyline)
-                        WritePolyPoints(writer, tmxObject.Polyline.Points);
-
-                    WriteCustomProperties(writer, tmxObject.Properties);
-                }
-
-                WriteCustomProperties(writer, objectGroup.Properties);
-            }
         }
 
         private static void WritePolyPoints(ContentWriter writer, string polyPointsString)
@@ -159,6 +125,52 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                 return TiledObjectType.Polyline;
             
             return TiledObjectType.Rectangle;
+        }
+
+        private void WriteObjectGroups(ContentWriter writer, IReadOnlyCollection<TmxObjectGroup> groups)
+        {
+            writer.Write(groups.Count);
+
+            foreach (var objectGroup in groups) {
+                WriteObjectGroup(writer, objectGroup);
+            }
+        }
+
+        private void WriteObjectGroup(ContentWriter writer, TmxObjectGroup group)
+        {
+            writer.Write(group.Name);
+            writer.Write(group.Visible);
+            writer.Write(group.Opacity);
+
+            writer.Write(group.Objects.Count);
+
+            foreach (var tmxObject in group.Objects)
+            {
+                var objectType = GetObjectType(tmxObject);
+
+                writer.Write((int)objectType);
+                writer.Write(tmxObject.Id);
+                writer.Write(tmxObject.Gid);
+                writer.Write(tmxObject.X);
+                writer.Write(tmxObject.Y);
+                writer.Write(tmxObject.Width);
+                writer.Write(tmxObject.Height);
+                writer.Write(tmxObject.Rotation);
+
+                writer.Write(tmxObject.Name ?? string.Empty);
+                writer.Write(tmxObject.Type ?? string.Empty);
+                writer.Write(tmxObject.Visible);
+
+                if (objectType == TiledObjectType.Polygon)
+                    WritePolyPoints(writer, tmxObject.Polygon.Points);
+
+                if (objectType == TiledObjectType.Polyline)
+                    WritePolyPoints(writer, tmxObject.Polyline.Points);
+
+                WriteCustomProperties(writer, tmxObject.Properties);
+            }
+
+            WriteCustomProperties(writer, group.Properties);
         }
 
         private static void WriteCustomProperties(ContentWriter writer, IReadOnlyCollection<TmxProperty> properties)

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
@@ -88,11 +88,9 @@ namespace MonoGame.Extended.Maps.Tiled
             return layer;
         }
 
-        public TiledObjectGroup CreateObjectGroup(string name, TiledObject[] objects, bool isVisible)
+        public void AddObjectGroup(List<TiledObjectGroup> objectGroups)
         {
-            var objectGroup = new TiledObjectGroup(name, objects) { IsVisible = isVisible };
-            _objectGroups.Add(objectGroup);
-            return objectGroup;
+            _objectGroups.AddRange(objectGroups);
         }
 
         public TiledMap Build()

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
@@ -88,9 +88,8 @@ namespace MonoGame.Extended.Maps.Tiled
             return layer;
         }
 
-        public TiledObjectGroup CreateObjectGroup(string name, TiledObject[] objects, bool isVisible)
+        public TiledObjectGroup AddObjectGroup(TiledObjectGroup objectGroup)
         {
-            var objectGroup = new TiledObjectGroup(name, objects) { IsVisible = isVisible };
             _objectGroups.Add(objectGroup);
             return objectGroup;
         }

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.Content;
@@ -52,6 +53,8 @@ namespace MonoGame.Extended.Maps.Tiled
                         tileSetTile.CreateTileSetTileFrame(order: k, tileId: frameId, duration: reader.ReadInt32());
                     }
                     ReadCustomProperties(reader, tileSetTile.Properties);
+                    
+                    tileSetTile.ObjectGroups.AddRange(ReadObjectGroups(reader));
                 }
                 ReadCustomProperties(reader, tileset.Properties);
             }
@@ -64,18 +67,26 @@ namespace MonoGame.Extended.Maps.Tiled
                 ReadCustomProperties(reader, layer.Properties);
             }
 
-            var objectGroupsCount = reader.ReadInt32();
-
-            for (var i = 0; i < objectGroupsCount; i++)
-            {
-                var objectGroup = ReadObjectGroup(reader, tiledMap);
-                ReadCustomProperties(reader, objectGroup.Properties);
-            }
+            tiledMap.AddObjectGroup(ReadObjectGroups(reader));
 
             return tiledMap.Build();
         }
 
-        private static TiledObjectGroup ReadObjectGroup(ContentReader reader, TiledMap tiledMap)
+        private static List<TiledObjectGroup> ReadObjectGroups(ContentReader reader) 
+        {
+            var list = new List<TiledObjectGroup>();
+            var objectGroupsCount = reader.ReadInt32();
+
+            for (var i = 0; i < objectGroupsCount; i++)
+            {
+                var objectGroup = ReadObjectGroup(reader);
+                ReadCustomProperties(reader, objectGroup.Properties);
+                list.Add(objectGroup);
+            }
+            return list;
+        }
+
+        private static TiledObjectGroup ReadObjectGroup(ContentReader reader)
         {
             var groupName = reader.ReadString();
             var visible = reader.ReadBoolean();
@@ -116,8 +127,8 @@ namespace MonoGame.Extended.Maps.Tiled
 
                 ReadCustomProperties(reader, objects[i].Properties);
             }
-
-            return tiledMap.CreateObjectGroup(groupName, objects, visible);
+            
+            return new TiledObjectGroup(groupName, objects) { IsVisible = visible };
         }
 
         private static void ReadCustomProperties(ContentReader reader, TiledProperties properties)

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMapReader.cs
@@ -52,6 +52,9 @@ namespace MonoGame.Extended.Maps.Tiled
                         tileSetTile.CreateTileSetTileFrame(order: k, tileId: frameId, duration: reader.ReadInt32());
                     }
                     ReadCustomProperties(reader, tileSetTile.Properties);
+
+                    var group = ReadObjectGroup(reader);
+                    tileSetTile.ObjectGroups.Add(group);
                 }
                 ReadCustomProperties(reader, tileset.Properties);
             }
@@ -68,14 +71,15 @@ namespace MonoGame.Extended.Maps.Tiled
 
             for (var i = 0; i < objectGroupsCount; i++)
             {
-                var objectGroup = ReadObjectGroup(reader, tiledMap);
+                var objectGroup = ReadObjectGroup(reader);
+                tiledMap.AddObjectGroup(objectGroup);
                 ReadCustomProperties(reader, objectGroup.Properties);
             }
 
             return tiledMap.Build();
         }
 
-        private static TiledObjectGroup ReadObjectGroup(ContentReader reader, TiledMap tiledMap)
+        private static TiledObjectGroup ReadObjectGroup(ContentReader reader)
         {
             var groupName = reader.ReadString();
             var visible = reader.ReadBoolean();
@@ -116,8 +120,8 @@ namespace MonoGame.Extended.Maps.Tiled
 
                 ReadCustomProperties(reader, objects[i].Properties);
             }
-
-            return tiledMap.CreateObjectGroup(groupName, objects, visible);
+            
+            return new TiledObjectGroup(groupName, objects) { IsVisible = visible };
         }
 
         private static void ReadCustomProperties(ContentReader reader, TiledProperties properties)

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledTileSetTile.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledTileSetTile.cs
@@ -8,11 +8,13 @@ namespace MonoGame.Extended.Maps.Tiled
         {
             Id = id;
             Animation = new List<TiledTileSetTileFrame>();
+            ObjectGroups = new List<TiledObjectGroup>();
             Properties = new TiledProperties();
             _currentTimeInMilliseconds = 0.0;
         }
         public int Id { get; set; }
         public List<TiledTileSetTileFrame> Animation { get; private set; }
+        public List<TiledObjectGroup> ObjectGroups { get; private set; }
         public TiledProperties Properties { get; private set; }
         public int? CurrentTileId
         {


### PR DESCRIPTION
So this time, everything is fixed and actually tested: The tilemap demo
works just fine (apart from Game.Exit() being obsolete). Those
objectgroups are now available in their respective TileSetTiles as seen
in this screenshot: http://screencast.com/t/YvdCmQoUcd