### PR TITLE
Some Basic Primitives.

### DIFF
--- a/Source/MonoGame.Extended.Tests/MonoGame.Extended.Tests.csproj
+++ b/Source/MonoGame.Extended.Tests/MonoGame.Extended.Tests.csproj
@@ -69,6 +69,11 @@
     <Compile Include="Particles\ParticleBufferTests.cs" />
     <Compile Include="Particles\Profiles\PointProfileTests.cs" />
     <Compile Include="Particles\Profiles\RingProfileTests.cs" />
+    <Compile Include="Primitives\BoundingBox2DTests.cs" />
+    <Compile Include="Primitives\Point2Tests.cs" />
+    <Compile Include="Primitives\Ray2DTests.cs" />
+    <Compile Include="Primitives\Segment2DTests.cs" />
+    <Compile Include="Primitives\Size2Tests.cs" />
     <Compile Include="RangeTests.cs" />
     <Compile Include="Shapes\PolygonFTests.cs" />
     <Compile Include="Shapes\CircleTests.cs" />

--- a/Source/MonoGame.Extended.Tests/Primitives/BoundingBox2DTests.cs
+++ b/Source/MonoGame.Extended.Tests/Primitives/BoundingBox2DTests.cs
@@ -1,0 +1,327 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Primitives;
+using NUnit.Framework;
+
+namespace MonoGame.Extended.Tests.Primitives
+{
+    [TestFixture]
+    public class BoundingBox2DTests
+    {
+        public IEnumerable<TestCaseData> ConstructorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Size2()).SetName(
+                        "The empty bounding box has the expected position and direction.");
+                yield return
+                    new TestCaseData(new Point2(5, 5), new Size2(15, 15)).SetName(
+                        "A non-empty bounding box has the expected position and direction.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ConstructorTestCases))]
+        public void Constructor(Point2 centre, Size2 radius)
+        {
+            var boundingBox = new BoundingBox2D(centre, radius);
+            Assert.AreEqual(centre, boundingBox.Centre);
+            Assert.AreEqual(radius, boundingBox.Radius);
+        }
+
+        public IEnumerable<TestCaseData> CreateFromMinimumMaximumTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Point2(), new BoundingBox2D()).SetName(
+                        "The bounding box created from the zero minimum point and zero maximum point is the empty bounding box.")
+                    ;
+                yield return
+                    new TestCaseData(new Point2(5, 5), new Point2(15, 15),
+                        new BoundingBox2D(new Point2(10, 10), new Size2(5, 5))).SetName(
+                        "The bounding box created from the non-zero minimum point and the non-zero maximum point is the expected bounding box.")
+                    ;
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CreateFromMinimumMaximumTestCases))]
+        public void CreateFromMinimumMaximum(Point2 minimum, Point2 maximum, BoundingBox2D expectedBoundingBox)
+        {
+            var actualBoundingBox = BoundingBox2D.CreateFromMinimumMaximum(minimum, maximum);
+            Assert.AreEqual(expectedBoundingBox, actualBoundingBox);
+        }
+
+        public IEnumerable<TestCaseData> CreateFromPointsTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(null, new BoundingBox2D()).SetName(
+                        "The bounding box created from null points is the empty bounding box.");
+                yield return
+                    new TestCaseData(new Point2[0], new BoundingBox2D()).SetName(
+                        "The bounding box created from the empty set of points is the empty bounding box.");
+                yield return
+                    new TestCaseData(
+                        new[]
+                        {
+                            new Point2(5, 5), new Point2(10, 10), new Point2(15, 15), new Point2(-5, -5),
+                            new Point2(-15, -15)
+                        }, new BoundingBox2D(new Point2(0, 0), new Size2(15, 15))).SetName(
+                        "The bounding box created from a non-empty set of points is the expected bounding box.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CreateFromPointsTestCases))]
+        public void CreateFromPoints(Point2[] points, BoundingBox2D expectedBoundingBox)
+        {
+            var actualBoundingBox = BoundingBox2D.CreateFromPoints(points);
+            Assert.AreEqual(expectedBoundingBox, actualBoundingBox);
+        }
+
+        public IEnumerable<TestCaseData> CreateFromTransformedTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(), Matrix2D.Identity, new BoundingBox2D()).SetName(
+                        "The bounding box created from the empty bounding box transformed by the identity matrix is the empty bounding box.")
+                    ;
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(0, 0), new Size2(20, 20)), Matrix2D.CreateScale(2), new BoundingBox2D(new Point2(0, 0), new Size2(40, 40))).SetName(
+                        "The bounding box created from a non-empty bounding box transformed by a non-identity matrix is the expected bounding box.")
+                    ;
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CreateFromTransformedTestCases))]
+        public void CreateFromTransformed(BoundingBox2D boundingBox, Matrix2D transformMatrix,
+            BoundingBox2D expectedBoundingBox)
+        {
+            var actualBoundingBox = BoundingBox2D.CreateFromTransformedBoundingBox(boundingBox, ref transformMatrix);
+            Assert.AreEqual(expectedBoundingBox, actualBoundingBox);
+        }
+
+        public IEnumerable<TestCaseData> UnionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(), new BoundingBox2D(), new BoundingBox2D()).SetName(
+                        "The union of two empty bounding boxes is the empty bounding box.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(0, 0), new Size2(15, 15)),
+                            new BoundingBox2D(20, 20, 40, 40), new BoundingBox2D(new Point2(20, 20), new Size2(40, 40)))
+                        .SetName(
+                            "The union of two non-empty bounding boxes is the expected bounding box.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(UnionTestCases))]
+        public void Union(BoundingBox2D boundingBox1, BoundingBox2D boundingBox2, BoundingBox2D expectedBoundingBox)
+        {
+            Assert.AreEqual(expectedBoundingBox, boundingBox1.Union(boundingBox2));
+            Assert.AreEqual(expectedBoundingBox, BoundingBox2D.Union(boundingBox1, boundingBox2));
+        }
+
+        public IEnumerable<TestCaseData> IntersectionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(), new BoundingBox2D(), new BoundingBox2D()).SetName(
+                        "The intersection of two empty bounding boxes is the empty bounding box.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(-10, -10), new Size2(15, 15)),
+                        new BoundingBox2D(20, 20, 40, 40),
+                        new BoundingBox2D(new Point2(-7.5f, -7.5f), new Size2(12.5f, 12.5f))).SetName(
+                        "The intersection of two overlapping non-empty bounding boxes is the expected bounding box.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(-30, -30), new Size2(15, 15)),
+                        new BoundingBox2D(20, 20, 10, 10),
+                        null).SetName(
+                        "The intersection of two non-overlapping non-empty bounding boxes is null.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(IntersectionTestCases))]
+        public void Intersection(BoundingBox2D boundingBox1, BoundingBox2D boundingBox2,
+            BoundingBox2D? expectedBoundingBox)
+        {
+            Assert.AreEqual(expectedBoundingBox, boundingBox1.Intersection(boundingBox2));
+            Assert.AreEqual(expectedBoundingBox, BoundingBox2D.Intersection(boundingBox1, boundingBox2));
+        }
+
+        public IEnumerable<TestCaseData> IntersectsTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(), new BoundingBox2D(), true).SetName(
+                        "Two empty bounding boxes intersect.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(-10, -10), new Size2(15, 15)),
+                        new BoundingBox2D(20, 20, 40, 40),
+                        new BoundingBox2D(new Point2(-7.5f, -7.5f), new Size2(12.5f, 12.5f)), true).SetName(
+                        "Two overlapping non-empty bounding boxes intersect.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(-40, -50), new Size2(15, 15)),
+                        new BoundingBox2D(20, 20, 15, 15), false).SetName(
+                        "Two non-overlapping non-empty bounding boxes do not intersect.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(IntersectsTestCases))]
+        public void Intersects(BoundingBox2D boundingBox1, BoundingBox2D boundingBox2, bool expectedToIntersect)
+        {
+            Assert.AreEqual(expectedToIntersect, boundingBox1.Intersects(boundingBox2));
+            Assert.AreEqual(expectedToIntersect, BoundingBox2D.Intersects(boundingBox1, boundingBox2));
+        }
+
+        public IEnumerable<TestCaseData> ContainsPointTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(), new Point2(), true).SetName(
+                        "The empty bounding box contains the zero point.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(0, 0), new Size2(15, 15)), new Point2(-15, -15), true)
+                        .SetName(
+                            "A non-empty bounding box contains a point inside it.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(0, 0), new Size2(15, 15)), new Point2(-16, 15), false)
+                        .SetName(
+                            "A non-empty bounding box does not contain a point outside it.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ContainsPointTestCases))]
+        public void ContainsPoint(BoundingBox2D boundingBox, Point2 point, bool expectedToContainPoint)
+        {
+            Assert.AreEqual(expectedToContainPoint, boundingBox.Contains(point));
+            Assert.AreEqual(expectedToContainPoint, BoundingBox2D.Contains(boundingBox, point));
+        }
+
+        public IEnumerable<TestCaseData> EqualityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(), new BoundingBox2D(), true).SetName(
+                        "Empty bounding boxes are equal.")
+                    ;
+                yield return
+                    new TestCaseData(
+                        new BoundingBox2D(new Point2(0, 0), new Size2(float.MaxValue, float.MinValue)),
+                        new BoundingBox2D(new Point2(0, 0),
+                            new Point2(float.MinValue, float.MaxValue)), false).SetName(
+                        "Two different non-empty segments are not equal.");
+                yield return
+                    new TestCaseData(
+                        new BoundingBox2D(new Point2(0, 0), new Size2(float.MinValue, float.MaxValue)),
+                        new BoundingBox2D(new Point2(0, 0),
+                            new Size2(float.MinValue, float.MaxValue)), true).SetName(
+                        "Two identical non-empty segments are equal.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(EqualityTestCases))]
+        public void Equality(BoundingBox2D boundingBox1, BoundingBox2D boundingBox2, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(Equals(boundingBox1, boundingBox2) == expectedToBeEqual);
+            Assert.IsTrue(boundingBox1 == boundingBox2 == expectedToBeEqual);
+            Assert.IsFalse(boundingBox1 == boundingBox2 != expectedToBeEqual);
+            Assert.IsTrue(boundingBox1.Equals(boundingBox2) == expectedToBeEqual);
+
+            if (expectedToBeEqual)
+                Assert.AreEqual(boundingBox1.GetHashCode(), boundingBox2.GetHashCode());
+        }
+
+        public IEnumerable<TestCaseData> InequalityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(), null, false).SetName(
+                        "A bounding box is not equal to a null object.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(), new object(), false).SetName(
+                        "A bounding box is not equal to an instantiated object.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(InequalityTestCases))]
+        public void Inequality(BoundingBox2D boundingBox, object obj, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(boundingBox.Equals(obj) == expectedToBeEqual);
+        }
+
+        public IEnumerable<TestCaseData> HashCodeTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(), new BoundingBox2D(), true).SetName(
+                        "Two empty bounding boxes have the same hash code.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(0, 0), new Size2(50, 50)),
+                        new BoundingBox2D(new Point2(0, 0), new Size2(50, 50)), true).SetName(
+                        "Two indentical non-empty bounding boxes have the same hash code.");
+                yield return
+                    new TestCaseData(new BoundingBox2D(new Point2(0, 0), new Size2(50, 50)),
+                        new BoundingBox2D(new Point2(50, 50), new Size2(50, 50)), false).SetName(
+                        "Two different non-empty bounding boxes do not have the same hash code.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(HashCodeTestCases))]
+        public void HashCode(BoundingBox2D boundingBox1, BoundingBox2D boundingBox2, bool expectedThatHashCodesAreEqual)
+        {
+            var hashCode1 = boundingBox1.GetHashCode();
+            var hashCode2 = boundingBox2.GetHashCode();
+            if (expectedThatHashCodesAreEqual)
+                Assert.AreEqual(hashCode1, hashCode2);
+            else
+                Assert.AreNotEqual(hashCode1, hashCode2);
+        }
+
+        public IEnumerable<TestCaseData> StringCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new BoundingBox2D(),
+                        string.Format(CultureInfo.CurrentCulture, "Centre: {0}, Radius: {1}", new Point2(),
+                            new Size2())).SetName(
+                        "The empty segment has the expected string representation using the current culture.");
+                yield return new TestCaseData(new BoundingBox2D(new Point2(5.1f, -5.123f), new Size2(5.4f, -5.4123f)),
+                    string.Format(CultureInfo.CurrentCulture, "Centre: {0}, Radius: {1}", new Point2(5.1f, -5.123f),
+                        new Size2(5.4f, -5.4123f))).SetName(
+                    "A non-empty segment has the expected string representation using the current culture.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(StringCases))]
+        public void String(BoundingBox2D boundingBox, string expectedString)
+        {
+            var actualString = boundingBox.ToString();
+            Assert.AreEqual(expectedString, actualString);
+        }
+    }
+}

--- a/Source/MonoGame.Extended.Tests/Primitives/BoundingBox2DTests.cs
+++ b/Source/MonoGame.Extended.Tests/Primitives/BoundingBox2DTests.cs
@@ -170,8 +170,7 @@ namespace MonoGame.Extended.Tests.Primitives
                         "Two empty bounding boxes intersect.");
                 yield return
                     new TestCaseData(new BoundingBox2D(new Point2(-10, -10), new Size2(15, 15)),
-                        new BoundingBox2D(20, 20, 40, 40),
-                        new BoundingBox2D(new Point2(-7.5f, -7.5f), new Size2(12.5f, 12.5f)), true).SetName(
+                        new BoundingBox2D(20, 20, 40, 40), true).SetName(
                         "Two overlapping non-empty bounding boxes intersect.");
                 yield return
                     new TestCaseData(new BoundingBox2D(new Point2(-40, -50), new Size2(15, 15)),

--- a/Source/MonoGame.Extended.Tests/Primitives/Point2Tests.cs
+++ b/Source/MonoGame.Extended.Tests/Primitives/Point2Tests.cs
@@ -1,0 +1,357 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Primitives;
+using NUnit.Framework;
+
+namespace MonoGame.Extended.Tests.Primitives
+{
+    [TestFixture]
+    public class Point2Tests
+    {
+        public IEnumerable<TestCaseData> ConstructorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(0, 0).SetName(
+                        "The zero point has the expected coordinates.");
+                yield return
+                    new TestCaseData(float.MinValue, float.MaxValue).SetName
+                    (
+                        "A non-zero point has the expected coordinates.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ConstructorTestCases))]
+        public void Constructor(float x, float y)
+        {
+            var point = new Point2(x, y);
+            Assert.AreEqual(x, point.X);
+            Assert.AreEqual(y, point.Y);
+        }
+
+        public IEnumerable<TestCaseData> CoordinatesTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), 0, 0).SetName(
+                        "The zero point has the expected coordinates.");
+                yield return
+                    new TestCaseData(new Point2(float.MinValue, float.MaxValue), float.MinValue, float.MaxValue).SetName
+                    (
+                        "A non-zero point has the expected coordinates.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CoordinatesTestCases))]
+        public void Coordinates(Point2 point, float expectedX, float expecetedY)
+        {
+            Assert.AreEqual(expectedX, point.X);
+            Assert.AreEqual(expecetedY, point.Y);
+
+            point.X = 10;
+            Assert.AreEqual(10, point.X);
+
+            point.Y = -10.123f;
+            Assert.AreEqual(-10.123f, point.Y);
+        }
+
+        public IEnumerable<TestCaseData> VectorAdditionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Vector2(), new Point2()).SetName(
+                        "The addition of the zero point and the zero vector is the zero point.");
+                yield return
+                    new TestCaseData(new Point2(5, 5), new Vector2(15, 15), new Point2(20, 20)).SetName(
+                        "The addition of a non-zero point and a non-zero vector is the expected point.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(VectorAdditionTestCases))]
+        public void VectorAddition(Point2 point, Vector2 vector, Point2 expectedPoint)
+        {
+            Assert.AreEqual(expectedPoint, point + vector);
+            Assert.AreEqual(expectedPoint, Point2.Add(point, vector));
+        }
+
+        public IEnumerable<TestCaseData> VectorSubtractionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Vector2(), new Point2()).SetName(
+                        "The vector subtraction of two zero points is the zero vector.");
+                yield return
+                    new TestCaseData(new Point2(5, 5), new Vector2(15, 15), new Point2(-10, -10)).SetName(
+                        "The vector subtraction of two non-zero points is the expected vector.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(VectorSubtractionTestCases))]
+        public void VectorSubtraction(Point2 point, Vector2 vector, Point2 expectedPoint)
+        {
+            Assert.AreEqual(expectedPoint, point - vector);
+            Assert.AreEqual(expectedPoint, Point2.Subtract(point, vector));
+        }
+
+
+        public IEnumerable<TestCaseData> DisplacementTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Point2(), new Vector2()).SetName(
+                        "The displacement between two zero points is the zero vector.");
+                yield return
+                    new TestCaseData(new Point2(5, 5), new Point2(15, 15), new Vector2(10, 10)).SetName(
+                        "The displacement between two non-zero points is the expected vector.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(DisplacementTestCases))]
+        public void Displacement(Point2 point1, Point2 point2, Vector2 expectedVector)
+        {
+            Assert.AreEqual(expectedVector, point2 - point1);
+            Assert.AreEqual(expectedVector, Point2.Displacement(point2, point1));
+        }
+
+        public IEnumerable<TestCaseData> SizeAdditionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Size2(), new Point2()).SetName(
+                        "The size addition of the zero point with the empty size is the zero point.");
+                yield return
+                    new TestCaseData(new Point2(5, 5), new Size2(15, 15), new Point2(20, 20)).SetName(
+                        "The size addition of a non-zero point with a non-empty size is the expected point.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SizeAdditionTestCases))]
+        public void SizeAdditon(Point2 point, Size2 size, Point2 expectedPoint)
+        {
+            Assert.AreEqual(expectedPoint, point + size);
+            Assert.AreEqual(expectedPoint, Point2.Add(point, size));
+        }
+
+        public IEnumerable<TestCaseData> SizeSubtractionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Size2(), new Point2()).SetName(
+                        "The size substraction of the zero point with the empty size is the zero point.");
+                yield return
+                    new TestCaseData(new Point2(5, 5), new Size2(15, 15), new Point2(-10, -10)).SetName(
+                        "The size subscration of a non-zero point with a non-empty size is the expected point.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SizeSubtractionTestCases))]
+        public void SizeSubtraction(Point2 point, Size2 size, Point2 expectedPoint)
+        {
+            Assert.AreEqual(expectedPoint, point - size);
+            Assert.AreEqual(expectedPoint, Point2.Subtract(point, size));
+        }
+
+        public IEnumerable<TestCaseData> MinimumTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Point2(), new Point2()).SetName(
+                        "The minimum coordinates of two zero points is the coordinates of the zero point.");
+                yield return
+                    new TestCaseData(new Point2(float.MaxValue, float.MinValue), new Point2(int.MaxValue, int.MinValue),
+                        new Point2(int.MaxValue, float.MinValue)).SetName(
+                        "The minimum coordaintes of two non-zero points is the expected coordinates.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(MinimumTestCases))]
+        public void Minimum(Point2 point1, Point2 point2, Point2 expectedPoint)
+        {
+            var actualPoint = Point2.Minimum(point1, point2);
+            Assert.AreEqual(expectedPoint, actualPoint);
+        }
+
+        public IEnumerable<TestCaseData> MaximumTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Point2(), new Point2()).SetName(
+                        "The maximum coordinates of two zero points is the coordinates of the zero point.");
+                yield return
+                    new TestCaseData(new Point2(float.MaxValue, float.MinValue), new Point2(int.MaxValue, int.MinValue),
+                        new Point2(float.MaxValue, int.MinValue)).SetName(
+                        "The maximum coordaintes of two non-zero points is the expected coordinates.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(MaximumTestCases))]
+        public void Maximum(Point2 point1, Point2 point2, Point2 expectedPoint)
+        {
+            var actualPoint = Point2.Maximum(point1, point2);
+            Assert.AreEqual(expectedPoint, actualPoint);
+        }
+
+        public IEnumerable<TestCaseData> EqualityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Point2(), true).SetName("Two zero points are equal.");
+                yield return
+                    new TestCaseData(new Point2(float.MinValue, float.MaxValue),
+                        new Point2(float.MaxValue, float.MinValue), false).SetName(
+                        "Two different non-zero points are not equal.");
+                yield return
+                    new TestCaseData(
+                            new Point2(float.MinValue, float.MaxValue), new Point2(float.MinValue, float.MaxValue), true)
+                        .SetName(
+                            "Two identical non-zero points are equal.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(EqualityTestCases))]
+        public void Equality(Point2 point1, Point2 point2, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(Equals(point1, point2) == expectedToBeEqual);
+            Assert.IsTrue(point1 == point2 == expectedToBeEqual);
+            Assert.IsFalse(point1 == point2 != expectedToBeEqual);
+            Assert.IsTrue(point1.Equals(point2) == expectedToBeEqual);
+
+            if (expectedToBeEqual)
+                Assert.AreEqual(point1.GetHashCode(), point2.GetHashCode());
+        }
+
+        public IEnumerable<TestCaseData> InequalityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), null, false).SetName("A point is not equal to a null object.");
+                yield return
+                    new TestCaseData(new Point2(), new object(), false).SetName(
+                        "A point is not equal to an instantiated object.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(InequalityTestCases))]
+        public void Inequality(Point2 point, object obj, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(point.Equals(obj) == expectedToBeEqual);
+        }
+
+        public IEnumerable<TestCaseData> HashCodeTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Point2(), true).SetName(
+                        "Two zero points have the same hash code.");
+                yield return
+                    new TestCaseData(new Point2(50, 50), new Point2(50, 50), true).SetName(
+                        "Two indentical non-zero points have the same hash code.");
+                yield return
+                    new TestCaseData(new Point2(0, 0), new Point2(50, 50), false).SetName(
+                        "Two different non-zero points do not have the same hash code.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(HashCodeTestCases))]
+        public void HashCode(Point2 point1, Point2 point2, bool expectedThatHashCodesAreEqual)
+        {
+            var hashCode1 = point1.GetHashCode();
+            var hashCode2 = point2.GetHashCode();
+            if (expectedThatHashCodesAreEqual)
+                Assert.AreEqual(hashCode1, hashCode2);
+            else
+                Assert.AreNotEqual(hashCode1, hashCode2);
+        }
+
+        public IEnumerable<TestCaseData> ToVectorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Vector2()).SetName(
+                        "The zero point converted to a vector is the zero vector.");
+                yield return
+                    new TestCaseData(new Point2(float.MinValue, float.MaxValue),
+                        new Vector2(float.MinValue, float.MaxValue)).SetName(
+                        "A non-zero point converted to a vector is the expected vector.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ToVectorTestCases))]
+        public void ToVector(Point2 point, Vector2 expectedVector)
+        {
+            var actualVector = (Vector2)point;
+            Assert.AreEqual(expectedVector, actualVector);
+        }
+
+        public IEnumerable<TestCaseData> FromVectorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Vector2(), new Point2()).SetName(
+                        "The zero vector converted to a point is the zero point.");
+                yield return
+                    new TestCaseData(new Vector2(float.MinValue, float.MaxValue),
+                        new Point2(float.MinValue, float.MaxValue)).SetName(
+                        "A non-zero vector converted to a point is the expected point.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(FromVectorTestCases))]
+        public void FromVector(Vector2 vector, Point2 expectedPoint)
+        {
+            var actualPoint = (Point2)vector;
+            Assert.AreEqual(expectedPoint, actualPoint);
+        }
+
+        public IEnumerable<TestCaseData> StringCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(),
+                        string.Format(CultureInfo.CurrentCulture, "({0}, {1})", 0, 0)).SetName(
+                        "The zero point has the expected string representation using the current culture.");
+                yield return new TestCaseData(new Point2(5.1f, -5.123f),
+                    string.Format(CultureInfo.CurrentCulture, "({0}, {1})", 5.1f, -5.123f)).SetName(
+                    "A non-zero point has the expected string representation using the current culture.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(StringCases))]
+        public void String(Point2 point, string expectedString)
+        {
+            var actualString = point.ToString();
+            Assert.AreEqual(expectedString, actualString);
+        }
+    }
+}

--- a/Source/MonoGame.Extended.Tests/Primitives/Ray2DTests.cs
+++ b/Source/MonoGame.Extended.Tests/Primitives/Ray2DTests.cs
@@ -1,0 +1,216 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Primitives;
+using NUnit.Framework;
+
+namespace MonoGame.Extended.Tests.Primitives
+{
+    [TestFixture]
+    public class Ray2DTests
+    {
+        public IEnumerable<TestCaseData> ConstructorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Vector2()).SetName(
+                        "The degenerate ray has the expected position and direction.");
+                yield return
+                    new TestCaseData(new Point2(5, 5), new Vector2(15, 15)).SetName(
+                        "A non-degenerate ray has the expected position and direction.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ConstructorTestCases))]
+        public void Constructor(Point2 position, Vector2 direction)
+        {
+            var ray = new Ray2D(position, direction);
+            Assert.AreEqual(position, ray.Position);
+            Assert.AreEqual(direction, ray.Direction);
+        }
+
+        public IEnumerable<TestCaseData> PositionDirectionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Ray2D(), new Point2(), new Vector2()).SetName(
+                        "The degenerate ray has the expected position and direction.");
+                yield return
+                    new TestCaseData(new Ray2D(new Point2(5, 5), new Vector2(15, 15)), new Point2(5, 5),
+                            new Vector2(15, 15)).SetName
+                        (
+                            "A non-degenerate ray has the expected position and direction.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(PositionDirectionTestCases))]
+        public void PositionDirection(Ray2D ray, Point2 expectedPosition, Vector2 expecetedDirection)
+        {
+            Assert.AreEqual(expectedPosition, ray.Position);
+            Assert.AreEqual(expecetedDirection, ray.Direction);
+
+            ray.Position.X = 10;
+            ray.Position.Y = 10;
+            Assert.AreEqual(new Point2(10, 10), ray.Position);
+
+            ray.Direction.X = -10.123f;
+            ray.Direction.Y = 10.123f;
+            Assert.AreEqual(new Vector2(-10.123f, 10.123f), ray.Direction);
+        }
+
+        public IEnumerable<TestCaseData> IntersectsBoundingBoxTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Ray2D(), new BoundingBox2D(), true, Point2.Zero, Point2.Zero).SetName(
+                        "The degenerate ray intersects the empty bounding box.");
+                yield return
+                    new TestCaseData(new Ray2D(new Point2(-75, -75), new Vector2(75, -75)),
+                        new BoundingBox2D(0, 0, 50, 50), false, Point2.NaN, Point2.NaN).SetName(
+                        "A non-degenerate ray that does not cross a non-empty bounding box does not intersect the bounding box.");
+                yield return
+                    new TestCaseData(new Ray2D(new Point2(0, 0), new Vector2(25, 0)), new BoundingBox2D(0, 0, 50, 50),
+                        true, new Point2(0, 0), new Point2(50, 0)).SetName(
+                        "A non-degenerate ray starting from inside a non-empty bounding box intersects the bounding box.");
+                yield return
+                    new TestCaseData(new Ray2D(new Point2(-100, 0), new Vector2(100, 0)),
+                        new BoundingBox2D(0, 0, 50, 50),
+                        true, new Point2(-50, 0), new Point2(50, 0)).SetName(
+                        "A non-degenerate ray crossing a non-empty bounding box intersects the bounding box.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(IntersectsBoundingBoxTestCases))]
+        public void IntersectsBoundingBox(Ray2D ray, BoundingBox2D axisAlignedBoundingBox, bool expectedResult,
+            Point2 firstExpectedIntersectionPoint, Point2 secondExpectedIntersectionPoint)
+        {
+            float rayNearDistance, rayFarDistance;
+            var actualResult = ray.Intersects(axisAlignedBoundingBox, out rayNearDistance, out rayFarDistance);
+            Assert.AreEqual(expectedResult, actualResult);
+
+            if (actualResult)
+            {
+                var firstActualIntersectionPoint = ray.Position + ray.Direction * rayNearDistance;
+                Assert.AreEqual(firstExpectedIntersectionPoint, firstActualIntersectionPoint);
+                var secondActualIntersectionPoint = ray.Position + ray.Direction * rayFarDistance;
+                Assert.AreEqual(secondExpectedIntersectionPoint, secondActualIntersectionPoint);
+            }
+            else
+            {
+                Assert.IsTrue(float.IsNaN(rayNearDistance));
+                Assert.IsTrue(float.IsNaN(rayFarDistance));
+            }
+        }
+
+        public IEnumerable<TestCaseData> EqualityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Ray2D(), new Ray2D(), true).SetName("Two degenerate rays are equal.");
+                yield return
+                    new TestCaseData(new Ray2D(new Point2(float.MinValue, float.MaxValue),
+                        new Vector2(float.MaxValue, float.MinValue)), false).SetName(
+                        "Two different non-degenerate rays are not equal.");
+                yield return
+                    new TestCaseData(
+                            new Ray2D(new Point2(float.MinValue, float.MaxValue),
+                                new Vector2(float.MinValue, float.MaxValue)), true)
+                        .SetName(
+                            "Two identical non-degenerate rays are equal.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(EqualityTestCases))]
+        public void Equality(Ray2D ray1, Ray2D ray2, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(Equals(ray1, ray2) == expectedToBeEqual);
+            Assert.IsTrue(ray1 == ray2 == expectedToBeEqual);
+            Assert.IsFalse(ray1 == ray2 != expectedToBeEqual);
+            Assert.IsTrue(ray1.Equals(ray2) == expectedToBeEqual);
+
+            if (expectedToBeEqual)
+                Assert.AreEqual(ray1.GetHashCode(), ray2.GetHashCode());
+        }
+
+        public IEnumerable<TestCaseData> InequalityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Ray2D(), null, false).SetName("A ray is not equal to a null object.");
+                yield return
+                    new TestCaseData(new Ray2D(), new object(), false).SetName(
+                        "A ray is not equal to an instantiated object.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(InequalityTestCases))]
+        public void Inequality(Ray2D ray, object obj, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(ray.Equals(obj) == expectedToBeEqual);
+        }
+
+        public IEnumerable<TestCaseData> HashCodeTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Ray2D(), new Ray2D(), true).SetName(
+                        "Two degenerate rays have the same hash code.");
+                yield return
+                    new TestCaseData(new Ray2D(new Point2(50, 50), new Vector2(50, 50)),
+                        new Ray2D(new Point2(50, 50), new Vector2(50, 50)), true).SetName(
+                        "Two indentical non-zero points have the same hash code.");
+                yield return
+                    new TestCaseData(new Ray2D(new Point2(0, 0), new Vector2(50, 50)),
+                        new Ray2D(new Point2(50, 50), new Vector2(50, 50)), false).SetName(
+                        "Two different non-zero points do not have the same hash code.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(HashCodeTestCases))]
+        public void HashCode(Ray2D ray1, Ray2D ray2, bool expectedThatHashCodesAreEqual)
+        {
+            var hashCode1 = ray1.GetHashCode();
+            var hashCode2 = ray2.GetHashCode();
+            if (expectedThatHashCodesAreEqual)
+                Assert.AreEqual(hashCode1, hashCode2);
+            else
+                Assert.AreNotEqual(hashCode1, hashCode2);
+        }
+
+        public IEnumerable<TestCaseData> StringCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Ray2D(),
+                        string.Format(CultureInfo.CurrentCulture, "Position: {0}, Direction: {1}", new Point2(),
+                            new Vector2())).SetName(
+                        "The degenerate ray has the expected string representation using the current culture.");
+                yield return new TestCaseData(new Ray2D(new Point2(5.1f, -5.123f), new Vector2(0, 1)),
+                    string.Format(CultureInfo.CurrentCulture, "Position: {0}, Direction: {1}", new Point2(5.1f, -5.123f),
+                        new Vector2(0, 1))).SetName(
+                    "A non-degenerate ray has the expected string representation using the current culture.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(StringCases))]
+        public void String(Ray2D ray, string expectedString)
+        {
+            var actualString = ray.ToString();
+            Assert.AreEqual(expectedString, actualString);
+        }
+    }
+}

--- a/Source/MonoGame.Extended.Tests/Primitives/Ray2DTests.cs
+++ b/Source/MonoGame.Extended.Tests/Primitives/Ray2DTests.cs
@@ -116,11 +116,13 @@ namespace MonoGame.Extended.Tests.Primitives
                     new TestCaseData(new Ray2D(), new Ray2D(), true).SetName("Two degenerate rays are equal.");
                 yield return
                     new TestCaseData(new Ray2D(new Point2(float.MinValue, float.MaxValue),
+                        new Vector2(float.MaxValue, float.MinValue)), new Ray2D(new Point2(float.MaxValue, float.MinValue),
                         new Vector2(float.MaxValue, float.MinValue)), false).SetName(
                         "Two different non-degenerate rays are not equal.");
                 yield return
                     new TestCaseData(
                             new Ray2D(new Point2(float.MinValue, float.MaxValue),
+                                new Vector2(float.MinValue, float.MaxValue)), new Ray2D(new Point2(float.MinValue, float.MaxValue),
                                 new Vector2(float.MinValue, float.MaxValue)), true)
                         .SetName(
                             "Two identical non-degenerate rays are equal.");

--- a/Source/MonoGame.Extended.Tests/Primitives/Segment2DTests.cs
+++ b/Source/MonoGame.Extended.Tests/Primitives/Segment2DTests.cs
@@ -1,0 +1,252 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using MonoGame.Extended.Primitives;
+using NUnit.Framework;
+
+namespace MonoGame.Extended.Tests.Primitives
+{
+    public class Segment2DTests
+    {
+        public IEnumerable<TestCaseData> ConstructorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Point2()).SetName(
+                        "The empty segment has expected starting and ending points.");
+                yield return
+                    new TestCaseData(
+                        new Point2(float.MaxValue, float.MinValue),
+                        new Point2(int.MaxValue, int.MinValue)).SetName(
+                        "A non-empty segment has the expected starting and ending points.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ConstructorTestCases))]
+        public void Constructor(Point2 startingPoint, Point2 endingPoint)
+        {
+            var segment = new Segment2D(startingPoint, endingPoint);
+            Assert.AreEqual(startingPoint, segment.Start);
+            Assert.AreEqual(endingPoint, segment.End);
+        }
+
+        public IEnumerable<TestCaseData> ClosestPointTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Segment2D(), new Point2(), new Point2()).SetName(
+                        "The closest point on the empty segment to the zero point is the zero point.");
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(200, 0)), new Point2(-100, 200),
+                        new Point2(0, 0)).SetName(
+                        "The closest point on a non-empty segment to a point which is projected beyond the start of the segment is the segment's starting point.")
+                    ;
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(200, 0)), new Point2(400, 200),
+                        new Point2(200, 0)).SetName(
+                        "The closest point on a non-empty segment to a point which is projected beyond the end of the segment is the segment's ending point.")
+                    ;
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(200, 0)), new Point2(100, 200),
+                        new Point2(100, 0)).SetName(
+                        "The closest point on a non-empty segment to a point which is projected inside the segment is the projected point.")
+                    ;
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ClosestPointTestCases))]
+        public void ClosestPoint(Segment2D segment, Point2 point, Point2 expectedClosestPoint)
+        {
+            var actualClosestPoint = segment.ClosestPointTo(point);
+            Assert.AreEqual(expectedClosestPoint, actualClosestPoint);
+        }
+
+        public IEnumerable<TestCaseData> SquaredDistanceToPointTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Segment2D(), new Point2(), 0).SetName(
+                        "The squared distance of the zero point to the empty segment is 0.");
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(20, 0)), new Point2(-10, 20), 500)
+                        .SetName(
+                            "The squared distance of a point projected beyond the start of a non-empty segment is the squared distance from the segment's starting point to the point.")
+                    ;
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(20, 0)), new Point2(40, 20), 400)
+                        .SetName(
+                            "The squared distance of a point projected beyond the end of a non-empty segment is the squared distance from the segment's ending point to the point.")
+                    ;
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(20, 0)), new Point2(10, 25), 625).SetName
+                    (
+                        "The squared distance of a point projected inside a non-empty segment is the squared distance from the projected point to the point.")
+                    ;
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SquaredDistanceToPointTestCases))]
+        public void SquaredDistanceToPoint(Segment2D segment, Point2 point,
+            float expectedDistance)
+        {
+            var actualDistance = segment.SquaredDistanceTo(point);
+            Assert.AreEqual(expectedDistance, actualDistance);
+        }
+
+        public IEnumerable<TestCaseData> IntersectsBoundingBoxTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Segment2D(), new BoundingBox2D(), true, Point2.Zero).SetName(
+                        "The empty segment intersects the empty bounding box.");
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(-75, -75), new Point2(75, -75)),
+                        new BoundingBox2D(0, 0, 50, 50), false, Point2.NaN).SetName(
+                        "A non-empty segment outside a non-empty bounding box does not intersect the bounding box.");
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(25, 0)), new BoundingBox2D(0, 0, 50, 50),
+                        true, new Point2(0, 0)).SetName(
+                        "A non-empty segment inside a non-empty bounding box intersects the bounding box.");
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(-100, 0), new Point2(100, 0)),
+                        new BoundingBox2D(0, 0, 50, 50),
+                        true, new Point2(-50, 0)).SetName(
+                        "A non-empty segment crossing a non-empty bounding box intersects the bounding box.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(IntersectsBoundingBoxTestCases))]
+        public void IntersectsBoundingBox(Segment2D segment, BoundingBox2D axisAlignedBoundingBox, bool expectedResult,
+            Point2 expectedIntersectionPoint)
+        {
+            Point2 actualIntersectionPoint;
+            var actualResult = segment.Intersects(axisAlignedBoundingBox, out actualIntersectionPoint);
+            Assert.AreEqual(expectedResult, actualResult);
+
+            if (actualResult)
+            {
+                Assert.AreEqual(expectedIntersectionPoint, actualIntersectionPoint);
+            }
+            else
+            {
+                Assert.IsTrue(float.IsNaN(actualIntersectionPoint.X));
+                Assert.IsTrue(float.IsNaN(actualIntersectionPoint.Y));
+            }
+        }
+
+        public IEnumerable<TestCaseData> EqualityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Segment2D(), new Segment2D(), true).SetName("Empty segments are equal.")
+                    ;
+                yield return
+                    new TestCaseData(
+                        new Segment2D(new Point2(0, 0), new Point2(float.MaxValue, float.MinValue)),
+                        new Segment2D(new Point2(0, 0),
+                            new Point2(float.MinValue, float.MaxValue)), false).SetName(
+                        "Two different non-empty segments are not equal.");
+                yield return
+                    new TestCaseData(
+                        new Segment2D(new Point2(0, 0), new Point2(float.MinValue, float.MaxValue)),
+                        new Segment2D(new Point2(0, 0),
+                            new Point2(float.MinValue, float.MaxValue)), true).SetName(
+                        "Two identical non-empty segments are equal.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(EqualityTestCases))]
+        public void Equality(Segment2D segment1, Segment2D segment2, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(Equals(segment1, segment2) == expectedToBeEqual);
+            Assert.IsTrue(segment1 == segment2 == expectedToBeEqual);
+            Assert.IsFalse(segment1 == segment2 != expectedToBeEqual);
+            Assert.IsTrue(segment1.Equals(segment2) == expectedToBeEqual);
+
+            if (expectedToBeEqual)
+                Assert.AreEqual(segment1.GetHashCode(), segment2.GetHashCode());
+        }
+
+        public IEnumerable<TestCaseData> InequalityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Segment2D(), null, false).SetName("A segment is not equal to a null object.");
+                yield return
+                    new TestCaseData(new Segment2D(), new object(), false).SetName(
+                        "A segment is not equal to an instantiated object.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(InequalityTestCases))]
+        public void Inequality(Segment2D segment, object obj, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(segment.Equals(obj) == expectedToBeEqual);
+        }
+
+        public IEnumerable<TestCaseData> HashCodeTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Segment2D(), new Segment2D(), true).SetName(
+                        "Two empty segments have the same hash code.");
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(50, 50)),
+                        new Segment2D(new Point2(0, 0), new Point2(50, 50)), true).SetName(
+                        "Two indentical non-empty segments have the same hash code.");
+                yield return
+                    new TestCaseData(new Segment2D(new Point2(0, 0), new Point2(50, 50)),
+                        new Segment2D(new Point2(50, 50), new Point2(50, 50)), false).SetName(
+                        "Two different non-empty segments do not have the same hash code.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(HashCodeTestCases))]
+        public void HashCode(Segment2D segment1, Segment2D segment2, bool expectedThatHashCodesAreEqual)
+        {
+            var hashCode1 = segment1.GetHashCode();
+            var hashCode2 = segment2.GetHashCode();
+            if (expectedThatHashCodesAreEqual)
+                Assert.AreEqual(hashCode1, hashCode2);
+            else
+                Assert.AreNotEqual(hashCode1, hashCode2);
+        }
+
+        public IEnumerable<TestCaseData> StringCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Segment2D(),
+                        string.Format(CultureInfo.CurrentCulture, "{0} -> {1}", new Point2(),
+                            new Point2())).SetName(
+                        "The empty segment has the expected string representation using the current culture.");
+                yield return new TestCaseData(new Segment2D(new Point2(5.1f, -5.123f), new Point2(5.4f, -5.4123f)),
+                    string.Format(CultureInfo.CurrentCulture, "{0} -> {1}", new Point2(5.1f, -5.123f),
+                        new Point2(5.4f, -5.4123f))).SetName(
+                    "A non-empty segment has the expected string representation using the current culture.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(StringCases))]
+        public void String(Segment2D segment, string expectedString)
+        {
+            var actualString = segment.ToString();
+            Assert.AreEqual(expectedString, actualString);
+        }
+    }
+}

--- a/Source/MonoGame.Extended.Tests/Primitives/Size2Tests.cs
+++ b/Source/MonoGame.Extended.Tests/Primitives/Size2Tests.cs
@@ -1,0 +1,285 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Primitives;
+using NUnit.Framework;
+
+namespace MonoGame.Extended.Tests.Primitives
+{
+    [TestFixture]
+    public class Size2Tests
+    {
+        public IEnumerable<TestCaseData> ConstructorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(0, 0).SetName(
+                        "The empty size has the expected dimensions.");
+                yield return
+                    new TestCaseData(float.MinValue, float.MaxValue).SetName
+                    (
+                        "A non-empty size has the expected dimensions.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ConstructorTestCases))]
+        public void Constructor(float width, float height)
+        {
+            var size = new Size2(width, height);
+            Assert.AreEqual(width, size.Width);
+            Assert.AreEqual(height, size.Height);
+        }
+
+        public IEnumerable<TestCaseData> DimensionsTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(), 0, 0).SetName(
+                        "The empty size has the expected dimensions.");
+                yield return
+                    new TestCaseData(new Size2(float.MinValue, float.MaxValue), float.MinValue, float.MaxValue).SetName
+                    (
+                        "A non-empty size has the expected dimensions.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(DimensionsTestCases))]
+        public void Dimensions(Size2 size, float expectedWidth, float expecetedHeight)
+        {
+            Assert.AreEqual(expectedWidth, size.Width);
+            Assert.AreEqual(expecetedHeight, size.Height);
+
+            size.Width = 10;
+            Assert.AreEqual(10, size.Width);
+
+            size.Height = -10.123f;
+            Assert.AreEqual(-10.123f, size.Height);
+        }
+
+        public IEnumerable<TestCaseData> AdditionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(), new Size2(), new Size2()).SetName(
+                        "The addition of two empty sizes is the empty size.");
+                yield return
+                    new TestCaseData(new Size2(5, 5), new Size2(15, 15), new Size2(20, 20)).SetName(
+                        "The addition of two non-empty sizes is the expected size.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(AdditionTestCases))]
+        public void Addition(Size2 size1, Size2 size2, Size2 expectedSize)
+        {
+            Assert.AreEqual(expectedSize, size1 + size2);
+            Assert.AreEqual(expectedSize, Size2.Add(size1, size2));
+        }
+
+        public IEnumerable<TestCaseData> SubtractionTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(), new Size2(), new Size2()).SetName(
+                        "The subtraction of two empty sizes is the empty size.");
+                yield return
+                    new TestCaseData(new Size2(5, 5), new Size2(15, 15), new Size2(-10, -10)).SetName(
+                        "The subtraction of two non-empty sizes is the expected size.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SubtractionTestCases))]
+        public void Subtraction(Size2 size1, Size2 size2, Size2 expectedSize)
+        {
+            Assert.AreEqual(expectedSize, size1 - size2);
+            Assert.AreEqual(expectedSize, Size2.Subtract(size1, size2));
+        }
+
+        public IEnumerable<TestCaseData> EqualityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(), new Size2(), true).SetName("Two empty sizes are equal.");
+                yield return
+                    new TestCaseData(new Size2(float.MinValue, float.MaxValue),
+                        new Size2(float.MaxValue, float.MinValue), false).SetName(
+                        "Two different non-empty sizes are not equal.");
+                yield return
+                    new TestCaseData(
+                            new Size2(float.MinValue, float.MaxValue), new Size2(float.MinValue, float.MaxValue), true)
+                        .SetName(
+                            "Two identical non-empty sizes are equal.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(EqualityTestCases))]
+        public void Equality(Size2 size1, Size2 size2, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(Equals(size1, size2) == expectedToBeEqual);
+            Assert.IsTrue(size1 == size2 == expectedToBeEqual);
+            Assert.IsFalse(size1 == size2 != expectedToBeEqual);
+            Assert.IsTrue(size1.Equals(size2) == expectedToBeEqual);
+
+            if (expectedToBeEqual)
+                Assert.AreEqual(size1.GetHashCode(), size2.GetHashCode());
+        }
+
+        public IEnumerable<TestCaseData> InequalityTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(), null, false).SetName("A size is not equal to a null object.");
+                yield return
+                    new TestCaseData(new Size2(), new object(), false).SetName(
+                        "A size is not equal to an instantiated object.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(InequalityTestCases))]
+        public void Inequality(Size2 size, object obj, bool expectedToBeEqual)
+        {
+            Assert.IsTrue(size.Equals(obj) == expectedToBeEqual);
+        }
+
+        public IEnumerable<TestCaseData> HashCodeTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(), new Size2(), true).SetName(
+                        "Two empty sizes have the same hash code.");
+                yield return
+                    new TestCaseData(new Size2(50, 50), new Size2(50, 50), true).SetName(
+                        "Two indentical non-empty sizes have the same hash code.");
+                yield return
+                    new TestCaseData(new Size2(0, 0), new Size2(50, 50), false).SetName(
+                        "Two different non-empty sizes do not have the same hash code.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(HashCodeTestCases))]
+        public void HashCode(Size2 size1, Size2 size2, bool expectedThatHashCodesAreEqual)
+        {
+            var hashCode1 = size1.GetHashCode();
+            var hashCode2 = size2.GetHashCode();
+            if (expectedThatHashCodesAreEqual)
+                Assert.AreEqual(hashCode1, hashCode2);
+            else
+                Assert.AreNotEqual(hashCode1, hashCode2);
+        }
+
+        public IEnumerable<TestCaseData> ToPointTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(), new Point2()).SetName("The empty size converted to a point is the zero point.");
+                yield return
+                    new TestCaseData(new Size2(float.MinValue, float.MaxValue), new Point2(float.MinValue, float.MaxValue)).SetName(
+                        "A non-empty size converted to a point is the expected point.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ToPointTestCases))]
+        public void ToPoint(Size2 size, Point2 expectedPoint)
+        {
+            var actualPoint = (Point2)size;
+            Assert.AreEqual(expectedPoint, actualPoint);
+        }
+
+        public IEnumerable<TestCaseData> FromPointTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Point2(), new Size2()).SetName("The zero point converted to a size is the empty size.");
+                yield return
+                    new TestCaseData(new Point2(float.MinValue, float.MaxValue), new Size2(float.MinValue, float.MaxValue)).SetName(
+                        "A non-zero point converted to a size is the expected size.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(FromPointTestCases))]
+        public void FromPoint(Point2 point, Size2 expectedSize)
+        {
+            var actualSize = (Size2)point;
+            Assert.AreEqual(expectedSize, actualSize);
+        }
+
+        public IEnumerable<TestCaseData> ToVectorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(), new Vector2()).SetName("The empty size converted to a vector is the zero vector.");
+                yield return
+                    new TestCaseData(new Size2(float.MinValue, float.MaxValue), new Vector2(float.MinValue, float.MaxValue)).SetName(
+                        "A non-empty size converted to a vector is the expected vector.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ToVectorTestCases))]
+        public void ToVector(Size2 size, Vector2 expectedVector)
+        {
+            var actualVector = (Vector2)size;
+            Assert.AreEqual(expectedVector, actualVector);
+        }
+
+        public IEnumerable<TestCaseData> FromVectorTestCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Vector2(), new Size2()).SetName("The zero vector converted to a size is the empty size.");
+                yield return
+                    new TestCaseData(new Vector2(float.MinValue, float.MaxValue), new Size2(float.MinValue, float.MaxValue)).SetName(
+                        "A non-zero vector converted to a size is the expected size.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(FromVectorTestCases))]
+        public void FromVector(Vector2 vector, Size2 expectedSize)
+        {
+            var actualSize = (Size2)vector;
+            Assert.AreEqual(expectedSize, actualSize);
+        }
+
+        public IEnumerable<TestCaseData> StringCases
+        {
+            get
+            {
+                yield return
+                    new TestCaseData(new Size2(),
+                        string.Format(CultureInfo.CurrentCulture, "Width: {0}, Height: {1}", 0, 0)).SetName(
+                        "The empty size has the expected string representation using the current culture.");
+                yield return new TestCaseData(new Size2(5.1f, -5.123f),
+                    string.Format(CultureInfo.CurrentCulture, "Width: {0}, Height: {1}", 5.1f, -5.123f)).SetName(
+                    "A non-empty size has the expected string representation using the current culture.");
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(StringCases))]
+        public void String(Size2 size, string expectedString)
+        {
+            var actualString = size.ToString();
+            Assert.AreEqual(expectedString, actualString);
+        }
+    }
+}

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -38,6 +38,12 @@
   <ItemGroup>
     <Compile Include="Animations\Animation.cs" />
     <Compile Include="Animations\AnimationComponent.cs" />
+    <Compile Include="Primitives\BoundingBox2D.cs" />
+    <Compile Include="Primitives\Point2.cs" />
+    <Compile Include="Primitives\Ray2D.cs" />
+    <Compile Include="Primitives\RayHelper.cs" />
+    <Compile Include="Primitives\Segment2D.cs" />
+    <Compile Include="Primitives\Size2.cs" />
     <Compile Include="Sprites\AnimatedSprite.cs" />
     <Compile Include="Animations\Tweens\DelayTween.cs" />
     <Compile Include="Animations\Tweens\FluentTweening.cs" />

--- a/Source/MonoGame.Extended/Primitives/BoundingBox2D.cs
+++ b/Source/MonoGame.Extended/Primitives/BoundingBox2D.cs
@@ -1,0 +1,396 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended.Primitives
+{
+    // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 4.2; Bounding Volumes - Axis-aligned Bounding Boxes (AABBs). pg 77 
+
+    /// <summary>
+    ///     An axis-aligned, four sided box defined by a centre <see cref="Point2" /> and a radius <see cref="Size2" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         An <see cref="BoundingBox2D" /> is categorized by having its faces oriented in such a way that its
+    ///         face normals are at all times parallel with the axes of the given coordinate system.
+    ///     </para>
+    ///     <para>
+    ///         The <see cref="BoundingBox2D" /> of a rotated <see cref="BoundingBox2D" /> will be equivalent or larger in size
+    ///         than the original depending on the angle of rotation.
+    ///     </para>
+    /// </remarks>
+    /// <seealso cref="IEquatable{T}" />
+    /// <seealso cref="IEquatableByRef{AxisAlignedBoundingBox2}" />
+    [DebuggerDisplay("{DebugDisplayString,nq}")]
+    public struct BoundingBox2D : IEquatable<BoundingBox2D>,
+        IEquatableByRef<BoundingBox2D>
+    {
+        /// <summary>
+        ///     The centre position of this <see cref="BoundingBox2D" />.
+        /// </summary>
+        public Point2 Centre;
+
+        /// <summary>
+        ///     The dimensions of this <see cref="BoundingBox2D" />.
+        /// </summary>
+        public Size2 Radius;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="BoundingBox2D" /> structure from the specified centre
+        ///     <see cref="Point2" /> and the radius <see cref="Size2" />.
+        /// </summary>
+        /// <param name="centre">The centre <see cref="Point2" />.</param>
+        /// <param name="radius">The radius <see cref="Size2" />.</param>
+        public BoundingBox2D(Point2 centre, Size2 radius)
+        {
+            Centre = centre;
+            Radius = radius;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="BoundingBox2D" /> structure from the specified centre
+        ///     position coordinates and the radius dimensions.
+        /// </summary>
+        /// <param name="x">The centre x-coordinate.</param>
+        /// <param name="y">The centre y-coordinate.</param>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        public BoundingBox2D(float x, float y, float width, float height)
+            : this(new Point2(x, y), new Size2(width, height))
+        {
+        }
+
+        /// <summary>
+        ///     Computes the <see cref="BoundingBox2D" /> from a minimum <see cref="Point2" /> and maximum
+        ///     <see cref="Point2" />.
+        /// </summary>
+        /// <param name="minimum">The minimum point.</param>
+        /// <param name="maximum">The maximum point.</param>
+        /// <returns>An <see cref="BoundingBox2D" />.</returns>
+        public static BoundingBox2D CreateFromMinimumMaximum(Point2 minimum, Point2 maximum)
+        {
+            var centre = new Point2((maximum.X + minimum.X) * 0.5f, (maximum.Y + minimum.Y) * 0.5f);
+            var radius = new Size2((maximum.X - minimum.X) * 0.5f, (maximum.Y - minimum.Y) * 0.5f);
+            return new BoundingBox2D(centre, radius);
+        }
+
+        /// <summary>
+        ///     Computes the <see cref="BoundingBox2D" /> from a list of <see cref="Point2" /> structures.
+        /// </summary>
+        /// <param name="points">The points.</param>
+        /// <returns>An <see cref="BoundingBox2D" />.</returns>
+        public static BoundingBox2D CreateFromPoints(IReadOnlyList<Point2> points)
+        {
+            // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 4.2; Bounding Volumes - Axis-aligned Bounding Boxes (AABBs). pg 82-84
+
+            if ((points == null) || (points.Count == 0))
+                return new BoundingBox2D();
+
+            var minimum = new Vector2(float.MaxValue);
+            var maximum = new Vector2(float.MinValue);
+
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (var index = 0; index < points.Count; ++index)
+            {
+                var point = points[index];
+                minimum = Point2.Minimum(minimum, point);
+                maximum = Point2.Maximum(maximum, point);
+            }
+
+            return CreateFromMinimumMaximum(minimum, maximum);
+        }
+
+        /// <summary>
+        ///     Updates this <see cref="BoundingBox2D" /> from a list of <see cref="Point2" /> structures.
+        /// </summary>
+        /// <param name="points">The points.</param>
+        public void UpdateFromPoints(IReadOnlyList<Point2> points)
+        {
+            var boundingBox = CreateFromPoints(points);
+            Centre = boundingBox.Centre;
+            Radius = boundingBox.Radius;
+        }
+
+        /// <summary>
+        ///     Computes the <see cref="BoundingBox2D" /> from the specified <see cref="BoundingBox2D" /> transformed by the
+        ///     specified <see cref="Matrix2D" />.
+        /// </summary>
+        /// <param name="boundingBox">The bounding box.</param>
+        /// <param name="transformMatrix">The transform matrix.</param>
+        /// <returns>
+        ///     The <see cref="BoundingBox2D" /> from the <paramref name="boundingBox" /> transformed by the
+        ///     <paramref name="transformMatrix" />.
+        /// </returns>
+        /// <remarks>
+        ///     <para>
+        ///         If a transformed <see cref="BoundingBox2D" /> is used for <paramref name="boundingBox" /> then the
+        ///         resulting <see cref="BoundingBox2D" /> will have the compounded transformation, which most likely is
+        ///         not desired.
+        ///     </para>
+        /// </remarks>
+        public static BoundingBox2D CreateFromTransformedBoundingBox(BoundingBox2D boundingBox,
+            ref Matrix2D transformMatrix)
+        {
+            // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 4.2; Bounding Volumes - Axis-aligned Bounding Boxes (AABBs). pg 86-87
+
+            var centre = transformMatrix.Transform(boundingBox.Centre);
+            var width = boundingBox.Radius.Height;
+            var height = boundingBox.Radius.Width;
+            width = width * Math.Abs(transformMatrix.M11) + width * Math.Abs(transformMatrix.M12) +
+                    width * Math.Abs(transformMatrix.M31);
+            height = height * Math.Abs(transformMatrix.M21) + height * Math.Abs(transformMatrix.M22) +
+                     height * Math.Abs(transformMatrix.M32);
+            return new BoundingBox2D(centre.X, centre.Y, width, height);
+        }
+
+        /// <summary>
+        ///     Computes the <see cref="BoundingBox2D" /> that contains the two specified
+        ///     <see cref="BoundingBox2D" /> structures.
+        /// </summary>
+        /// <param name="first">The first bounding box.</param>
+        /// <param name="second">The second bounding box.</param>
+        /// <returns>
+        ///     An <see cref="BoundingBox2D" /> that contains both the <paramref name="first" /> and the
+        ///     <paramref name="second" />.
+        /// </returns>
+        public static BoundingBox2D Union(BoundingBox2D first, BoundingBox2D second)
+        {
+            // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 6.5; Bounding Volume Hierarchies - Merging Bounding Volumes. pg 267
+
+            var firstMinimum = first.Centre - first.Radius;
+            var firstMaximum = first.Centre + first.Radius;
+            var secondMinimum = second.Centre - second.Radius;
+            var secondMaximum = second.Centre + second.Radius;
+
+            var minimum = Point2.Minimum(firstMinimum, secondMinimum);
+            var maximum = Point2.Maximum(firstMaximum, secondMaximum);
+
+            return CreateFromMinimumMaximum(minimum, maximum);
+        }
+
+        /// <summary>
+        ///     Computes the <see cref="BoundingBox2D" /> that contains both the specified
+        ///     <see cref="BoundingBox2D" /> and this
+        ///     <see cref="BoundingBox2D" />.
+        /// </summary>
+        /// <param name="axisAlignedBoundingBox">The bounding box.</param>
+        /// <returns>
+        ///     An <see cref="BoundingBox2D" /> that contains both the <paramref name="axisAlignedBoundingBox" /> and
+        ///     this
+        ///     <see cref="BoundingBox2D" />.
+        /// </returns>
+        public BoundingBox2D Union(BoundingBox2D axisAlignedBoundingBox)
+        {
+            return Union(this, axisAlignedBoundingBox);
+        }
+
+        /// <summary>
+        ///     Computes the <see cref="Nullable{BoundingBox2D}" /> that is in common between the two specified
+        ///     <see cref="BoundingBox2D" />
+        ///     structures.
+        /// </summary>
+        /// <param name="first">The first bounding box.</param>
+        /// <param name="second">The second bounding box.</param>
+        /// <returns>
+        ///     An <see cref="BoundingBox2D" /> that is in common between both the <paramref name="first" /> and
+        ///     the <paramref name="second" />, if they intersect; otherwise, <code>null</code>.
+        /// </returns>
+        public static BoundingBox2D? Intersection(BoundingBox2D first,
+            BoundingBox2D second)
+        {
+            var firstMinimum = first.Centre - first.Radius;
+            var firstMaximum = first.Centre + first.Radius;
+            var secondMinimum = second.Centre - second.Radius;
+            var secondMaximum = second.Centre + second.Radius;
+
+            var minimum = Point2.Maximum(firstMinimum, secondMinimum);
+            var maximum = Point2.Minimum(firstMaximum, secondMaximum);
+
+            if ((maximum.X < minimum.X) || (maximum.Y < minimum.Y))
+                return null;
+
+            return CreateFromMinimumMaximum(minimum, maximum);
+        }
+
+        /// <summary>
+        ///     Computes the <see cref="BoundingBox2D" /> that is in common between the specified
+        ///     <see cref="BoundingBox2D" /> and this <see cref="BoundingBox2D" />.
+        /// </summary>
+        /// <param name="axisAlignedBoundingBox">The bounding box.</param>
+        /// <returns>
+        ///     An <see cref="BoundingBox2D" /> that is in common between the specified
+        ///     <see cref="BoundingBox2D" /> and this <see cref="BoundingBox2D" />.
+        /// </returns>
+        public BoundingBox2D? Intersection(BoundingBox2D axisAlignedBoundingBox)
+        {
+            return Intersection(this, axisAlignedBoundingBox);
+        }
+
+        /// <summary>
+        ///     Determines whether the two specified <see cref="BoundingBox2D" /> structures intersect.
+        /// </summary>
+        /// <param name="first">The first bounding box.</param>
+        /// <param name="second">The second bounding box.</param>
+        /// <returns>
+        ///     <c>true</c> if the <paramref name="first" /> intersects with the <see cref="second" />; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool Intersects(BoundingBox2D first, BoundingBox2D second)
+        {
+            // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 4.2; Bounding Volumes - Axis-aligned Bounding Boxes (AABBs). pg 80
+
+            var distance = first.Centre - second.Centre;
+            var radius = first.Radius + second.Radius;
+            return (Math.Abs(distance.X) <= radius.Width) && (Math.Abs(distance.Y) <= radius.Height);
+        }
+
+        /// <summary>
+        ///     Determines whether the specified <see cref="BoundingBox2D" /> intersects with this
+        ///     <see cref="BoundingBox2D" />.
+        /// </summary>
+        /// <param name="boundingBox">The bounding box.</param>
+        /// <returns>
+        ///     <c>true</c> if the <paramref name="boundingBox" /> intersects with this
+        ///     <see cref="BoundingBox2D" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Intersects(BoundingBox2D boundingBox)
+        {
+            return Intersects(this, boundingBox);
+        }
+
+        /// <summary>
+        ///     Determines whether the specified <see cref="BoundingBox2D" /> contains the specified
+        ///     <see cref="Point2" />.
+        /// </summary>
+        /// <param name="boundingBox">The bounding box.</param>
+        /// <param name="point">The point.</param>
+        /// <returns>
+        ///     <c>true</c> if the <paramref name="boundingBox" /> contains the <paramref name="point" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public static bool Contains(BoundingBox2D boundingBox, Point2 point)
+        {
+            // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 4.2; Bounding Volumes - Axis-aligned Bounding Boxes (AABBs). pg 78
+
+            var distance = boundingBox.Centre - point;
+            var radius = boundingBox.Radius;
+
+            return (Math.Abs(distance.X) <= radius.Width) && (Math.Abs(distance.Y) <= radius.Height);
+        }
+
+        /// <summary>
+        ///     Determines whether this <see cref="BoundingBox2D" /> contains the specified <see cref="Point2" />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="BoundingBox2D" /> contains the <paramref name="point" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Contains(Point2 point)
+        {
+            return Contains(this, point);
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="BoundingBox2D" /> structures. The result specifies whether the values of the
+        ///     <see cref="Centre" /> and <see cref="Radius" /> fields of the two <see cref="BoundingBox2D" /> structures
+        ///     are equal.
+        /// </summary>
+        /// <param name="first">The first bounding box.</param>
+        /// <param name="second">The second bounding box.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="Centre" /> and <see cref="Radius" /> fields of the two
+        ///     <see cref="BoundingBox2D" /> structures are equal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator ==(BoundingBox2D first, BoundingBox2D second)
+        {
+            return first.Equals(ref second);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="BoundingBox2D" /> is equal to another
+        ///     <see cref="BoundingBox2D" />.
+        /// </summary>
+        /// <param name="boundingBox">The bounding box.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="BoundingBox2D" /> is equal to the <paramref name="boundingBox" />;
+        ///     otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(BoundingBox2D boundingBox)
+        {
+            return Equals(ref boundingBox);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="BoundingBox2D" /> is equal to another <see cref="BoundingBox2D" />.
+        /// </summary>
+        /// <param name="boundingBox">The ray.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="BoundingBox2D" /> is equal to the <paramref name="boundingBox" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Equals(ref BoundingBox2D boundingBox)
+        {
+            return (boundingBox.Centre == Centre) && (boundingBox.Radius == Radius);
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether this <see cref="BoundingBox2D" /> is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to make the comparison with.</param>
+        /// <returns>
+        ///     <c>true</c> if this  <see cref="BoundingBox2D" /> is equal to <paramref name="obj" />; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is BoundingBox2D)
+                return Equals((BoundingBox2D)obj);
+            return false;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="BoundingBox2D" /> structures. The result specifies whether the values of the
+        ///     <see cref="Centre" /> and <see cref="Radius" /> fields of the two <see cref="BoundingBox2D" /> structures
+        ///     are unequal.
+        /// </summary>
+        /// <param name="first">The first bounding box.</param>
+        /// <param name="second">The second bounding box.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="Centre" /> and <see cref="Radius" /> fields of the two
+        ///     <see cref="BoundingBox2D" /> structures are unequal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator !=(BoundingBox2D first, BoundingBox2D second)
+        {
+            return !(first == second);
+        }
+
+        /// <summary>
+        ///     Returns a hash code of this <see cref="BoundingBox2D" /> suitable for use in hashing algorithms and data
+        ///     structures like a hash table.
+        /// </summary>
+        /// <returns>
+        ///     A hash code of this <see cref="BoundingBox2D" />.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Centre.GetHashCode() * 397) ^ Radius.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="string" /> that represents this <see cref="BoundingBox2D" />.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="string" /> that represents this <see cref="BoundingBox2D" />.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"Centre: {Centre}, Radius: {Radius}";
+        }
+
+        internal string DebugDisplayString => ToString();
+    }
+}

--- a/Source/MonoGame.Extended/Primitives/Point2.cs
+++ b/Source/MonoGame.Extended/Primitives/Point2.cs
@@ -1,0 +1,372 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended.Primitives
+{
+    // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 3.2; A Math and Geometry Primer - Coordinate Systems and Points. pg 35
+
+    /// <summary>
+    ///     A two-dimensional point defined by a 2-tuple of real numbers, (x, y).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A point is a position in two-dimensional space, the location of which is described in terms of a
+    ///         two-dimensional coordinate system, given by a reference point, called the origin, and two coordinate axes.
+    ///     </para>
+    ///     <para>
+    ///         A common two-dimensional coordinate system is the Cartesian (or rectangular) coordinate system where the
+    ///         coordinate axes, conventionally denoted the X axis and Y axis, are perpindicular to each other. For the
+    ///         three-dimensional rectangular coordinate system, the third axis is called the Z axis.
+    ///     </para>
+    ///     <para>
+    ///         In general, a point is a position in space, the location of which is described in terms of a coordinate system,
+    ///         given by a reference point, called the origin, and a number of coordinate axes. Points in an n-dimensional
+    ///         coordinate system are each specified by an n-tuple of realnumbers (x1, x2, . . . , xn). The n-tuple is called
+    ///         the coordinate of the point. The point described by the n-tuple is the one reached by starting at the origin
+    ///         and moving x1 units along the first coordinate axis, x2 units along the second coordinate axis, and so on for
+    ///         all given numbers. The origin is the point with all zero components, (0, 0, . . . , 0). A coordinate system may
+    ///         be given relative to a parent coordinate system, in which case the origin of the subordinate coordinate system
+    ///         may correspond to any point in the parent coordinate system.
+    ///     </para>
+    /// </remarks>
+    /// <seealso cref="IEquatable{Point2}" />
+    /// <seealso cref="IEquatableByRef{Point2}" />
+    [DebuggerDisplay("{DebugDisplayString,nq}")]
+    public struct Point2 : IEquatable<Point2>, IEquatableByRef<Point2>
+    {
+        /// <summary>
+        ///     Returns a <see cref="Point2" /> with <see cref="X" /> and <see cref="Y" /> equal to <c>0.0f</c>.
+        /// </summary>
+        public static readonly Point2 Zero = new Point2();
+
+        /// <summary>
+        ///     Returns a <see cref="Point2" /> with <see cref="X" /> and <see cref="Y" /> set to not a number.
+        /// </summary>
+        public static readonly Point2 NaN = new Point2(float.NaN, float.NaN);
+
+        /// <summary>
+        ///     The x-coordinate of this <see cref="Point2" />.
+        /// </summary>
+        public float X;
+
+        /// <summary>
+        ///     The y-coordinate of this <see cref="Point2" />.
+        /// </summary>
+        public float Y;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Point2" /> structure from the specified coordinates.
+        /// </summary>
+        /// <param name="x">The x-coordinate.</param>
+        /// <param name="y">The y-coordinate.</param>
+        public Point2(float x, float y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="Point2" /> structures. The result specifies
+        ///     whether the values of the <see cref="X" /> and <see cref="Y" />
+        ///     fields of the two <see cref="Point2" />
+        ///     structures are equal.
+        /// </summary>
+        /// <param name="first">The first point.</param>
+        /// <param name="second">The second point.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="X" /> and <see cref="Y" />
+        ///     fields of the two <see cref="Point2" />
+        ///     structures are equal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator ==(Point2 first, Point2 second)
+        {
+            return first.Equals(ref second);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="Point2" /> is equal to another <see cref="Point2" />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Point2" /> is equal to the <paramref name="point" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Equals(Point2 point)
+        {
+            return Equals(ref point);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="Point2" /> is equal to another <see cref="Point2" />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Point2" /> is equal to the <paramref name="point" /> parameter; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Equals(ref Point2 point)
+        {
+            // ReSharper disable CompareOfFloatsByEqualityOperator
+            return (point.X == X) && (point.Y == Y);
+            // ReSharper restore CompareOfFloatsByEqualityOperator
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether this <see cref="Point2" /> is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to make the comparison with.</param>
+        /// <returns>
+        ///     <c>true</c> if this  <see cref="Point2" /> is equal to <paramref name="obj" />; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is Point2)
+                return Equals((Point2)obj);
+            return false;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="Point2" /> structures. The result specifies
+        ///     whether the values of the <see cref="X" /> or <see cref="Y" />
+        ///     fields of the two <see cref="Point2" />
+        ///     structures are unequal.
+        /// </summary>
+        /// <param name="first">The first point.</param>
+        /// <param name="second">The second point.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="X" /> or <see cref="Y" />
+        ///     fields of the two <see cref="Point2" />
+        ///     structures are unequal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator !=(Point2 first, Point2 second)
+        {
+            return !(first == second);
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Point2" /> representing the addition of a <see cref="Point2" /> and a <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="vector">The vector.</param>
+        /// <returns>
+        ///     The <see cref="Point2" /> representing the addition of a <see cref="Point2" /> and a <see cref="Vector2"/>.
+        /// </returns>
+        public static Point2 operator +(Point2 point, Vector2 vector)
+        {
+            return Add(point, vector);
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Point2" /> representing the addition of a <see cref="Point2" /> and a <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="vector">The vector.</param>
+        /// <returns>
+        ///     The <see cref="Point2" /> representing the addition of a <see cref="Point2" /> and a <see cref="Vector2"/>.
+        /// </returns>
+        public static Point2 Add(Point2 point, Vector2 vector)
+        {
+            Point2 p;
+            p.X = point.X + vector.X;
+            p.Y = point.Y + vector.Y;
+            return p;
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Point2" /> representing the subtraction of a <see cref="Point2" /> and a <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="vector">The vector.</param>
+        /// <returns>
+        ///     The <see cref="Point2" /> representing the substraction of a <see cref="Point2" /> and a <see cref="Vector2"/>.
+        /// </returns>
+        public static Point2 operator -(Point2 point, Vector2 vector)
+        {
+            return Subtract(point, vector);
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Point2" /> representing the addition of a <see cref="Point2" /> and a <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="vector">The vector.</param>
+        /// <returns>
+        ///     The <see cref="Point2" /> representing the substraction of a <see cref="Point2" /> and a <see cref="Vector2"/>.
+        /// </returns>
+        public static Point2 Subtract(Point2 point, Vector2 vector)
+        {
+            Point2 p;
+            p.X = point.X - vector.X;
+            p.Y = point.Y - vector.Y;
+            return p;
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Vector2" /> representing the displacement of two <see cref="Point2" /> structures.
+        /// </summary>
+        /// <param name="point2">The second point.</param>
+        /// <param name="point1">The first point.</param>
+        /// <returns>
+        ///     The <see cref="Vector2" /> representing the displacement of two <see cref="Point2" /> structures.
+        /// </returns>
+        public static Vector2 operator -(Point2 point1, Point2 point2)
+        {
+            return Displacement(point1, point2);
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Vector2" /> representing the displacement of two <see cref="Point2" /> structures.
+        /// </summary>
+        /// <param name="point2">The second point.</param>
+        /// <param name="point1">The first point.</param>
+        /// <returns>
+        ///     The <see cref="Vector2" /> representing the displacement of two <see cref="Point2" /> structures.
+        /// </returns>
+        public static Vector2 Displacement(Point2 point2, Point2 point1)
+        {
+            Vector2 vector;
+            vector.X = point2.X - point1.X;
+            vector.Y = point2.Y - point1.Y;
+            return vector;
+        }
+
+        /// <summary>
+        ///     Translates a <see cref='Point2' /> by a given <see cref='Size2' />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="size">The size.</param>
+        /// <returns>
+        ///     The result of the operator.
+        /// </returns>
+        public static Point2 operator +(Point2 point, Size2 size)
+        {
+            return Add(point, size);
+        }
+
+        /// <summary>
+        ///     Translates a <see cref='Point2' /> by a given <see cref='Size2' />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="size">The size.</param>
+        /// <returns>
+        ///     The result of the operator.
+        /// </returns>
+        public static Point2 Add(Point2 point, Size2 size)
+        {
+            return new Point2(point.X + size.Width, point.Y + size.Height);
+        }
+
+        /// <summary>
+        ///     Translates a <see cref='Point2' /> by the negative of a given <see cref='Size2' />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="size">The size.</param>
+        /// <returns>
+        ///     The result of the operator.
+        /// </returns>
+        public static Point2 operator -(Point2 point, Size2 size)
+        {
+            return Subtract(point, size);
+        }
+
+        /// <summary>
+        ///     Translates a <see cref='Point2' /> by the negative of a given <see cref='Size2' /> .
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <param name="size">The size.</param>
+        /// <returns>
+        ///     The result of the operator.
+        /// </returns>
+        public static Point2 Subtract(Point2 point, Size2 size)
+        {
+            return new Point2(point.X - size.Width, point.Y - size.Height);
+        }
+
+        /// <summary>
+        ///     Returns a hash code of this <see cref="Point2" /> suitable for use in hashing algorithms and data
+        ///     structures like a hash table.
+        /// </summary>
+        /// <returns>
+        ///     A hash code of this <see cref="Point2" />.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (X.GetHashCode() * 397) ^ Y.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Point2" /> that contains the minimal coordinate values from two <see cref="Point2" />
+        ///     structures.
+        ///     structures.
+        /// </summary>
+        /// <param name="first">The first point.</param>
+        /// <param name="second">The second point.</param>
+        /// <returns>
+        ///     The the <see cref="Point2" /> that contains the minimal coordinate values from two <see cref="Point2" />
+        ///     structures.
+        /// </returns>
+        public static Point2 Minimum(Point2 first, Point2 second)
+        {
+            return new Point2(first.X < second.X ? first.X : second.X,
+                first.Y < second.Y ? first.Y : second.Y);
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Point2" /> that contains the maximal coordinate values from two <see cref="Point2" />
+        ///     structures.
+        ///     structures.
+        /// </summary>
+        /// <param name="first">The first point.</param>
+        /// <param name="second">The second point.</param>
+        /// <returns>
+        ///     The the <see cref="Point2" /> that contains the maximal coordinate values from two <see cref="Point2" />
+        ///     structures.
+        /// </returns>
+        public static Point2 Maximum(Vector2 first, Vector2 second)
+        {
+            return new Point2(first.X > second.X ? first.X : second.X,
+                first.Y > second.Y ? first.Y : second.Y);
+        }
+
+        /// <summary>
+        ///     Performs an implicit conversion from a <see cref="Point2" /> to a position <see cref="Vector2" />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>
+        ///     The resulting <see cref="Vector2" />.
+        /// </returns>
+        public static implicit operator Vector2(Point2 point)
+        {
+            return new Vector2(point.X, point.Y);
+        }
+
+        /// <summary>
+        ///     Performs an implicit conversion from a <see cref="Vector2" /> to a position <see cref="Point2" />.
+        /// </summary>
+        /// <param name="vector">The vector.</param>
+        /// <returns>
+        ///     The resulting <see cref="Point2" />.
+        /// </returns>
+        public static implicit operator Point2(Vector2 vector)
+        {
+            return new Point2(vector.X, vector.Y);
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="string" /> that represents this <see cref="Point2" />.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="string" /> that represents this <see cref="Point2" />.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"({X}, {Y})";
+        }
+
+        internal string DebugDisplayString => ToString();
+    }
+}

--- a/Source/MonoGame.Extended/Primitives/Ray2D.cs
+++ b/Source/MonoGame.Extended/Primitives/Ray2D.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended.Primitives
+{
+    // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 3.5; A Math and Geometry Primer - Lines, Rays, and Segments. pg 53-54    
+    /// <summary>
+    ///     A two dimensional ray defined by a starting <see cref="Point2" /> and a direction <see cref="Vector2" />.
+    /// </summary>
+    /// <seealso cref="IEquatable{Ray2}" />
+    /// <seealso cref="IEquatableByRef{Ray2}" />
+    [DebuggerDisplay("{DebugDisplayString,nq}")]
+    public struct Ray2D : IEquatable<Ray2D>, IEquatableByRef<Ray2D>
+    {
+        /// <summary>
+        ///     The starting <see cref="Point2" /> of this <see cref="Ray2D" />.
+        /// </summary>
+        public Point2 Position;
+
+        /// <summary>
+        ///     The direction <see cref="Vector2" /> of this <see cref="Ray2D" />.
+        /// </summary>
+        public Vector2 Direction;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Ray2D" /> structure from the specified position and direction.
+        /// </summary>
+        /// <param name="position">The starting point.</param>
+        /// <param name="direction">The direction vector.</param>
+        public Ray2D(Point2 position, Vector2 direction)
+        {
+            Position = position;
+            Direction = direction;
+        }
+
+        /// <summary>
+        ///     Determines whether this <see cref="Ray2D" /> intersects with a specified <see cref="BoundingBox2D" />.
+        /// </summary>
+        /// <param name="axisAlignedBoundingBox">The bounding box.</param>
+        /// <param name="rayNearDistance">
+        ///     When this method returns, contains the distance along the ray to the first intersection
+        ///     point with the <paramref name="axisAlignedBoundingBox" />, if an intersection was found; otherwise, <see cref="float.NaN" />.
+        ///     This parameter is passed uninitialized.
+        /// </param>
+        /// <param name="rayFarDistance">
+        ///     When this method returns, contains the distance along the ray to the second intersection
+        ///     point with the <paramref name="axisAlignedBoundingBox" />, if an intersection was found; otherwise, <see cref="float.NaN" />.
+        ///     This parameter is passed uninitialized.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Ray2D" /> intersects with <paramref name="axisAlignedBoundingBox" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Intersects(BoundingBox2D axisAlignedBoundingBox, out float rayNearDistance, out float rayFarDistance)
+        {
+            // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 5.3; Basic Primitive Tests - Intersecting Lines, Rays, and (Directed Segments). pg 179-181
+
+            var boundingBoxMinimumPoint = axisAlignedBoundingBox.Centre - axisAlignedBoundingBox.Radius;
+            var boundingBoxMaximumPoint = axisAlignedBoundingBox.Centre + axisAlignedBoundingBox.Radius;
+
+            // Set to the smallest possible value so the algorithm can find the first hit along the ray
+            var minimumDistanceAlongRay = float.MinValue;
+            // Set to the maximum possible value so the algorithm can find the last hit along the ray
+            var maximumDistanceAlongRay = float.MaxValue;
+
+            // For all relevant slabs which in this case is two.
+
+            // The first, horizontal, slab.
+            if (!RayHelper.IntersectsSlab(Position.X, Direction.X, boundingBoxMinimumPoint.X, boundingBoxMaximumPoint.X,
+                ref minimumDistanceAlongRay,
+                ref maximumDistanceAlongRay))
+            {
+                rayNearDistance = rayFarDistance = float.NaN;
+                return false;
+            }
+
+            // The second, vertical, slab.
+            if (!RayHelper.IntersectsSlab(Position.Y, Direction.Y, boundingBoxMinimumPoint.Y, boundingBoxMaximumPoint.Y,
+                ref minimumDistanceAlongRay,
+                ref maximumDistanceAlongRay))
+            {
+                rayNearDistance = rayFarDistance = float.NaN;
+                return false;
+            }
+
+            // Ray intersects the 2 slabs.
+            rayNearDistance = minimumDistanceAlongRay < 0 ? 0 : minimumDistanceAlongRay;
+            rayFarDistance = maximumDistanceAlongRay;
+            return true;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="Ray2D" /> structures. The result specifies whether the values of the <see cref="Position" />
+        ///     and <see cref="Direction" /> fields of the two <see cref="Ray2D" /> structures are equal.
+        /// </summary>
+        /// <param name="first">The first ray.</param>
+        /// <param name="second">The second ray.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="Position" /> and <see cref="Direction" />
+        ///     fields of the two <see cref="Ray2D" />
+        ///     structures are equal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator ==(Ray2D first, Ray2D second)
+        {
+            return first.Equals(ref second);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="Ray2D" /> is equal to another <see cref="Ray2D" />.
+        /// </summary>
+        /// <param name="ray">The ray.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Ray2D" /> is equal to the <paramref name="ray" /> parameter; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Equals(Ray2D ray)
+        {
+            return Equals(ref ray);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="Ray2D" /> is equal to another <see cref="Ray2D" />.
+        /// </summary>
+        /// <param name="ray">The ray.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Ray2D" /> is equal to the <paramref name="ray" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Equals(ref Ray2D ray)
+        {
+            // ReSharper disable CompareOfFloatsByEqualityOperator
+            return (ray.Position == Position) && (ray.Direction == Direction);
+            // ReSharper restore CompareOfFloatsByEqualityOperator
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether this <see cref="Ray2D" /> is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to make the comparison with.</param>
+        /// <returns>
+        ///     <c>true</c> if this  <see cref="Ray2D" /> is equal to <paramref name="obj" />; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is Ray2D)
+                return Equals((Ray2D)obj);
+            return false;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="Ray2D" /> structures. The result specifies whether the values of the <see cref='Position' />
+        ///     and <see cref="Direction" /> fields of the two <see cref="Ray2D" /> structures are unequal.
+        /// </summary>
+        /// <param name="first">The first ray.</param>
+        /// <param name="second">The second ray.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="Position" /> and <see cref="Direction" />
+        ///     fields of the two <see cref="Ray2D" />
+        ///     structures are unequal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator !=(Ray2D first, Ray2D second)
+        {
+            return !(first == second);
+        }
+
+        /// <summary>
+        ///     Returns a hash code of this <see cref="Ray2D" /> suitable for use in hashing algorithms and data
+        ///     structures like a hash table.
+        /// </summary>
+        /// <returns>
+        ///     A hash code of this <see cref="Ray2D" />.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Position.GetHashCode() * 397) ^ Direction.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="string" /> that represents this <see cref="Ray2D" />.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="string" /> that represents this <see cref="Ray2D" />.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"Position: {Position}, Direction: {Direction}";
+        }
+
+        internal string DebugDisplayString => ToString();
+    }
+}

--- a/Source/MonoGame.Extended/Primitives/RayHelper.cs
+++ b/Source/MonoGame.Extended/Primitives/RayHelper.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace MonoGame.Extended.Primitives
+{
+    internal class RayHelper
+    {
+        // Used by Ray2 and Segment2
+        internal static bool IntersectsSlab(float positionCoordinate, float directionCoordinate, float slabMinimum, float slabMaximum, ref float rayMinimumDistance, ref float rayMaximumDistance)
+        {
+            // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 5.3; Basic Primitive Tests - Intersecting Lines, Rays, and (Directed Segments). pg 179-181
+
+            if (Math.Abs(directionCoordinate) < float.Epsilon)
+            {
+                // Ray is parallel to slab. No hit if origin is not with in the slab
+                return positionCoordinate >= slabMinimum && positionCoordinate <= slabMaximum;
+            }
+
+            // Compute intersection values of ray with near and far plane of slab
+            var rayNearDistance = (slabMinimum - positionCoordinate) / directionCoordinate;
+            var rayFarDistance = (slabMaximum - positionCoordinate) / directionCoordinate;
+
+            if (rayNearDistance > rayFarDistance)
+            {
+                // Swap near and far distance
+                var temp = rayFarDistance;
+                rayNearDistance = rayFarDistance;
+                rayFarDistance = temp;
+            }
+
+            // Compute the intersection of slab intersection intervals
+            rayMinimumDistance = rayNearDistance > rayMinimumDistance ? rayNearDistance : rayMinimumDistance;
+            rayMaximumDistance = rayFarDistance < rayMaximumDistance ? rayFarDistance : rayMaximumDistance;
+
+            // Exit with no collision as soon as slab intersection becomes empty
+            return rayMinimumDistance <= rayMaximumDistance;
+        }
+    }
+}

--- a/Source/MonoGame.Extended/Primitives/Segment2D.cs
+++ b/Source/MonoGame.Extended/Primitives/Segment2D.cs
@@ -1,0 +1,261 @@
+﻿using System;
+
+namespace MonoGame.Extended.Primitives
+{
+    // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 3.5; A Math and Geometry Primer - Lines, Rays, and Segments. pg 53-54    
+    /// <summary>
+    ///     A two dimensional line segment defined by two <see cref="Point2" /> structures, a starting point and an ending point.
+    /// </summary>
+    /// <seealso cref="IEquatable{Segment2}" />
+    /// <seealso cref="IEquatableByRef{Segment2}" />
+    public struct Segment2D : IEquatable<Segment2D>, IEquatableByRef<Segment2D>
+    {
+        /// <summary>
+        ///     The starting <see cref="Point2" /> of this <see cref="Segment2D"/>.
+        /// </summary>
+        public Point2 Start;
+
+        /// <summary>
+        ///     The ending <see cref="Point2" /> of this <see cref="Segment2D"/>.
+        /// </summary>
+        public Point2 End;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Segment2D" /> structure from the specified starting and ending <see cref="Point2"/> structures.
+        /// </summary>
+        /// <param name="start">The starting point.</param>
+        /// <param name="end">The ending point.</param>
+        public Segment2D(Point2 start, Point2 end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Segment2D" /> structure.
+        /// </summary>
+        /// <param name="x1">The starting x-coordinate.</param>
+        /// <param name="y1">The starting y-coordinate.</param>
+        /// <param name="x2">The ending x-coordinate.</param>
+        /// <param name="y2">The ending y-coordinate.</param>
+        public Segment2D(float x1, float y1, float x2, float y2)
+            : this(new Point2(x1, y1), new Point2(x2, y2))
+        {
+        }
+
+        // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 5.1.2; Basic Primitive Tests - Closest Point on Line Segment to Point. pg 127-130
+        /// <summary>
+        ///     Computes the closest <see cref="Point2" /> on this <see cref="Segment2D" /> to a specified <see cref="Point2" />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>The closest <see cref="Point2" /> on this <see cref="Segment2D" /> to the <paramref name="point" />.</returns>
+        public Point2 ClosestPointTo(Point2 point)
+        {
+            // Computes the parameterized position: d(t) = Start + t * (End – Start)
+
+            var startToEnd = End - Start;
+            var startToPoint = point - Start;
+            // Project arbitrary point onto the line segment, deferring the division
+            var t = startToEnd.Dot(startToPoint);
+            // If outside segment, clamp t (and therefore d) to the closest endpoint
+            if (t <= 0)
+                return Start;
+
+            // Always nonnegative since denom = (||vector||)^2
+            var denominator = startToEnd.Dot(startToEnd);
+            if (t >= denominator)
+                return End;
+
+            // The point projects inside the [Start, End] interval, must do deferred division now
+            t /= denominator;
+            startToEnd *= t;
+            return new Point2(Start.X + startToEnd.X, Start.Y + startToEnd.Y);
+        }
+
+        // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 5.1.2.1; Basic Primitive Tests - Distance of Point to Segment. pg 127-130        
+        /// <summary>
+        ///     Computes the squared distance from this <see cref="Segment2D" /> to a specified <see cref="Point2" />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>The squared distance from this <see cref="Segment2D" /> to a specified <see cref="Point2" />.</returns>
+        public float SquaredDistanceTo(Point2 point)
+        {
+            var startToEnd = End - Start;
+            var startToPoint = point - Start;
+            var endToPoint = point - End;
+            // Handle cases where the point projects outside the line segment
+            var dot = startToPoint.Dot(startToEnd);
+            var startToPointDistanceSquared = startToPoint.Dot(startToPoint);
+            if (dot <= 0.0f)
+                return startToPointDistanceSquared;
+            var startToEndDistanceSquared = startToEnd.Dot(startToEnd);
+            if (dot >= startToEndDistanceSquared)
+                endToPoint.Dot(endToPoint);
+            // Handle the case where the point projects onto the line segment
+            return startToPointDistanceSquared - dot * dot / startToEndDistanceSquared;
+        }
+
+        /// <summary>
+        ///     Computes the distance from this <see cref="Segment2D" /> to a specified <see cref="Point2" />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>The distance from this <see cref="Segment2D" /> to a specified <see cref="Point2" />.</returns>
+        public float DistanceTo(Point2 point)
+        {
+            return (float)Math.Sqrt(SquaredDistanceTo(point));
+        }
+
+        /// <summary>
+        ///     Determines whether this <see cref="Segment2D" /> intersects with the specified <see cref="BoundingBox2D" />.
+        /// </summary>
+        /// <param name="axisAlignedBoundingBox">The bounding box.</param>
+        /// <param name="intersectionPoint">
+        ///     When this method returns, contains the <see cref="Point2" /> of intersection, if an
+        ///     intersection was found; otherwise, the <see cref="Point2.NaN" />. This parameter is passed uninitialized.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Segment2D" /> intersects with <paramref name="axisAlignedBoundingBox" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Intersects(BoundingBox2D axisAlignedBoundingBox, out Point2 intersectionPoint)
+        {
+            // Real-Time Collision Detection, Christer Ericson, 2005. Chapter 5.3; Basic Primitive Tests - Intersecting Lines, Rays, and (Directed Segments). pg 179-181
+
+            var minimumPoint = axisAlignedBoundingBox.Centre - axisAlignedBoundingBox.Radius;
+            var maximumPoint = axisAlignedBoundingBox.Centre + axisAlignedBoundingBox.Radius;
+            var minimumDistance = float.MinValue;
+            var maximumDistance = float.MaxValue;
+
+            var direction = End - Start;
+            if (!RayHelper.IntersectsSlab(Start.X, direction.X, minimumPoint.X, maximumPoint.X, ref minimumDistance, ref maximumDistance))
+            {
+                intersectionPoint  = Point2.NaN;
+                return false;
+            }
+
+            if (!RayHelper.IntersectsSlab(Start.Y, direction.Y, minimumPoint.Y, maximumPoint.Y, ref minimumDistance, ref maximumDistance))
+            {
+                intersectionPoint = Point2.NaN;
+                return false;
+            }
+
+            // Segment intersects the 2 slabs.
+
+            if (minimumDistance <= 0)
+            {
+                intersectionPoint = Start;
+            }
+            else
+            {
+                intersectionPoint = minimumDistance * direction;
+                intersectionPoint.X += Start.X;
+                intersectionPoint.Y += Start.Y;
+            }
+
+            return true;
+        }
+
+
+        /// <summary>
+        ///     Compares two <see cref="Segment2D" /> structures. The result specifies
+        ///     whether the values of the <see cref="Start" /> and <see cref="End" />
+        ///     fields of the two <see cref='Segment2D' />
+        ///     structures are equal.
+        /// </summary>
+        /// <param name="first">The first segment.</param>
+        /// <param name="second">The second segment.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="Start" /> and <see cref="End" />
+        ///     fields of the two <see cref="Segment2D" />
+        ///     structures are equal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator ==(Segment2D first, Segment2D second)
+        {
+            return first.Equals(ref second);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="Segment2D"/> is equal to another <see cref="Segment2D"/>.
+        /// </summary>
+        /// <param name="segment">The segment.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Segment2D"/> is equal to the <paramref name="segment" />; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Segment2D segment)
+        {
+            return Equals(ref segment);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="Segment2D"/> is equal to another <see cref="Segment2D"/>.
+        /// </summary>
+        /// <param name="segment">The segment.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Segment2D"/> is equal to the <paramref name="segment" /> parameter; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(ref Segment2D segment)
+        {
+            return Start == segment.Start && End == segment.End;
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether this <see cref="Segment2D" /> is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to make the comparison with.</param>
+        /// <returns>
+        ///     <c>true</c> if this  <see cref="Segment2D" /> is equal to <paramref name="obj"/>; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is Segment2D)
+                return Equals((Segment2D)obj);
+            return false;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="Segment2D" /> structures. The result specifies
+        ///     whether the values of the <see cref="Start" /> and <see cref="End" />
+        ///     fields of the two <see cref="Segment2D" />
+        ///     structures are unequal.
+        /// </summary>
+        /// <param name="first">The first point.</param>
+        /// <param name="second">The second point.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="Start" /> and <see cref="End" />
+        ///     fields of the two <see cref="Segment2D" />
+        ///     structures are unequal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator !=(Segment2D first, Segment2D second)
+        {
+            return !(first == second);
+        }
+
+        /// <summary>
+        ///     Returns a hash code of this <see cref="Segment2D" /> suitable for use in hashing algorithms and data
+        ///     structures like a hash table.
+        /// </summary>
+        /// <returns>
+        ///     A hash code of this <see cref="Segment2D" />.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Start.GetHashCode() * 397) ^ End.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="string" /> that represents this <see cref="Segment2D" />.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="string" /> that represents this <see cref="Segment2D" />.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"{Start} -> {End}";
+        }
+
+        internal string DebugDisplayString => ToString();
+    }
+}

--- a/Source/MonoGame.Extended/Primitives/Size2.cs
+++ b/Source/MonoGame.Extended/Primitives/Size2.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended.Primitives
+{
+    /// <summary>
+    ///     A two dimensional size defined by two real numbers, a width and a height.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A size is a subspace of two-dimensional space, the area of which is described in terms of a two-dimensional
+    ///         coordinate system, given by a reference point and two coordinate axes.
+    ///     </para>
+    /// </remarks>
+    /// <seealso cref="IEquatable{Size2}" />
+    /// <seealso cref="IEquatableByRef{Size2}" />
+    public struct Size2 : IEquatable<Size2>, IEquatableByRef<Size2>
+    {
+        /// <summary>
+        ///     Returns a <see cref="Size2" /> with <see cref="Width" /> and <see cref="Height" /> equal to <c>0.0f</c>.
+        /// </summary>
+        public static readonly Size2 Empty = new Size2();
+
+        /// <summary>
+        ///     The horizontal component of this <see cref="Size2" />.
+        /// </summary>
+        public float Width;
+
+        /// <summary>
+        ///     The vertical component of this <see cref="Size2" />.
+        /// </summary>
+        public float Height;
+
+        /// <summary>
+        ///     Gets a value that indicates whether this <see cref="Size2" /> is empty.
+        /// </summary>
+        // ReSharper disable CompareOfFloatsByEqualityOperator
+        public bool IsEmpty => (Width == 0) && (Height == 0);
+
+        // ReSharper restore CompareOfFloatsByEqualityOperator
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Size2" /> structure from the specified dimensions.
+        /// </summary>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        public Size2(float width, float height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="Size2" /> structures. The result specifies
+        ///     whether the values of the <see cref="Width" /> and <see cref="Height" />
+        ///     fields of the two <see cref="Point2" /> structures are equal.
+        /// </summary>
+        /// <param name="first">The first size.</param>
+        /// <param name="second">The second size.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="Width" /> and <see cref="Height" />
+        ///     fields of the two <see cref="Point2" /> structures are equal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator ==(Size2 first, Size2 second)
+        {
+            return first.Equals(ref second);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="Size2" /> is equal to another <see cref="Size2" />.
+        /// </summary>
+        /// <param name="size">The size.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Point2" /> is equal to the <paramref name="size" /> parameter; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Equals(Size2 size)
+        {
+            return Equals(ref size);
+        }
+
+        /// <summary>
+        ///     Indicates whether this <see cref="Size2" /> is equal to another <see cref="Size2" />.
+        /// </summary>
+        /// <param name="size">The size.</param>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="Point2" /> is equal to the <paramref name="size" />; otherwise,
+        ///     <c>false</c>.
+        /// </returns>
+        public bool Equals(ref Size2 size)
+        {
+            // ReSharper disable CompareOfFloatsByEqualityOperator
+            return (Width == size.Width) && (Height == size.Height);
+            // ReSharper restore CompareOfFloatsByEqualityOperator
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether this <see cref="Size2" /> is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to make the comparison with.</param>
+        /// <returns>
+        ///     <c>true</c> if this  <see cref="Size2" /> is equal to <paramref name="obj" />; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is Size2)
+                return Equals((Size2)obj);
+            return false;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="Size2" /> structures. The result specifies
+        ///     whether the values of the <see cref="Width" /> or <see cref="Height" />
+        ///     fields of the two <see cref="Size2" /> structures are unequal.
+        /// </summary>
+        /// <param name="first">The first size.</param>
+        /// <param name="second">The second size.</param>
+        /// <returns>
+        ///     <c>true</c> if the <see cref="Width" /> or <see cref="Height" />
+        ///     fields of the two <see cref="Size2" /> structures are unequal; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool operator !=(Size2 first, Size2 second)
+        {
+            return !(first == second);
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Size2" /> representing the vector addition of two <see cref="Size2" /> structures as if
+        ///     they
+        ///     were <see cref="Vector2" /> structures.
+        /// </summary>
+        /// <param name="first">The first size.</param>
+        /// <param name="second">The second size.</param>
+        /// <returns>
+        ///     The <see cref="Size2" /> representing the vector addition of two <see cref="Size2" /> structures as if they
+        ///     were <see cref="Vector2" /> structures.
+        /// </returns>
+        public static Size2 operator +(Size2 first, Size2 second)
+        {
+            return Add(first, second);
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Size2" /> representing the vector addition of two <see cref="Size2" /> structures.
+        /// </summary>
+        /// <param name="first">The first size.</param>
+        /// <param name="second">The second size.</param>
+        /// <returns>
+        ///     The <see cref="Size2" /> representing the vector addition of two <see cref="Size2" /> structures.
+        /// </returns>
+        public static Size2 Add(Size2 first, Size2 second)
+        {
+            Size2 size;
+            size.Width = first.Width + second.Width;
+            size.Height = first.Height + second.Height;
+            return size;
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Size2" /> representing the vector subtraction of two <see cref="Size2" /> structures.
+        /// </summary>
+        /// <param name="first">The first size.</param>
+        /// <param name="second">The second size.</param>
+        /// <returns>
+        ///     The <see cref="Size2" /> representing the vector subtraction of two <see cref="Size2" /> structures.
+        /// </returns>
+        public static Size2 operator -(Size2 first, Size2 second)
+        {
+            return Subtract(first, second);
+        }
+
+        /// <summary>
+        ///     Calculates the <see cref="Size2" /> representing the vector subtraction of two <see cref="Size2" /> structures.
+        /// </summary>
+        /// <param name="first">The first size.</param>
+        /// <param name="second">The second size.</param>
+        /// <returns>
+        ///     The <see cref="Size2" /> representing the vector subtraction of two <see cref="Size2" /> structures.
+        /// </returns>
+        public static Size2 Subtract(Size2 first, Size2 second)
+        {
+            Size2 size;
+            size.Width = first.Width - second.Width;
+            size.Height = first.Height - second.Height;
+            return size;
+        }
+
+        /// <summary>
+        ///     Returns a hash code of this <see cref="Size2" /> suitable for use in hashing algorithms and data
+        ///     structures like a hash table.
+        /// </summary>
+        /// <returns>
+        ///     A hash code of this <see cref="Point2" />.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Width.GetHashCode() * 397) ^ Height.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        ///     Performs an implicit conversion from a <see cref="Point2" /> to a <see cref="Size2" />.
+        /// </summary>
+        /// <param name="point">The point.</param>
+        /// <returns>
+        ///     The resulting <see cref="Size2" />.
+        /// </returns>
+        public static implicit operator Size2(Point2 point)
+        {
+            return new Size2(point.X, point.Y);
+        }
+
+        /// <summary>
+        ///     Performs an implicit conversion from a <see cref="Point2" /> to a <see cref="Size2" />.
+        /// </summary>
+        /// <param name="size">The size.</param>
+        /// <returns>
+        ///     The resulting <see cref="Point2" />.
+        /// </returns>
+        public static implicit operator Point2(Size2 size)
+        {
+            return new Point2(size.Width, size.Height);
+        }
+
+        /// <summary>
+        ///     Performs an implicit conversion from a <see cref="Size2" /> to a <see cref="Vector2" />.
+        /// </summary>
+        /// <param name="size">The size.</param>
+        /// <returns>
+        ///     The resulting <see cref="Vector2" />.
+        /// </returns>
+        public static implicit operator Vector2(Size2 size)
+        {
+            return new Vector2(size.Width, size.Height);
+        }
+
+        /// <summary>
+        ///     Performs an implicit conversion from a <see cref="Vector2" /> to a <see cref="Size2" />.
+        /// </summary>
+        /// <param name="vector">The vector.</param>
+        /// <returns>
+        ///     The resulting <see cref="Size2" />.
+        /// </returns>
+        public static implicit operator Size2(Vector2 vector)
+        {
+            return new Size2(vector.X, vector.Y);
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="string" /> that represents this <see cref="Size2" />.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="string" /> that represents this <see cref="Size2" />.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"Width: {Width}, Height: {Height}";
+        }
+
+        internal string DebugDisplayString => ToString();
+    }
+}


### PR DESCRIPTION
Some basic primitives. Includes full documentation along with the unit tests for, every, damn, method and operator.

Primitives: `Point2`, `Size2`, `Segment2D`, `Ray2D`, `BoundingBox2D`.

I added a `Point2` because [technically it is _not_ the same as a `Vector2`](http://math.stackexchange.com/questions/645672/what-is-the-difference-between-a-point-and-a-vector). However, I added all the operators to `Point2` which make sense, including translation by a displacement vector which I would expect would be used most commonly.

`Size2` might not be useful since we already have a `Size` and `SizeF`, but later I'm going to add a `Size3` which would have a base, width and height fields which would be used for a `BoundingBox3D` for example. I added `Size2` just to be consistent with naming.

`Segment2D` and `Ray2D` both use the helper method `RayHelper.IntersectsSlab` for finding the intersection between a `BoundingBox2D`.

Other than that, I also used NUnit`s [TestCaseSource](http://nunit.org/index.php?p=testCaseSource&r=2.5) for the unit tests and added a string name for each test explaining the assertion. These strings become visible in ReSharper's GUI extensions for Visual Studio which is nice.

<img width="1440" alt="screen shot 2016-10-09 at 7 03 57 pm" src="https://cloud.githubusercontent.com/assets/519592/19225557/859133b4-8e53-11e6-9428-8d324fc27c91.png">










