### PR TITLE
Added a new constructor and documentation to TextureAtlas class

### DIFF
--- a/Source/MonoGame.Extended.Tests/Shapes/RectangleFTests.cs
+++ b/Source/MonoGame.Extended.Tests/Shapes/RectangleFTests.cs
@@ -33,5 +33,14 @@ namespace MonoGame.Extended.Tests.Shapes
 
             Assert.AreEqual(rect1, rect2);
         }
+
+        [Test]
+        public void PassPointAsConstructorParameter_Test()
+        {
+            var rect1 = new RectangleF(new Vector2(0, 0), new SizeF(12, 56));
+            var rect2 = new RectangleF(new Vector2(0, 0), new Point(12, 56));
+
+            Assert.AreEqual(rect1, rect2);
+        }
     }
 }

--- a/Source/MonoGame.Extended/TextureAtlases/TextureAtlas.cs
+++ b/Source/MonoGame.Extended/TextureAtlases/TextureAtlas.cs
@@ -1,28 +1,78 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.TextureAtlases
 {
+    /// <summary>
+    ///     Defines a texture atlas which stores a source image and contains regions specifying its sub-images.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Texture atlas (also called a tile map, tile engine, or sprite sheet) is a large image containing a collection, or "atlas", of sub-images, each of which is a texture map for some part of a 2D or 3D model.
+    ///         The sub-textures can be rendered by modifying the texture coordinates of the object's uvmap on the atlas, essentially telling it which part of the image its texture is in.
+    ///         In an application where many small textures are used frequently, it is often more efficient to store the textures in a texture atlas which is treated as a single unit by the graphics hardware.
+    ///         This saves memory and because there are less rendering state changes by binding once, it can be faster to bind one large texture once than to bind many smaller textures as they are drawn.
+    ///         Careful alignment may be needed to avoid bleeding between sub textures when used with mipmapping, and artefacts between tiles for texture compression.
+    ///     </para>
+    /// </remarks>
     public class TextureAtlas : IEnumerable<TextureRegion2D>
     {
+        /// <summary>
+        ///     Initializes a new texture atlas with an empty list of regions.
+        /// </summary>
+        /// <param name="texture">Source <see cref="Texture2D "/> image used to draw on screen.</param>
         public TextureAtlas(Texture2D texture)
         {
             Texture = texture;
             _regions = new List<TextureRegion2D>();
             _regionMap = new Dictionary<string, int>();
         }
-        
+
+        /// <summary>
+        ///     Initializes a new texture atlas and populates it with regions.
+        /// </summary>
+        /// <param name="texture">Source <see cref="Texture2D "/> image used to draw on screen.</param>
+        /// <param name="regions">A collection of regions to populate the atlas with.</param>
+        public TextureAtlas(Texture2D texture, Dictionary<string, Rectangle> regions)
+        {
+            Texture = texture;
+            _regions = new List<TextureRegion2D>();
+            _regionMap = new Dictionary<string, int>();
+            foreach (KeyValuePair<string, Rectangle> region in regions)
+                CreateRegion(region.Key, region.Value.X, region.Value.Y, region.Value.Width, region.Value.Height);
+        }
+
         private readonly Dictionary<string, int> _regionMap; 
 
+        /// <summary>
+        ///     Gets a source <see cref="Texture2D"/> image.
+        /// </summary>
         public Texture2D Texture { get; }
 
         private readonly List<TextureRegion2D> _regions;
+
+        /// <summary>
+        ///     Gets a list of regions in the <see cref="TextureAtlas"/>.
+        /// </summary>
         public IEnumerable<TextureRegion2D> Regions => _regions;
 
+        /// <summary>
+        ///     Gets the number of regions in the <see cref="TextureAtlas"/>.
+        /// </summary>
         public int RegionCount => _regions.Count;
 
+        /// <summary>
+        ///     Creates a new texture region and adds it to the list of the <see cref="TextureAtlas"/>' regions.
+        /// </summary>
+        /// <param name="name">Name of the texture region.</param>
+        /// <param name="x">X coordinate of the region's top left corner.</param>
+        /// <param name="y">Y coordinate of the region's top left corner.</param>
+        /// <param name="width">Width of the texture region.</param>
+        /// <param name="height">Height of the texture region.</param>
+        /// <returns>Created texture region.</returns>
         public TextureRegion2D CreateRegion(string name, int x, int y, int width, int height)
         {
             if (_regionMap.ContainsKey(name))
@@ -35,11 +85,19 @@ namespace MonoGame.Extended.TextureAtlases
             return region;
         }
 
+        /// <summary>
+        ///     Removes a texture region from the <see cref="TextureAtlas"/>
+        /// </summary>
+        /// <param name="index">An index of the <see cref="TextureRegion2D"/> in <see cref="Region"/> to remove</param>
         public void RemoveRegion(int index)
         {
             _regions.RemoveAt(index);
         }
 
+        /// <summary>
+        ///     Removes a texture region from the <see cref="TextureAtlas"/>
+        /// </summary>
+        /// <param name="name">Name of the <see cref="TextureRegion2D"/> to remove</param>
         public void RemoveRegion(string name)
         {
             int index;
@@ -51,6 +109,11 @@ namespace MonoGame.Extended.TextureAtlases
             }
         }
 
+        /// <summary>
+        ///     Gets a <see cref="TextureRegion2D"/> from the <see cref="TextureAtlas"/>' list.
+        /// </summary>
+        /// <param name="index">An index of the <see cref="TextureRegion2D"/> in <see cref="Region"/> to get.</param>
+        /// <returns>The <see cref="TextureRegion2D"/>.</returns>
         public TextureRegion2D GetRegion(int index)
         {
             if (index < 0 || index >= _regions.Count)
@@ -59,6 +122,11 @@ namespace MonoGame.Extended.TextureAtlases
             return _regions[index];
         }
 
+        /// <summary>
+        ///     Gets a <see cref="TextureRegion2D"/> from the <see cref="TextureAtlas"/>' list.
+        /// </summary>
+        /// <param name="name">Name of the <see cref="TextureRegion2D"/> to get.</param>
+        /// <returns>The <see cref="TextureRegion2D"/>.</returns>
         public TextureRegion2D GetRegion(string name)
         {
             int index;
@@ -73,16 +141,34 @@ namespace MonoGame.Extended.TextureAtlases
 
         public TextureRegion2D this[int index] => GetRegion(index);
 
+        /// <summary>
+        ///     Gets the enumerator of the <see cref="TextureAtlas"/>' list of regions.
+        /// </summary>
+        /// <returns>The <see cref="IEnumerator"/> of regions.</returns>
         public IEnumerator<TextureRegion2D> GetEnumerator()
         {
             return _regions.GetEnumerator();
         }
 
+        /// <summary>
+        ///     Gets the enumerator of the <see cref="TextureAtlas"/>' list of regions.
+        /// </summary>
+        /// <returns>The <see cref="IEnumerator"/> of regions</returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
 
+        /// <summary>
+        ///     Creates a new <see cref="TextureAtlas"/> and populates it with a grid of <see cref="TextureRegion2D"/>.
+        /// </summary>
+        /// <param name="texture">Source <see cref="Texture2D"/> image used to draw on screen</param>
+        /// <param name="regionWidth">Width of the <see cref="TextureRegion2D"/>.</param>
+        /// <param name="regionHeight">Height of the <see cref="TextureRegion2D"/>.</param>
+        /// <param name="maxRegionCount">The number of <see cref="TextureRegion2D"/> to create.</param>
+        /// <param name="margin">Minimum distance of the regions from the border of the source <see cref="Texture2D"/> image.</param>
+        /// <param name="spacing">Horizontal and vertical space between regions.</param>
+        /// <returns>A created and populated <see cref="TextureAtlas"/>.</returns>
         public static TextureAtlas Create(Texture2D texture, int regionWidth, int regionHeight, int maxRegionCount = int.MaxValue, int margin = 0, int spacing = 0)
         {
             var textureAtlas = new TextureAtlas(texture);


### PR DESCRIPTION
What the constructor does is take the `Dictionary<string, Rectangle>` of regions together with `Texture2D` and populates the `TextureAtlas.Regions` with them. Constructor is useful if the atlas regions are defined in the separate XML file which Content Pipeline deserializes into dictionary.

Also, I hope the documentation is... decent, at least, as I've done it by hand. If it's good enough, I might continue on with other classes.