### PR TITLE
PolygonF position

### DIFF
--- a/Source/MonoGame.Extended.Tests/Shapes/PolygonFTests.cs
+++ b/Source/MonoGame.Extended.Tests/Shapes/PolygonFTests.cs
@@ -18,7 +18,8 @@ namespace MonoGame.Extended.Tests.Shapes
                 new Vector2(0, 10)
             };
 
-            var polygon = new PolygonF(vertices);
+            var position = new Vector2(0,0);
+            var polygon = new PolygonF(position,vertices);
 
             Assert.IsTrue(polygon.Contains(new Vector2(5, 5)));
             Assert.IsTrue(polygon.Contains(new Vector2(0.01f, 0.01f)));
@@ -38,7 +39,9 @@ namespace MonoGame.Extended.Tests.Shapes
                 new Vector2(0, 10)
             };
 
-            var polygon = new PolygonF(vertices);
+            var position = new Vector2(0,0);
+
+            var polygon = new PolygonF(position,vertices);
             polygon.Offset(new Vector2(2, 3));
 
             Assert.AreEqual(new Vector2(2, 3), polygon.Vertices[0]);
@@ -57,7 +60,9 @@ namespace MonoGame.Extended.Tests.Shapes
                 new Vector2(-5, 10)
             };
 
-            var polygon = new PolygonF(vertices);
+            var position = new Vector2(0,0);
+
+            var polygon = new PolygonF(position, vertices);
             polygon.Rotate(MathHelper.ToRadians(90));
 
             const float tolerance = 0.01f;
@@ -76,7 +81,9 @@ namespace MonoGame.Extended.Tests.Shapes
                 new Vector2(-1, 1)
             };
 
-            var polygon = new PolygonF(vertices);
+            var position = new Vector2(0,0);
+
+            var polygon = new PolygonF(position,vertices);
             polygon.Scale(new Vector2(1, -0.5f));
 
             const float tolerance = 0.01f;

--- a/Source/MonoGame.Extended/Shapes/PolygonF.cs
+++ b/Source/MonoGame.Extended/Shapes/PolygonF.cs
@@ -7,7 +7,11 @@ namespace MonoGame.Extended.Shapes
 {
     public struct PolygonF : IShapeF, IEquatable<PolygonF>
     {
-        public PolygonF (IEnumerable<Vector2> vertices)
+        public PolygonF (float x, float y,IEnumerable<Vector2> vertices) : this(new Vector2(x,y), vertices)
+        {
+        }
+
+        public PolygonF (Vector2 location, IEnumerable<Vector2> vertices)
         {
             _localVertices = vertices.ToArray();
             _transformedVertices = _localVertices;
@@ -15,6 +19,7 @@ namespace MonoGame.Extended.Shapes
             _rotation = 0;
             _scale = Vector2.One;
             _isDirty = false;
+            Location = location;
         }
 
         private readonly Vector2[] _localVertices;
@@ -23,6 +28,8 @@ namespace MonoGame.Extended.Shapes
         private float _rotation;
         private Vector2 _scale;
         private bool _isDirty;
+
+        public Vector2 Location { get; set; }
 
         public Vector2[] Vertices
         {
@@ -89,11 +96,11 @@ namespace MonoGame.Extended.Shapes
 
         public PolygonF TransformedCopy(Vector2 offset, float rotation, Vector2 scale)
         {
-            var polygon = new PolygonF(_localVertices);
+            var polygon = new PolygonF(Location,_localVertices);
             polygon.Offset(offset);
             polygon.Rotate(rotation);
             polygon.Scale(scale - Vector2.One);
-            return new PolygonF(polygon.Vertices);
+            return new PolygonF(Location,polygon.Vertices);
         }
 
         public RectangleF BoundingRectangle

--- a/Source/MonoGame.Extended/Shapes/SpriteBatchExtensions.cs
+++ b/Source/MonoGame.Extended/Shapes/SpriteBatchExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
@@ -31,9 +31,9 @@ namespace MonoGame.Extended.Shapes
         /// <param name="polygon">The polygon to draw</param>
         /// <param name="color">The color to use</param>
         /// <param name="thickness">The thickness of the lines</param>
-        public static void DrawPolygon(this SpriteBatch spriteBatch, Vector2 position, PolygonF polygon, Color color, float thickness = 1f)
+        public static void DrawPolygon(this SpriteBatch spriteBatch, PolygonF polygon, Color color, float thickness = 1f)
         {
-            DrawPolygon(spriteBatch, position, polygon.Vertices, color, thickness);
+            DrawPolygon(spriteBatch, polygon.Location, polygon.Vertices, color, thickness);
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed that both RectangleF and CircleF had positions (well, they were called location) and that PolygonF did not. I needed the position in PolygonF for my game so I added the changes for myself.

I'm not sure if this is a good idea or not for the library but I though it could be useful. If it's not something that you want done for any reason whatsoever just reject the pull request, it's all fine. Anyway this is a great library just though I would share what I added for myself.

edit: I did think about just making the first `IEnumerable<Vector2>` value the position but I though that would complicate everything while confusing everyone in the process.

edit: turns out this might be a bad idea, going to close this.