### PR TITLE
Implemented animated tiles

### DIFF
--- a/Source/Demos/Demo.TiledMaps/Game1.cs
+++ b/Source/Demos/Demo.TiledMaps/Game1.cs
@@ -83,6 +83,7 @@ namespace Demo.TiledMaps
             var keyboardState = Keyboard.GetState();
             var mouseState = Mouse.GetState();
 
+            _mapRenderer.Update(gameTime);
             if (keyboardState.IsKeyDown(Keys.Escape))
                 Exit();
 

--- a/Source/MonoGame.Extended/Maps/Renderers/DynamicGroupRenderDetails.cs
+++ b/Source/MonoGame.Extended/Maps/Renderers/DynamicGroupRenderDetails.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.Maps.Tiled;
+
+namespace MonoGame.Extended.Maps.Renderers {
+    class DynamicGroupRenderDetails : GroupRenderDetails
+    {
+        public List<TiledTile> Tiles;
+
+        public DynamicGroupRenderDetails(GraphicsDevice gd, IEnumerable<VertexPositionTexture> vertices, IEnumerable<ushort> indexes, Texture2D texture, List<TiledTile> tiles) : base(gd, vertices, indexes, texture)
+        {
+            Tiles = tiles;
+            TileCount = tiles.Count;
+        }
+    }
+}

--- a/Source/MonoGame.Extended/Maps/Renderers/FullMapRenderer.cs
+++ b/Source/MonoGame.Extended/Maps/Renderers/FullMapRenderer.cs
@@ -58,6 +58,19 @@ namespace MonoGame.Extended.Maps.Renderers
             };
         }
 
+        public void Update(GameTime gameTime)
+        {
+            foreach(var tileset in _map.Tilesets)
+            {
+                foreach(var tile in tileset.Tiles)
+                {
+                    tile.Update(gameTime.ElapsedGameTime.Milliseconds);
+                }
+            }
+
+            RebuildDynamicRenderDetails();
+        }
+
         [Obsolete]
         public void Draw(Camera2D camera)
         {
@@ -137,9 +150,8 @@ namespace MonoGame.Extended.Maps.Renderers
                     ushort[] indexes;
                     CreatePrimitives(point, region, 0, layer.Depth, out vertices, out indexes);
 
-                    var group = new GroupRenderDetails(region.Texture, 1);
-                    group.SetVertices(vertices, _graphicsDevice);
-                    group.SetIndexes(indexes, _graphicsDevice);
+                    var group = new GroupRenderDetails(_graphicsDevice, vertices, indexes, region.Texture, 1);
+                    group.SetIndexes(indexes);
                     group.Opacity = layer.Opacity;
 
                     mapDetails.AddGroup(group);
@@ -155,7 +167,7 @@ namespace MonoGame.Extended.Maps.Renderers
                         o => o.ObjectType != TiledObjectType.Tile || !o.IsVisible || !o.Gid.HasValue;
 
                     var groups =
-                        CreateGroupsByTileset(objectGroup.Objects.Reverse(), objectGroup, f, o => o.Gid.Value,
+                        CreateGroupsByTileset(objectGroup.Objects.Reverse(), objectGroup, f, o => o.Gid.Value, o => false,
                             o => (o.Position - new Vector2(0, o.Height)).ToPoint(), o => new SizeF(o.Width, o.Height));
 
                     foreach (var g in groups)
@@ -166,8 +178,7 @@ namespace MonoGame.Extended.Maps.Renderers
                 else if (tileLayer != null)
                 {
                     var groups =
-                        CreateGroupsByTileset(GetTilesGroupedByTileset(tileLayer), tileLayer, t => t.IsBlank, t => t.Id,
-                            t => tileLayer.GetTileLocation(t));
+                        CreateGroupsByTileset(GetTilesGroupedByTileset(tileLayer), tileLayer, t => t.IsBlank, t => t.Id, t => t.HasAnimation, t => tileLayer.GetTileLocation(t));
 
                     foreach (var g in groups)
                     {
@@ -177,6 +188,58 @@ namespace MonoGame.Extended.Maps.Renderers
             }
 
             return mapDetails;
+        }
+
+        public void RebuildDynamicRenderDetails()
+        {
+            VertexPositionTexture[] vertices = new VertexPositionTexture[4];
+
+            Vector2 camPosition = Vector2.Negate(Vector2.Transform(Vector2.Zero, _basicEffect.View)); 
+            Rectangle camViewport = new Rectangle((int) camPosition.X, (int) camPosition.Y, _graphicsDevice.Viewport.Width, _graphicsDevice.Viewport.Height);
+
+            foreach (var renderDetails in _currentRenderDetails)
+            {
+                DynamicGroupRenderDetails dynamicRenderDetails = renderDetails as DynamicGroupRenderDetails;
+                if (dynamicRenderDetails == null || dynamicRenderDetails.TileCount == 0)
+                    continue;
+
+                List<VertexPositionTexture> updatedVertices = new List<VertexPositionTexture>(dynamicRenderDetails.TileCount * 4);
+                for (int i = 0; i < dynamicRenderDetails.TileCount; i++)
+                {
+                    TiledTile tile = dynamicRenderDetails.Tiles[i];
+
+                    vertices[0] = dynamicRenderDetails.Vertices[i * 4];
+                    vertices[1] = dynamicRenderDetails.Vertices[i * 4 + 1];
+                    vertices[2] = dynamicRenderDetails.Vertices[i * 4 + 2];
+                    vertices[3] = dynamicRenderDetails.Vertices[i * 4 + 3];
+
+                    if (
+                        camViewport.Contains(new Rectangle(tile.X*_map.TileWidth, tile.Y*_map.TileHeight, _map.TileWidth,
+                            _map.TileHeight)))
+                    {
+                        TiledTileset tileset = _map.GetTilesetByTileId(tile.Id);
+                        int? tileId = tile.TilesetTile.CurrentTileId + 1;
+                        if (tileId == null)
+                            tileId = tile.CurrentTileId;
+
+                        var region = tileset.GetTileRegion((int) tileId);
+                        Vector2 tc0, tc1;
+                        tc0.X = (region.X + 0.5f) / region.Texture.Width;
+                        tc0.Y = (region.Y + 0.5f) / region.Texture.Height;
+                        tc1.X = (float)(region.X + region.Width) / region.Texture.Width;
+                        tc1.Y = (float)(region.Y + region.Height) / region.Texture.Height;
+
+
+                        vertices[0].TextureCoordinate = tc0;
+                        vertices[1].TextureCoordinate = new Vector2(tc1.X, tc0.Y);
+                        vertices[2].TextureCoordinate = new Vector2(tc0.X, tc1.Y);
+                        vertices[3].TextureCoordinate = tc1;
+                    }
+
+                    updatedVertices.AddRange(vertices);
+                }
+                dynamicRenderDetails.SetVertices(updatedVertices);
+            }
         }
 
         protected virtual List<TiledTile> GetTilesGroupedByTileset(TiledTileLayer layer)
@@ -205,14 +268,22 @@ namespace MonoGame.Extended.Maps.Renderers
         }
 
         protected virtual IEnumerable<GroupRenderDetails> CreateGroupsByTileset<T>(IEnumerable<T> objs, TiledLayer layer,
-            Func<T, bool> filterOut, Func<T, int> getTileId, Func<T, Point> getPosition, Func<T, SizeF> getSize = null)
-        {
-            var verticesByTileset =
+            Func<T, bool> filterOut, Func<T, int> getTileId, Func<T, bool> hasAnimation, Func<T, Point> getPosition, Func<T, SizeF> getSize = null) {
+            var staticVerticesByTileset =
                 _map.Tilesets.ToDictionary(ts => ts, ts => new List<VertexPositionTexture>());
-            var indexesByTileset =
+            var staticIndexesByTileset =
                 _map.Tilesets.ToDictionary(ts => ts, ts => new List<ushort>());
-            var tileCountByTileset =
+            var staticTileCountByTileset =
                 _map.Tilesets.ToDictionary(ts => ts, ts => 0);
+
+            var dynamicVerticesByTileset =
+                _map.Tilesets.ToDictionary(ts => ts, ts => new List<VertexPositionTexture>());
+            var dynamicIndexesByTileset =
+                _map.Tilesets.ToDictionary(ts => ts, ts => new List<ushort>());
+            var dynamicTileCountByTileset =
+                _map.Tilesets.ToDictionary(ts => ts, ts => 0);
+
+            List<TiledTile> animatedTiles = new List<TiledTile>();
 
             foreach (T obj in objs)
             {
@@ -229,29 +300,54 @@ namespace MonoGame.Extended.Maps.Renderers
 
                 VertexPositionTexture[] vertices;
                 ushort[] indexes;
-                CreatePrimitives(point, region, tileCountByTileset[tileset], layer.Depth,
-                    out vertices, out indexes, getSize?.Invoke(obj));
 
-                verticesByTileset[tileset].AddRange(vertices);
-                indexesByTileset[tileset].AddRange(indexes);
-                tileCountByTileset[tileset]++;
+                if (hasAnimation(obj))
+                {
+                    CreatePrimitives(point, region, dynamicTileCountByTileset[tileset], layer.Depth,
+                        out vertices, out indexes, getSize?.Invoke(obj));
+
+                    dynamicVerticesByTileset[tileset].AddRange(vertices);
+                    dynamicIndexesByTileset[tileset].AddRange(indexes);
+                    dynamicTileCountByTileset[tileset]++;
+                    animatedTiles.Add(obj as TiledTile);
+                }
+                else
+                {
+                    CreatePrimitives(point, region, staticTileCountByTileset[tileset], layer.Depth,
+                        out vertices, out indexes, getSize?.Invoke(obj));
+
+                    staticVerticesByTileset[tileset].AddRange(vertices);
+                    staticIndexesByTileset[tileset].AddRange(indexes);
+                    staticTileCountByTileset[tileset]++;
+                }
             }
 
             var groups = new List<GroupRenderDetails>();
 
             foreach (var tileset in _map.Tilesets)
             {
-                if (tileCountByTileset[tileset] == 0)
+                if (staticTileCountByTileset[tileset] == 0)
                 {
                     continue;
                 }
 
-                var group = new GroupRenderDetails(tileset.Texture, tileCountByTileset[tileset]);
-                group.SetVertices(verticesByTileset[tileset], _graphicsDevice);
-                group.SetIndexes(indexesByTileset[tileset], _graphicsDevice);
-                group.Opacity = layer.Opacity;
+                var staticGroup = new GroupRenderDetails(_graphicsDevice, staticVerticesByTileset[tileset], staticIndexesByTileset[tileset], tileset.Texture, staticTileCountByTileset[tileset]);
+                staticGroup.Opacity = layer.Opacity;
 
-                groups.Add(group);
+                groups.Add(staticGroup);
+
+
+
+                if (dynamicTileCountByTileset[tileset] == 0)
+                {
+                    continue;
+                }
+
+                var dynamicGroup = new DynamicGroupRenderDetails(_graphicsDevice, dynamicVerticesByTileset[tileset], dynamicIndexesByTileset[tileset], tileset.Texture, animatedTiles);
+                dynamicGroup.Opacity = layer.Opacity;
+
+                groups.Add(dynamicGroup);
+
             }
 
             return groups;

--- a/Source/MonoGame.Extended/Maps/Renderers/GroupRenderDetails.cs
+++ b/Source/MonoGame.Extended/Maps/Renderers/GroupRenderDetails.cs
@@ -6,37 +6,37 @@ namespace MonoGame.Extended.Maps.Renderers
 {
     public class GroupRenderDetails
     {
-        public GroupRenderDetails(Texture2D texture)
-        {
+        public GroupRenderDetails(GraphicsDevice gd, IEnumerable<VertexPositionTexture> vertices, IEnumerable<ushort> indexes, Texture2D texture) {
+            VertexBuffer = new VertexBuffer(gd, typeof(VertexPositionTexture), vertices.Count(), BufferUsage.WriteOnly);
+            IndexBuffer = new IndexBuffer(gd, typeof(ushort), indexes.Count(), BufferUsage.WriteOnly);
+            SetVertices(vertices);
+            SetIndexes(indexes);
             Texture = texture;
         }
 
-        public GroupRenderDetails(Texture2D texture, int tileCount)
+        public GroupRenderDetails(GraphicsDevice gd, IEnumerable<VertexPositionTexture> vertices, IEnumerable<ushort> indexes, Texture2D texture, int tileCount) : this(gd, vertices, indexes, texture)
         {
-            Texture = texture;
             TileCount = tileCount;
         }
 
         public Texture2D Texture { get; set; }
         public int TileCount { get; set; }
+        public List<VertexPositionTexture> Vertices { get; private set; }
         public VertexBuffer VertexBuffer { get; private set; }
         public IndexBuffer IndexBuffer { get; private set; }
         public float Opacity { get; set; }
 
-        public void SetVertices(IEnumerable<VertexPositionTexture> vertices, GraphicsDevice gd)
+        public void SetVertices(IEnumerable<VertexPositionTexture> vertices)
         {
-            var vertArray = vertices.ToArray();
-            var vb = new VertexBuffer(gd, typeof(VertexPositionTexture), vertArray.Length, BufferUsage.WriteOnly);
-            vb.SetData(vertArray);
-            VertexBuffer = vb;
+            Vertices = new List<VertexPositionTexture>(vertices.Count());
+            Vertices.AddRange(vertices);
+            VertexBuffer.SetData(vertices.ToArray());
         }
 
-        public void SetIndexes(IEnumerable<ushort> indexes, GraphicsDevice gd)
+        public void SetIndexes(IEnumerable<ushort> indexes)
         {
             var indexArray = indexes.ToArray();
-            var ib = new IndexBuffer(gd, typeof(ushort), indexArray.Length, BufferUsage.WriteOnly);
-            ib.SetData(indexArray);
-            IndexBuffer = ib;
+            IndexBuffer.SetData(indexArray);
         }
     }
 }

--- a/Source/MonoGame.Extended/Maps/Renderers/IMapRenderer.cs
+++ b/Source/MonoGame.Extended/Maps/Renderers/IMapRenderer.cs
@@ -8,6 +8,8 @@ namespace MonoGame.Extended.Maps.Renderers
     {
         void SwapMap(TiledMap newMap);
 
+        void Update(GameTime gameTime);
+
         [Obsolete]
         void Draw(Camera2D camera);
 

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Compile Include="Animations\Animation.cs" />
     <Compile Include="Animations\AnimationComponent.cs" />
+    <Compile Include="Maps\Renderers\DynamicGroupRenderDetails.cs" />
     <Compile Include="Maps\Renderers\FullMapRenderer.cs" />
     <Compile Include="Maps\Renderers\GroupRenderDetails.cs" />
     <Compile Include="Maps\Renderers\IMapRenderer.cs" />


### PR DESCRIPTION
I'd recommend to use the "very-large" demo map (you have to adjust the camera to look at 0/0 (I didn't want to change the lookAt value for all maps in the demo application).

Open for discussion:
* Only Tiles are animated. Are animated object and image layers are needed? 
* Is there a better way to get the camera viewport?
* Should we store the absolute tile position in each TiledTile? So we wouldn't need to create a new Rectangle for each tile in the "is in viewport"-check.
* I've moved the VBO and IBO construction into the GroupRenderDetails constructor because I think it's more appropriate there (it also allows to use SetVertices without recreating a new vbo in every call)
