### PR TITLE
Fixed scale for BitmapFont draws

### DIFF
--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontExtensions.cs
@@ -305,6 +305,7 @@ namespace MonoGame.Extended.BitmapFonts
             var dx = position.X;
             var dy = position.Y;
             var codePoints = BitmapFont.GetUnicodeCodePoints(text).ToArray();
+            Vector2 positionOffset = Vector2.Zero;
 
             for (int i = 0, l = codePoints.Length; i < l; i++)
             {
@@ -314,8 +315,14 @@ namespace MonoGame.Extended.BitmapFonts
                 if (fontRegion != null)
                 {
                     var charPosition = new Vector2(dx + fontRegion.XOffset, dy + fontRegion.YOffset);
+                    var scaledCharPosition = charPosition * new Vector2(scale.X, scale.Y);
 
-                    spriteBatch.Draw(fontRegion.TextureRegion, charPosition, color, rotation, origin, scale, effects,
+                    if (i==0)
+                        positionOffset = scaledCharPosition - charPosition;
+
+                    scaledCharPosition -= positionOffset;
+
+                    spriteBatch.Draw(fontRegion.TextureRegion, scaledCharPosition, color, rotation, origin, scale, effects,
                         layerDepth);
 
                     if (i != text.Length - 1)


### PR DESCRIPTION
Hey, here's a little fix for issue #188.

I think the actual scale, doing at an individual letter level, was not really useful, it's much more convenient to have a scale for the full sentence. This way we would require less bitmap fonts to write texts of multiple size in projects.

Here are some examples using the demo :

![untitled](https://cloud.githubusercontent.com/assets/10435246/19284083/bd5c818e-8ff4-11e6-8e6c-984df8264e98.png)
![untitled2](https://cloud.githubusercontent.com/assets/10435246/19284085/bd5ed448-8ff4-11e6-8ae9-d46887887431.png)
![untitled3](https://cloud.githubusercontent.com/assets/10435246/19284084/bd5e068a-8ff4-11e6-9901-e69df477fcd7.png)

I think it should be a great temporary solution before finding one that would also correct the rotation issue, which I haven't investigated yet.

I've directly modified the existing draw, I don't really know if we need both solution for scaling.