### PR TITLE
Precalculate tilecount per tileset when TiledTileLayer is created

### DIFF
--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
@@ -185,22 +185,17 @@ namespace MonoGame.Extended.Maps.Tiled
 
                 foreach (var layer in _layers)
                 {
-
-
-                    var tiledTileLayer = layer as TiledTileLayer;
-
-                    if (tiledTileLayer != null)
+                    if (layer is TiledTileLayer)
                     {
-                        var tileLayer = tiledTileLayer;
+                        var tileLayer = layer as TiledTileLayer;
                         var indexCount = 6;
                         var primitivesCount = 2;
 
                         if (tileLayer.IsVisible)
                         {
-
                             foreach (var tileset in _tilesets)
                             {
-                                var tilesToDraw = tiledTileLayer.Tiles.Count(x => tileset.Equals(GetTileSetByTileId(x.Id)));
+                                var tilesToDraw = tileLayer.Tiles.Count(x => tileset.Equals(GetTileSetByTileId(x.Id)));
 
                                 if (tilesToDraw > 0)
                                 {
@@ -208,12 +203,20 @@ namespace MonoGame.Extended.Maps.Tiled
                                         _basicEffect.Texture = tileset.Texture;
 
                                     pass.Apply();
-                                    _graphicsDevice.DrawIndexedPrimitives(
-                                        primitiveType: PrimitiveType.TriangleList,
-                                        baseVertex: 0,
-                                        startIndex: tilesIndexesSoFar,
-                                        primitiveCount: primitivesCount * tilesToDraw
-                                    );
+
+                                    int baseVert = 0;
+
+                                    do
+                                    {
+                                        _graphicsDevice.DrawIndexedPrimitives(
+                                            primitiveType: PrimitiveType.TriangleList,
+                                            baseVertex: baseVert,
+                                            startIndex: tilesIndexesSoFar,
+                                            primitiveCount: primitivesCount * tilesToDraw
+                                        );
+                                        baseVert += ushort.MaxValue + 1;
+                                    } while (baseVert < _tilesVertices.Length);
+
                                     tilesIndexesSoFar += indexCount * tilesToDraw;
                                 }
                             }

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
@@ -195,7 +195,7 @@ namespace MonoGame.Extended.Maps.Tiled
                         {
                             foreach (var tileset in _tilesets)
                             {
-                                var tilesToDraw = tileLayer.Tiles.Count(x => tileset.Equals(GetTileSetByTileId(x.Id)));
+                                var tilesToDraw = tileLayer.GetTileCountForTileset(tileset);
 
                                 if (tilesToDraw > 0)
                                 {

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
@@ -35,6 +35,7 @@ namespace MonoGame.Extended.Maps.Tiled
         private RenderTarget2D _renderTarget;
         private readonly List<TiledTile> _animatedTiles;
         private List<TiledTileSetTile> _uniqueTileSetTiles = new List<TiledTileSetTile>();
+        private readonly Dictionary<TiledTileset, int> tileCountByTileset = new Dictionary<TiledTileset, int>();
 
         public VertexPositionTexture[] Vertices { get; private set; }
         public int NotBlankTilesCount { get; private set; }
@@ -59,6 +60,14 @@ namespace MonoGame.Extended.Maps.Tiled
                     for (tilesetIndex = tilesets.Count - 1; tilesetIndex > 0; tilesetIndex--)
                         if (tilesets[tilesetIndex].FirstId <= data[tileDataIndex])
                             break;
+
+                    TiledTileset ts = tilesets[tilesetIndex];
+                    if (!this.tileCountByTileset.ContainsKey(ts))
+                    {
+                        this.tileCountByTileset[ts] = 0;
+                    }
+
+                    this.tileCountByTileset[ts]++;
 
                     tiles.ElementAt(tilesetIndex).Add(new TiledTile(data[tileDataIndex], x, y, _map.GetTileSetTileById(data[tileDataIndex])));
                     tileDataIndex++;
@@ -115,6 +124,16 @@ namespace MonoGame.Extended.Maps.Tiled
             }
             Vertices = verticesList.ToArray();
             return Vertices;
+        }
+
+        public int GetTileCountForTileset(TiledTileset tileset)
+        {
+            if(!this.tileCountByTileset.ContainsKey(tileset))
+            {
+                return 0;
+            }
+
+            return this.tileCountByTileset[tileset];
         }
 
         public override void Draw(SpriteBatch spriteBatch, Rectangle? visibleRectangle = null, Color? backgroundColor = null, GameTime gameTime = null)

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
@@ -35,7 +35,7 @@ namespace MonoGame.Extended.Maps.Tiled
         private RenderTarget2D _renderTarget;
         private readonly List<TiledTile> _animatedTiles;
         private List<TiledTileSetTile> _uniqueTileSetTiles = new List<TiledTileSetTile>();
-        private readonly Dictionary<TiledTileset, int> tileCountByTileset = new Dictionary<TiledTileset, int>();
+        private readonly Dictionary<TiledTileset, int> _tileCountByTileset = new Dictionary<TiledTileset, int>();
 
         public VertexPositionTexture[] Vertices { get; private set; }
         public int NotBlankTilesCount { get; private set; }
@@ -62,12 +62,12 @@ namespace MonoGame.Extended.Maps.Tiled
                             break;
 
                     TiledTileset ts = tilesets[tilesetIndex];
-                    if (!this.tileCountByTileset.ContainsKey(ts))
+                    if (!_tileCountByTileset.ContainsKey(ts))
                     {
-                        this.tileCountByTileset[ts] = 0;
+                        _tileCountByTileset[ts] = 0;
                     }
 
-                    this.tileCountByTileset[ts]++;
+                    _tileCountByTileset[ts]++;
 
                     tiles.ElementAt(tilesetIndex).Add(new TiledTile(data[tileDataIndex], x, y, _map.GetTileSetTileById(data[tileDataIndex])));
                     tileDataIndex++;
@@ -128,12 +128,12 @@ namespace MonoGame.Extended.Maps.Tiled
 
         public int GetTileCountForTileset(TiledTileset tileset)
         {
-            if(!this.tileCountByTileset.ContainsKey(tileset))
+            if(!_tileCountByTileset.ContainsKey(tileset))
             {
                 return 0;
             }
 
-            return this.tileCountByTileset[tileset];
+            return _tileCountByTileset[tileset];
         }
 
         public override void Draw(SpriteBatch spriteBatch, Rectangle? visibleRectangle = null, Color? backgroundColor = null, GameTime gameTime = null)


### PR DESCRIPTION
The calculation of how many tiles were being drawn was being done (EffectPassesCount \* LayerCount \* TilesetCount) times each time the map was being drawn.  For small maps this wasn't a big deal but for larger maps such as the 500x500 untitled.tmx map storing the counts at the TiledTileLayer level took my FPS from ~37 to ~90 FPS.  Also tested against level01/02/03 and Platformer demo but those maps were too small to see any improvement.
