### PR TITLE
Removed the X and Y properties keeping Position

### DIFF
--- a/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
@@ -6,12 +6,12 @@ namespace MonoGame.Extended.Maps.Tiled
 {
     public class TiledObject
     {
-        public TiledObject(TiledObjectType objectType,int id,int? gid,float x,float y,float width,float height) : this(objectType,id,gid,width,height)
+        public TiledObject(TiledObjectType objectType, int id, int? gid, float x, float y, float width, float height) : this(objectType,id,gid,width,height)
         {
             Position = new Vector2(x,y);
         }
         
-        public TiledObject(TiledObjectType objectType,int id,int? gid,Vector2 position,float width,float height) : this(objectType,id,gid,width,height)
+        public TiledObject(TiledObjectType objectType, int id, int? gid, Vector2 position, float width, float height) : this(objectType,id,gid,width,height)
         {
             Position = position;
         }

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended.Shapes;
 
@@ -6,13 +6,21 @@ namespace MonoGame.Extended.Maps.Tiled
 {
     public class TiledObject
     {
-        public TiledObject(TiledObjectType objectType, int id, int? gid, float x, float y, float width, float height)
+        public TiledObject(TiledObjectType objectType,int id,int? gid,float x,float y,float width,float height) : this(objectType,id,gid,width,height)
+        {
+            Position = new Vector2(x,y);
+        }
+        
+        public TiledObject(TiledObjectType objectType,int id,int? gid,Vector2 position,float width,float height) : this(objectType,id,gid,width,height)
+        {
+            Position = position;
+        }
+
+        private TiledObject(TiledObjectType objectType, int id, int? gid, float width, float height)
         {
             ObjectType = objectType;
             Id = id;
             Gid = gid;
-            X = x;
-            Y = y;
             Width = width;
             Height = height;
             Points = new List<Vector2>();
@@ -23,11 +31,9 @@ namespace MonoGame.Extended.Maps.Tiled
         public int? Gid { get; }
         public TiledObjectType ObjectType { get; }
         public string Name { get; set; }
-        public float X { get; }
-        public float Y { get; }
         public float Width { get; }
         public float Height { get; }
-        public Vector2 Position => new Vector2(X, Y);
+        public Vector2 Position { get; private set; }
         public SizeF Size => new SizeF(Width, Height);
         public RectangleF BoundingRectangle => new RectangleF(Position, Size);
         public TiledProperties Properties { get; }


### PR DESCRIPTION
I removed the X and Y properties keeping Position property to make things less redundant.
I also added another constructor that takes a Vector2 position directly.

edit: I wanted to fix the spacing a bit in the 2nd commit, but I totally forgot to write a good message...