### PR TITLE
Only draw tiles that actually exist for each tileset/layer combination

### DIFF
--- a/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledMap.cs
@@ -37,11 +37,6 @@ namespace MonoGame.Extended.Maps.Tiled
         private readonly List<TiledTileset> _tilesets;
         private readonly List<TiledObjectGroup> _objectGroups;
 
-        private VertexBuffer _tilesVertexBuffer;
-        private IndexBuffer _tilesIndexBuffer;
-        private VertexPositionTexture[] _tilesVertices;
-        private short[] _tilesIndexes;
-
         private readonly DepthStencilState _depthBufferState;
         //private Matrix _worldMatrix;
         //private Matrix _viewMatrix;
@@ -95,41 +90,15 @@ namespace MonoGame.Extended.Maps.Tiled
 
         public TiledMap Build()
         {
-            var tileVertices = new List<VertexPositionTexture>();
-            var tileIndexes = new List<short>();
             var tileLayers = _layers.OfType<TiledTileLayer>().ToArray();
             var depth = 0f;
             var depthInc = 1.0f / (_layers.Count - 1);
-            var indexOffset = 0;
 
             foreach (var layer in tileLayers)
             {
-                var vertices = layer.BuildVertices(depth);
-                tileVertices.AddRange(vertices);
-                var tilesCount = layer.Tiles.Where(x => x.Id != 0).ToList().Count;
-
-                for (var i = 0; i < tilesCount; i++)
-                {
-                    var thisTileIndexes = new short[6];
-                    thisTileIndexes[0] = (short)(4 * indexOffset);
-                    thisTileIndexes[1] = (short)(4 * indexOffset + 1);
-                    thisTileIndexes[2] = (short)(4 * indexOffset + 2);
-                    thisTileIndexes[3] = (short)(4 * indexOffset + 1);
-                    thisTileIndexes[4] = (short)(4 * indexOffset + 3);
-                    thisTileIndexes[5] = (short)(4 * indexOffset + 2);
-                    tileIndexes.AddRange(thisTileIndexes);
-                    indexOffset++;
-                }
-
+                layer.BuildVertices(_graphicsDevice, depth);
                 depth -= depthInc;
             }
-
-            _tilesVertices = tileVertices.ToArray();
-            _tilesIndexes = tileIndexes.ToArray();
-            _tilesVertexBuffer = new VertexBuffer(_graphicsDevice, typeof(VertexPositionTexture), _tilesVertices.Length, BufferUsage.WriteOnly);
-            _tilesIndexBuffer = new IndexBuffer(_graphicsDevice, typeof(short), _tilesIndexes.Length, BufferUsage.WriteOnly);
-            _tilesVertexBuffer.SetData(_tilesVertices);
-            _tilesIndexBuffer.SetData(_tilesIndexes);
 
             //_highestZ = _layers.Max(layer => layer.Depth) + 1;
 
@@ -173,8 +142,6 @@ namespace MonoGame.Extended.Maps.Tiled
             _basicEffect.Projection = Matrix.CreateOrthographicOffCenter(left: 0, right: _graphicsDevice.Viewport.Width,
                 bottom: _graphicsDevice.Viewport.Height, top: 0, zNearPlane: 0f, zFarPlane: -1f);
 
-            _graphicsDevice.SetVertexBuffer(_tilesVertexBuffer);
-            _graphicsDevice.Indices = _tilesIndexBuffer;
             _graphicsDevice.DepthStencilState = _depthBufferState;
             _graphicsDevice.BlendState = BlendState.AlphaBlend;
             _graphicsDevice.SamplerStates[0] = SamplerState.PointClamp;
@@ -195,7 +162,15 @@ namespace MonoGame.Extended.Maps.Tiled
                         {
                             foreach (var tileset in _tilesets)
                             {
-                                var tilesToDraw = tileLayer.GetTileCountForTileset(tileset);
+                                TiledRenderDetails renderDetails = tileLayer.GetRenderDetailsForTileset(tileset);
+                                if (renderDetails == null)
+                                {
+                                    continue;
+                                }
+
+                                var tilesToDraw = renderDetails.TileCount;
+                                _graphicsDevice.SetVertexBuffer(renderDetails.VertexBuffer);
+                                _graphicsDevice.Indices = renderDetails.IndexBuffer;
 
                                 if (tilesToDraw > 0)
                                 {
@@ -211,11 +186,11 @@ namespace MonoGame.Extended.Maps.Tiled
                                         _graphicsDevice.DrawIndexedPrimitives(
                                             primitiveType: PrimitiveType.TriangleList,
                                             baseVertex: baseVert,
-                                            startIndex: tilesIndexesSoFar,
+                                            startIndex: 0,
                                             primitiveCount: primitivesCount * tilesToDraw
                                         );
                                         baseVert += ushort.MaxValue + 1;
-                                    } while (baseVert < _tilesVertices.Length);
+                                    } while (baseVert < renderDetails.VertexBuffer.VertexCount);
 
                                     tilesIndexesSoFar += indexCount * tilesToDraw;
                                 }

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledRenderDetails.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledRenderDetails.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.Xna.Framework.Graphics;
+
+namespace MonoGame.Extended.Maps.Tiled
+{
+    public class TiledRenderDetails
+    {
+        public TiledRenderDetails(GraphicsDevice gd, int tileCount, List<VertexPositionTexture> vertices, List<short> indexes)
+        {
+            TileCount = tileCount;
+
+            VertexBuffer = new VertexBuffer(gd, typeof(VertexPositionTexture), vertices.Count, BufferUsage.WriteOnly);
+            VertexBuffer.SetData(vertices.ToArray());
+            IndexBuffer = new IndexBuffer(gd, typeof(short), indexes.Count, BufferUsage.WriteOnly);
+            IndexBuffer.SetData(indexes.ToArray());
+        }
+
+        public int TileCount { get; set; }
+        public VertexBuffer VertexBuffer { get; set; }
+        public IndexBuffer IndexBuffer { get; set; }
+    }
+}

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledRenderDetails.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledRenderDetails.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
-
 using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.Maps.Tiled
 {
     public class TiledRenderDetails
     {
-        public TiledRenderDetails(GraphicsDevice gd, int tileCount, List<VertexPositionTexture> vertices, List<short> indexes)
+        public TiledRenderDetails(GraphicsDevice gd, int tileCount, List<VertexPositionTexture> vertices, List<ushort> indexes)
         {
             TileCount = tileCount;
 

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
@@ -141,17 +141,17 @@ namespace MonoGame.Extended.Maps.Tiled
                 }
 
                 int indexOffset = 0;
-                List<short> tileIndexes = new List<short>();
+                List<ushort> tileIndexes = new List<ushort>();
 
                 for (var i = 0; i < tilesCount; i++)
                 {
-                    var thisTileIndexes = new short[6];
-                    thisTileIndexes[0] = (short) (4 * indexOffset);
-                    thisTileIndexes[1] = (short) (4 * indexOffset + 1);
-                    thisTileIndexes[2] = (short) (4 * indexOffset + 2);
-                    thisTileIndexes[3] = (short) (4 * indexOffset + 1);
-                    thisTileIndexes[4] = (short) (4 * indexOffset + 3);
-                    thisTileIndexes[5] = (short) (4 * indexOffset + 2);
+                    var thisTileIndexes = new ushort[6];
+                    thisTileIndexes[0] = (ushort) (4 * indexOffset);
+                    thisTileIndexes[1] = (ushort) (4 * indexOffset + 1);
+                    thisTileIndexes[2] = (ushort) (4 * indexOffset + 2);
+                    thisTileIndexes[3] = (ushort) (4 * indexOffset + 1);
+                    thisTileIndexes[4] = (ushort) (4 * indexOffset + 3);
+                    thisTileIndexes[5] = (ushort) (4 * indexOffset + 2);
                     tileIndexes.AddRange(thisTileIndexes);
                     indexOffset++;
                 }

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledTileLayer.cs
@@ -36,8 +36,8 @@ namespace MonoGame.Extended.Maps.Tiled
         private readonly List<TiledTile> _animatedTiles;
         private List<TiledTilesetTile> _uniqueTilesetTiles = new List<TiledTilesetTile>();
         private readonly Dictionary<TiledTileset, int> _tileCountByTileset = new Dictionary<TiledTileset, int>();
+        private readonly Dictionary<TiledTileset, TiledRenderDetails> _detailsByTileset = new Dictionary<TiledTileset, TiledRenderDetails>();
 
-        public VertexPositionTexture[] Vertices { get; private set; }
         public int NotBlankTilesCount { get; private set; }
 
         public IEnumerable<TiledTile> Tiles => _tiles;
@@ -67,7 +67,10 @@ namespace MonoGame.Extended.Maps.Tiled
                         _tileCountByTileset[ts] = 0;
                     }
 
-                    _tileCountByTileset[ts]++;
+                    if (data[tileDataIndex] != 0)
+                    {
+                        _tileCountByTileset[ts]++;
+                    }
 
                     tiles.ElementAt(tilesetIndex).Add(new TiledTile(data[tileDataIndex], x, y, _map.GetTilesetTileById(data[tileDataIndex])));
                     tileDataIndex++;
@@ -87,10 +90,8 @@ namespace MonoGame.Extended.Maps.Tiled
             return tileData;
         }
 
-        internal VertexPositionTexture[] BuildVertices(float depth)
+        internal void BuildVertices(GraphicsDevice gd, float depth)
         {
-            var verticesList = new List<VertexPositionTexture>();
-
             var vr = new Rectangle(0, 0, _map.WidthInPixels, _map.HeightInPixels);
             var firstCol = vr.Left < 0 ? 0 : (int)Math.Floor(vr.Left / (float)_map.TileWidth);
             var firstRow = vr.Top < 0 ? 0 : (int)Math.Floor(vr.Top / (float)_map.TileHeight);
@@ -98,6 +99,9 @@ namespace MonoGame.Extended.Maps.Tiled
             var rows = Math.Min(_map.Height, vr.Height / _map.TileHeight);
             var renderOrderFunc = GetRenderOrderFunction();
             var tiles = renderOrderFunc(firstCol, firstRow, firstCol + columns, firstRow + rows);
+
+            Dictionary<TiledTileset, List<VertexPositionTexture>> verticesByTileset =
+                _map.Tilesets.ToDictionary(ts => ts, ts => new List<VertexPositionTexture>());
 
             foreach (var tile in tiles)
             {
@@ -120,20 +124,50 @@ namespace MonoGame.Extended.Maps.Tiled
                 vertices[1] = new VertexPositionTexture(new Vector3(point.X + tileWidth, point.Y, depth), new Vector2(tc1.X, tc0.Y));
                 vertices[2] = new VertexPositionTexture(new Vector3(point.X, point.Y + tileHeight, depth), new Vector2(tc0.X, tc1.Y));
                 vertices[3] = new VertexPositionTexture(new Vector3(point.X + tileWidth, point.Y + tileHeight, depth), tc1);
-                verticesList.AddRange(vertices);
+
+                TiledTileset tileSet = _map.Tilesets.FirstOrDefault(ts=>ts.Texture == region.Texture);
+                if (tileSet != null)
+                {
+                    verticesByTileset[tileSet].AddRange(vertices);
+                }
             }
-            Vertices = verticesList.ToArray();
-            return Vertices;
+
+            foreach (TiledTileset ts in _map.Tilesets)
+            {
+                int tilesCount;
+                if (!_tileCountByTileset.TryGetValue(ts, out tilesCount) || tilesCount == 0)
+                {
+                    continue;
+                }
+
+                int indexOffset = 0;
+                List<short> tileIndexes = new List<short>();
+
+                for (var i = 0; i < tilesCount; i++)
+                {
+                    var thisTileIndexes = new short[6];
+                    thisTileIndexes[0] = (short) (4 * indexOffset);
+                    thisTileIndexes[1] = (short) (4 * indexOffset + 1);
+                    thisTileIndexes[2] = (short) (4 * indexOffset + 2);
+                    thisTileIndexes[3] = (short) (4 * indexOffset + 1);
+                    thisTileIndexes[4] = (short) (4 * indexOffset + 3);
+                    thisTileIndexes[5] = (short) (4 * indexOffset + 2);
+                    tileIndexes.AddRange(thisTileIndexes);
+                    indexOffset++;
+                }
+
+                _detailsByTileset[ts] = new TiledRenderDetails(gd, tilesCount, verticesByTileset[ts], tileIndexes);
+            }
         }
 
-        public int GetTileCountForTileset(TiledTileset tileset)
+        public TiledRenderDetails GetRenderDetailsForTileset(TiledTileset tileset)
         {
-            if(!_tileCountByTileset.ContainsKey(tileset))
+            if (!_detailsByTileset.ContainsKey(tileset))
             {
-                return 0;
+                return null;
             }
 
-            return _tileCountByTileset[tileset];
+            return _detailsByTileset[tileset];
         }
 
         public override void Draw(SpriteBatch spriteBatch, Rectangle? visibleRectangle = null, Color? backgroundColor = null, GameTime gameTime = null)

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Compile Include="Animations\Animation.cs" />
     <Compile Include="Animations\AnimationComponent.cs" />
+    <Compile Include="Maps\Tiled\TiledRenderDetails.cs" />
     <Compile Include="Primitives\BoundingRectangle.cs" />
     <Compile Include="Primitives\Point2.cs" />
     <Compile Include="Primitives\Ray2D.cs" />


### PR DESCRIPTION
One more performance optimization for Tiled map rendering (I don't think there's anymore low-hanging fruit in terms of performance).  I noticed that for any map (lets say 100x100 tiles for example) we were drawing 10,000 tiles for each tileset/layer combination even if the tile was blank.  Considering most layers beyond the "base" layer usually have more blank tiles than visible tiles, this is a huge waste.

By only drawing tiles for those that existed I was able to improve the FPS on my machine for untitled.tmx (500x500) from ~90 to ~1,100 FPS.  The vertices/indexes for DrawIndexedPrimatives are saved in a new class TiledRenderDetails on each layer at layer creation and fetched during TiledMap.Draw.

I've tested these changes on the Platformer and TiledTileMap demos.