### PR TITLE
Made BitmapFont ctr public

### DIFF
--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -8,7 +8,7 @@ namespace MonoGame.Extended.BitmapFonts
 {
     public class BitmapFont
     {
-        internal BitmapFont(string name, IEnumerable<BitmapFontRegion> regions, int lineHeight)
+        public BitmapFont(string name, IEnumerable<BitmapFontRegion> regions, int lineHeight)
         {
             _characterMap = regions.ToDictionary(r => r.Character);
 


### PR DESCRIPTION
I'm not using the MonoGame content pipeline, so i need the contructor to be public to be able to manually load a BitmapFont from file