### PR TITLE
New overloads for BitmapFont DrawString

### DIFF
--- a/Source/Demos/Demo.BitmapFonts/Game1.cs
+++ b/Source/Demos/Demo.BitmapFonts/Game1.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System.Text;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoGame.Extended;
@@ -18,6 +19,16 @@ namespace Demo.BitmapFonts
         private string _labelText = "";
         private SpriteBatch _spriteBatch;
         private ViewportAdapter _viewportAdapter;
+        private StringBuilder _stringBuilderText;
+        private SpriteEffects _effect;
+        private KeyboardState _lastKeyboardState;
+        private KeyboardState _currentKeyboardState;
+        private float _rotation;
+        private float _layer;
+        private Vector2 _scale;
+        private bool _wrappedText;
+        private readonly Vector2 _bodyTextPosition = new Vector2(50, 60);
+        private Color _bodyTextColor = new Color(Color.Black, 0.5f);
 
         public Game1()
         {
@@ -34,7 +45,20 @@ namespace Demo.BitmapFonts
             _camera = new Camera2D(_viewportAdapter);
             _backgroundTexture = Content.Load<Texture2D>("vignette");
             _bitmapFont = Content.Load<BitmapFont>("montserrat-32");
-
+            _stringBuilderText = new StringBuilder();
+            _stringBuilderText.AppendLine("This text is built using lines manually wrapped and");
+            _stringBuilderText.AppendLine("appended to a StringBuilder object.");
+            _stringBuilderText.AppendLine("Lorem Ipsum comes from sections 1.10.32 and 1.10.33");
+            _stringBuilderText.AppendLine("of \"de Finibus Bonorum et Malorum\" (The Extremes");
+            _stringBuilderText.AppendLine("of Good and Evil) by Cicero, written in 45 BC. This");
+            _stringBuilderText.AppendLine("book is a treatise on the theory of ethics, very");
+            _stringBuilderText.AppendLine("popular during the Renaissance. The first line of");
+            _stringBuilderText.AppendLine("Lorem Ipsum, \"Lorem ipsum dolor sit amet..\",");
+            _stringBuilderText.AppendLine("comes from a line in section 1.10.32.");
+            _effect = SpriteEffects.None;
+            _layer = 0f;
+            _scale = Vector2.One;
+            _wrappedText = true;
             _spriteBatch = new SpriteBatch(GraphicsDevice);
         }
 
@@ -44,7 +68,8 @@ namespace Demo.BitmapFonts
 
         protected override void Update(GameTime gameTime)
         {
-            var keyboardState = Keyboard.GetState();
+            _lastKeyboardState = _currentKeyboardState;
+            _currentKeyboardState = Keyboard.GetState();
             var mouseState = Mouse.GetState();
 
             //if (keyboardState.IsKeyDown(Keys.Escape))
@@ -52,9 +77,66 @@ namespace Demo.BitmapFonts
             //    Exit();
             //}
 
-            _labelText = $"{mouseState.X}, {mouseState.Y}";
+            // layers
+            if (_currentKeyboardState.IsKeyDown(Keys.Down) && _lastKeyboardState.IsKeyUp(Keys.Down))
+            {
+                _layer -= 0.1f;
+                if (_layer < 0f)
+                {
+                    _layer = 0f;
+                }
+            }
+            if (_currentKeyboardState.IsKeyDown(Keys.Up) && _lastKeyboardState.IsKeyUp(Keys.Up))
+            {
+                _layer += 0.1f;
+                if (_layer > 1f)
+                {
+                    _layer = 1f;
+                }
+            }
+
+            // scale
+            if (_currentKeyboardState.IsKeyDown(Keys.Add) && _lastKeyboardState.IsKeyUp(Keys.Add))
+            {
+                _scale += new Vector2(0.1f, 0.1f);
+            }
+            if (_currentKeyboardState.IsKeyDown(Keys.Subtract) && _lastKeyboardState.IsKeyUp(Keys.Subtract))
+            {
+                _scale -= new Vector2(0.1f, 0.1f);
+            }
+
+            // rotate
+            if (_currentKeyboardState.IsKeyDown(Keys.R) && _lastKeyboardState.IsKeyUp(Keys.R))
+            {
+                _rotation += 10f;
+                if (_rotation >= 360f) _rotation = 0f;
+            }
+
+            if (_currentKeyboardState.IsKeyDown(Keys.W) && _lastKeyboardState.IsKeyUp(Keys.W))
+            {
+                _wrappedText = !_wrappedText;
+            }
+
+            // flip
+            if (_currentKeyboardState.IsKeyDown(Keys.F) && _lastKeyboardState.IsKeyUp(Keys.F))
+            {
+                switch (_effect)
+                {
+                    case SpriteEffects.None:
+                        _effect = SpriteEffects.FlipHorizontally;
+                        break;
+                    case SpriteEffects.FlipHorizontally:
+                        _effect = SpriteEffects.FlipVertically;
+                        break;
+                    case SpriteEffects.FlipVertically:
+                        _effect = SpriteEffects.None;
+                        break;
+                }
+            }
+
+            _labelText = $"Layer={_layer:F} Angle={_rotation} Scale={_scale.X} Effect={_effect}";
             var stringRectangle = _bitmapFont.GetStringRectangle(_labelText, Vector2.Zero);
-            _labelPosition = new Vector2(400 - stringRectangle.Width / 2, 440);
+            _labelPosition = new Vector2(800/2 - stringRectangle.Width/2, 440);
 
             base.Update(gameTime);
         }
@@ -64,19 +146,62 @@ namespace Demo.BitmapFonts
             GraphicsDevice.Clear(Color.Black);
 
             _spriteBatch.Begin(transformMatrix: _camera.GetViewMatrix());
-            _spriteBatch.Draw(_backgroundTexture, _viewportAdapter.BoundingRectangle, Color.White);
-            _bitmapFont.LetterSpacing = 3;
-            _spriteBatch.DrawString(_bitmapFont, "MonoGame.Extended BitmapFont Sample", new Vector2(50, 10), Color.White);
-            _bitmapFont.LetterSpacing = 0;
-            _spriteBatch.DrawString(_bitmapFont, "Contrary to popular belief, Lorem Ipsum is not simply random text.\n\n" + 
-                "It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard " + 
-                "McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin " + 
-                "words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, " + 
-                "discovered the undoubtable source.", new Vector2(50, 60), new Color(Color.Black, 0.5f), 750);
-            _spriteBatch.DrawString(_bitmapFont, _labelText, _labelPosition, Color.Black);
+            DrawBackground();
+            DrawTitle();
+            DrawBodyText();
+            DrawLabel();
+            DrawInstructions();
             _spriteBatch.End();
 
             base.Draw(gameTime);
+        }
+
+        private void DrawBackground()
+        {
+            _spriteBatch.Draw(_backgroundTexture, _viewportAdapter.BoundingRectangle, Color.White);
+        }
+
+        private void DrawTitle()
+        {
+            _bitmapFont.LetterSpacing = 3;
+            _spriteBatch.DrawString(_bitmapFont, "MonoGame.Extended BitmapFont Sample", new Vector2(50, 10), Color.White,
+                MathHelper.ToRadians(_rotation), Vector2.Zero, _scale, _effect, _layer);
+        }
+
+        private void DrawBodyText()
+        {
+            _bitmapFont.LetterSpacing = 0;
+            if (_wrappedText)
+            {
+                // pass it one long line of text and wrap it at the specified width
+                _spriteBatch.DrawString(_bitmapFont,
+                    "This text is continuous and wrapped at 750 pixels. " +
+                    "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of " +
+                    "classical Latin literature from 45 BC, making it over 2000 years old. Richard " +
+                    "McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more " +
+                    "obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of " +
+                    "the word in classical literature, discovered the undoubtable source.",
+                    _bodyTextPosition, _bodyTextColor, 750);
+            }
+            else
+            {
+                // pass it a StringBuilder object to draw
+                _spriteBatch.DrawString(_bitmapFont, _stringBuilderText, _bodyTextPosition, _bodyTextColor);
+            }
+        }
+
+        private void DrawInstructions()
+        {
+            const string instructions = "W = Wrap, R = Rotate, +/- = Scale, F = Flip, Up/Down = Layer";
+            var textSize = _bitmapFont.GetSize(instructions);
+            var screenWidth = _viewportAdapter.VirtualWidth;
+            var x = screenWidth/2 - textSize.Width/2;
+            _spriteBatch.DrawString(_bitmapFont, instructions, new Vector2(x, 410), Color.Black);
+        }
+
+        private void DrawLabel()
+        {
+            _spriteBatch.DrawString(_bitmapFont, _labelText, _labelPosition, Color.Black);
         }
     }
 }

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
@@ -1,59 +1,307 @@
 using System;
+using System.Linq;
+using System.Text;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.TextureAtlases;
-using System.Linq;
 
 namespace MonoGame.Extended.BitmapFonts
 {
     public static class BitmapFontExtensions
     {
-        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont bitmapFont, string text, Vector2 position, Color color, int wrapWidth = int.MaxValue, float layerDepth = 0f)
+        /// <summary>
+        ///     Adds a string to a batch of sprites for rendering using the specified font, text, position, color, layer,
+        ///     and width (in pixels) where to wrap the text at.
+        /// </summary>
+        /// <remarks>
+        ///     <see cref="BitmapFont" /> objects are loaded from the Content Manager. See the <see cref="BitmapFont" /> class for
+        ///     more information.
+        ///     Before any calls to <see cref="DrawString" /> you must call <see cref="SpriteBatch.Begin" />. Once all calls to
+        ///     <see cref="DrawString" /> are complete, call <see cref="SpriteBatch.End" />.
+        ///     Use a newline character (\n) to draw more than one line of text.
+        /// </remarks>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="layerDepth">
+        ///     The depth of a layer. By default, 0 represents the front layer and 1 represents a back layer.
+        ///     Use SpriteSortMode if you want sprites to be sorted during drawing.
+        /// </param>
+        /// <param name="wrapWidth">The width (in pixels) where to wrap the text at.</param>
+        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont font, string text, Vector2 position,
+            Color color, float layerDepth, int wrapWidth = int.MaxValue)
         {
             if (wrapWidth == int.MaxValue)
+                DrawInternal(spriteBatch, font, text, position, color, layerDepth);
+            else
+                DrawWrapped(spriteBatch, font, text, position, color, wrapWidth, layerDepth);
+        }
+
+        /// <summary>
+        ///     Adds a string to a batch of sprites for rendering using the specified font, text, position, color,
+        ///     and width (in pixels) where to wrap the text at. The text is drawn on layer 0f.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="wrapWidth">The width (in pixels) where to wrap the text at.</param>
+        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont font, string text, Vector2 position,
+            Color color, int wrapWidth = int.MaxValue)
+        {
+            if (wrapWidth == int.MaxValue)
+                DrawInternal(spriteBatch, font, text, position, color, 0f);
+            else
+                DrawWrapped(spriteBatch, font, text, position, color, wrapWidth, 0f);
+        }
+
+        /// <summary>
+        ///     Adds a string to a batch of sprites for rendering using the specified font, text, position, color, rotation,
+        ///     origin, scale, effects and layer.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="rotation">Specifies the angle (in radians) to rotate the text about its origin.</param>
+        /// <param name="origin">The origin for each letter; the default is (0,0) which represents the upper-left corner.</param>
+        /// <param name="scalef">Scale factor.</param>
+        /// <param name="effects">Effects to apply.</param>
+        /// <param name="layerDepth">
+        ///     The depth of a layer. By default, 0 represents the front layer and 1 represents a back layer.
+        ///     Use SpriteSortMode if you want sprites to be sorted during drawing.
+        /// </param>
+        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont font, string text, Vector2 position,
+            Color color, float rotation, Vector2 origin, float scalef, SpriteEffects effects, float layerDepth)
+        {
+            var scale = new Vector2(scalef, scalef);
+            DrawInternal(spriteBatch, font, text, position, color, rotation, origin, scale, effects, layerDepth);
+        }
+
+        /// <summary>
+        ///     Adds a string to a batch of sprites for rendering using the specified font, text, position, color, rotation,
+        ///     origin, scale, effects and layer.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="rotation">Specifies the angle (in radians) to rotate the text about its origin.</param>
+        /// <param name="origin">The origin for each letter; the default is (0,0) which represents the upper-left corner.</param>
+        /// <param name="scale">Scale factor.</param>
+        /// <param name="effects">Effects to apply.</param>
+        /// <param name="layerDepth">
+        ///     The depth of a layer. By default, 0 represents the front layer and 1 represents a back layer.
+        ///     Use SpriteSortMode if you want sprites to be sorted during drawing.
+        /// </param>
+        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont font, string text, Vector2 position,
+            Color color, float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
+        {
+            DrawInternal(spriteBatch, font, text, position, color, rotation, origin, scale, effects, layerDepth);
+        }
+
+        /// <summary>
+        ///     Adds a string to a batch of sprites for rendering using the specified font, text, position, color, rotation,
+        ///     origin, scale, effects and layer.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="rotation">Specifies the angle (in radians) to rotate the text about its origin.</param>
+        /// <param name="origin">The origin for each letter; the default is (0,0) which represents the upper-left corner.</param>
+        /// <param name="scalef">Scale factor.</param>
+        /// <param name="effects">Effects to apply.</param>
+        /// <param name="layerDepth">
+        ///     The depth of a layer. By default, 0 represents the front layer and 1 represents a back layer.
+        ///     Use SpriteSortMode if you want sprites to be sorted during drawing.
+        /// </param>
+        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont font, StringBuilder text,
+            Vector2 position,
+            Color color, float rotation, Vector2 origin, float scalef, SpriteEffects effects, float layerDepth)
+        {
+            var scale = new Vector2(scalef, scalef);
+            DrawInternal(spriteBatch, font, text.ToString(), position, color, rotation, origin, scale, effects, layerDepth);
+        }
+
+        /// <summary>
+        ///     Adds a string to a batch of sprites for rendering using the specified font, text, position, color, rotation,
+        ///     origin, scale, effects and layer.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="rotation">Specifies the angle (in radians) to rotate the text about its origin.</param>
+        /// <param name="origin">The origin for each letter; the default is (0,0) which represents the upper-left corner.</param>
+        /// <param name="scale">Scale factor.</param>
+        /// <param name="effects">Effects to apply.</param>
+        /// <param name="layerDepth">
+        ///     The depth of a layer. By default, 0 represents the front layer and 1 represents a back layer.
+        ///     Use SpriteSortMode if you want sprites to be sorted during drawing.
+        /// </param>
+        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont font, StringBuilder text,
+            Vector2 position,
+            Color color, float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
+        {
+            DrawInternal(spriteBatch, font, text.ToString(), position, color, rotation, origin, scale, effects, layerDepth);
+        }
+
+        /// <summary>
+        ///     Adds a string to a batch of sprites for rendering using the specified font, text, position, and color.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        public static void DrawString(this SpriteBatch spriteBatch, BitmapFont font, StringBuilder text,
+            Vector2 position, Color color)
+        {
+            DrawInternal(spriteBatch, font, text.ToString(), position, color, 0f);
+        }
+
+        /// <summary>
+        ///     Method to handle wrapping text at a specified width. Passes onto the <see cref="DrawInto" /> method
+        ///     if the user passes in int.MaxValue as the width.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="wrapWidth">The width (in pixels) where to wrap the text at.</param>
+        /// <param name="layerDepth">
+        ///     The depth of a layer. By default, 0 represents the front layer and 1 represents a back layer.
+        ///     Use SpriteSortMode if you want sprites to be sorted during drawing.
+        /// </param>
+        private static void DrawWrapped(this SpriteBatch spriteBatch, BitmapFont font, string text, Vector2 position,
+            Color color, int wrapWidth, float layerDepth)
+        {
+            HandleNullParameters(font, text);
+
+            if (wrapWidth == int.MaxValue)
             {
-                DrawString(spriteBatch, bitmapFont, text, position, color, layerDepth);
+                DrawInternal(spriteBatch, font, text, position, color, layerDepth);
                 return;
             }
 
+            // parse the text and wrap it at the specified width
             var dx = position.X;
             var dy = position.Y;
             var sentences = text.Split(new[] {'\n'}, StringSplitOptions.None);
 
             foreach (var sentence in sentences)
             {
-                var words = sentence.Split(new[] { ' ' }, StringSplitOptions.None);
+                var words = sentence.Split(new[] {' '}, StringSplitOptions.None);
 
                 for (var i = 0; i < words.Length; i++)
                 {
                     var word = words[i];
-                    var size = bitmapFont.GetStringRectangle(word, Vector2.Zero);
+                    var size = font.GetStringRectangle(word, Vector2.Zero);
 
-                    if (i != 0 && dx + size.Width >= wrapWidth)
+                    if ((i != 0) && (dx + size.Width >= wrapWidth))
                     {
-                        dy += bitmapFont.LineHeight;
+                        dy += font.LineHeight;
                         dx = position.X;
                     }
 
-                    DrawString(spriteBatch, bitmapFont, word, new Vector2(dx, dy), color, layerDepth);
+                    DrawInternal(spriteBatch, font, word, new Vector2(dx, dy), color, layerDepth);
                     dx += size.Width;
 
-                    var spaceCharRegion = bitmapFont.GetCharacterRegion(' ');
+                    var spaceCharRegion = font.GetCharacterRegion(' ');
                     if (i != words.Length - 1)
-                        dx += spaceCharRegion.XAdvance + bitmapFont.LetterSpacing;
+                        dx += spaceCharRegion.XAdvance + font.LetterSpacing;
                     else
                         dx += spaceCharRegion.XOffset + spaceCharRegion.Width;
                 }
 
                 dx = position.X;
-                dy += bitmapFont.LineHeight;
+                dy += font.LineHeight;
             }
         }
 
-        // this overload is no longer public because the method signature conflicts with the other one,
-        // instead the other one calls this one.
-        internal static void DrawString(this SpriteBatch spriteBatch, BitmapFont bitmapFont, string text, Vector2 position, Color color, float layerDepth)
+        /// <summary>
+        ///     Draw text using most of the values with defaults.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="layerDepth">
+        ///     The depth of a layer. By default, 0 represents the front layer and 1 represents a back layer.
+        ///     Use SpriteSortMode if you want sprites to be sorted during drawing.
+        /// </param>
+        private static void DrawInternal(this SpriteBatch spriteBatch, BitmapFont font, string text, Vector2 position,
+            Color color, float layerDepth)
         {
+            const float rotation = 0f;
+            const SpriteEffects effects = SpriteEffects.None;
+            var scale = Vector2.One;
+            var origin = Vector2.Zero;
+            DrawInternal(spriteBatch, font, text, position, color, rotation, origin, scale, effects, layerDepth);
+        }
+
+        /// <summary>
+        ///     Internal method that actually does the heavy lifting of drawing the text
+        ///     using all of the provided parameters.
+        /// </summary>
+        /// <param name="spriteBatch"></param>
+        /// <param name="font">A font for displaying text.</param>
+        /// <param name="text">The text message to display.</param>
+        /// <param name="position">The location (in screen coordinates) to draw the text.</param>
+        /// <param name="color">
+        ///     The <see cref="Color" /> to tint a sprite. Use <see cref="Color.White" /> for full color with no
+        ///     tinting.
+        /// </param>
+        /// <param name="rotation">Specifies the angle (in radians) to rotate the text about its origin.</param>
+        /// <param name="origin">The origin for each letter; the default is (0,0) which represents the upper-left corner.</param>
+        /// <param name="scale">Scale factor.</param>
+        /// <param name="effects">Effects to apply.</param>
+        /// <param name="layerDepth">
+        ///     The depth of a layer. By default, 0 represents the front layer and 1 represents a back layer.
+        ///     Use SpriteSortMode if you want sprites to be sorted during drawing.
+        /// </param>
+        private static void DrawInternal(this SpriteBatch spriteBatch, BitmapFont font, string text, Vector2 position,
+            Color color, float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
+        {
+            HandleNullParameters(font, text);
+
             var dx = position.X;
             var dy = position.Y;
             var codePoints = BitmapFont.GetUnicodeCodePoints(text).ToArray();
@@ -61,26 +309,40 @@ namespace MonoGame.Extended.BitmapFonts
             for (int i = 0, l = codePoints.Length; i < l; i++)
             {
                 var character = codePoints[i];
-                var fontRegion = bitmapFont.GetCharacterRegion(character);
+                var fontRegion = font.GetCharacterRegion(character);
 
                 if (fontRegion != null)
                 {
                     var charPosition = new Vector2(dx + fontRegion.XOffset, dy + fontRegion.YOffset);
 
-                    spriteBatch.Draw(fontRegion.TextureRegion, charPosition, color, 0, Vector2.Zero, Vector2.One, SpriteEffects.None, layerDepth);
+                    spriteBatch.Draw(fontRegion.TextureRegion, charPosition, color, rotation, origin, scale, effects,
+                        layerDepth);
 
                     if (i != text.Length - 1)
-                        dx += fontRegion.XAdvance + bitmapFont.LetterSpacing;
+                        dx += fontRegion.XAdvance + font.LetterSpacing;
                     else
                         dx += fontRegion.XOffset + fontRegion.Width;
                 }
 
-                if (character == '\n')
-                {
-                    dy += bitmapFont.LineHeight;
-                    dx = position.X;
-                }
+                if (character != '\n') continue;
+
+                dy += font.LineHeight;
+                dx = position.X;
             }
+        }
+
+        /// <summary>
+        ///     Handles dealing with null properties that are essential to rendering the <see cref="BitmapFont" />.
+        /// </summary>
+        /// <param name="bitmapFont">All draw functions must have a <see cref="BitmapFont" /> to use.</param>
+        /// <param name="text">All draw functions must have text to use.</param>
+        private static void HandleNullParameters(BitmapFont bitmapFont, string text)
+        {
+            if (bitmapFont == null)
+                throw new ArgumentNullException(nameof(bitmapFont), "No BitmapFont specified.");
+
+            if (text == null)
+                throw new ArgumentNullException(nameof(text), "No text string specified.");
         }
     }
 }


### PR DESCRIPTION
Added additional overloads to the BitmapFont DrawString methods to support the same functions the SpriteBatch.DrawString have. BitmapFont DrawString now supports scaling, orgins, SpriteEffects. Also updated the demo to showcase all of these.