### PR TITLE
Include IShapeF object as part of the TiledObject

### DIFF
--- a/Source/MonoGame.Extended.Tests/Maps/Renderers/FullMapRendererTest.cs
+++ b/Source/MonoGame.Extended.Tests/Maps/Renderers/FullMapRendererTest.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 using MonoGame.Extended.TextureAtlases;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended.Maps.Tiled;
+using MonoGame.Extended.Shapes;
 
 namespace MonoGame.Extended.Tests.Maps.Renderers
 {
@@ -21,9 +22,10 @@ namespace MonoGame.Extended.Tests.Maps.Renderers
             var m = new TiledMap("test", 2, 2, 32, 32);
             m.CreateTileset(texture, 0, 32, 32, 4);
 
+            IShapeF shape = new RectangleF(1, 1, 1, 1);
             TiledObject[] objs =
             {
-                new TiledObject(TiledObjectType.Tile, 1, null, 1, 1, 1, 1) { IsVisible = true },
+                new TiledObject(TiledObjectType.Tile, 1, null, shape, 1, 1) { IsVisible = true },
             };
 
             var layer = new TiledObjectLayer("object", objs);
@@ -46,9 +48,10 @@ namespace MonoGame.Extended.Tests.Maps.Renderers
             var m = new TiledMap("test", 2, 2, 32, 32);
             m.CreateTileset(texture, 0, 32, 32, 4);
 
+            IShapeF shape = new RectangleF(1, 1, 1, 1);
             TiledObject[] objs =
             {
-                new TiledObject(TiledObjectType.Rectangle, 1, 1, 1, 1, 1, 1) { IsVisible = true },
+                new TiledObject(TiledObjectType.Rectangle, 1, 1, shape, 1, 1) { IsVisible = true },
             };
 
             var layer = new TiledObjectLayer("object", objs);
@@ -71,9 +74,10 @@ namespace MonoGame.Extended.Tests.Maps.Renderers
             var m = new TiledMap("test", 2, 2, 32, 32);
             m.CreateTileset(texture, 0, 32, 32, 4);
 
+            IShapeF shape = new RectangleF(1, 1, 1, 1);
             TiledObject[] objs =
             {
-                new TiledObject(TiledObjectType.Tile, 1, 1, 1, 1, 1, 1) { IsVisible = true },
+                new TiledObject(TiledObjectType.Tile, 1, 1, shape, 1, 1) { IsVisible = true },
             };
 
             var layer = new TiledObjectLayer("object", objs);
@@ -97,9 +101,10 @@ namespace MonoGame.Extended.Tests.Maps.Renderers
             var m = new TiledMap("test", 2, 2, 32, 32);
             m.CreateTileset(texture, 0, 32, 32, 4);
 
+            IShapeF shape = new RectangleF(1, 1, 1, 1);
             TiledObject[] objs =
             {
-                new TiledObject(TiledObjectType.Tile, 1, 1, 1, 1, 1, 1) { IsVisible = false },
+                new TiledObject(TiledObjectType.Tile, 1, 1, shape, 1, 1) { IsVisible = false },
             };
 
             var layer = new TiledObjectLayer("object", objs);

--- a/Source/MonoGame.Extended.Tests/MonoGame.Extended.Tests.csproj
+++ b/Source/MonoGame.Extended.Tests/MonoGame.Extended.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Primitives\Segment2DTests.cs" />
     <Compile Include="Primitives\Size2Tests.cs" />
     <Compile Include="RangeTests.cs" />
+    <Compile Include="Shapes\EllipseFTest.cs" />
     <Compile Include="Shapes\PolygonFTests.cs" />
     <Compile Include="Shapes\CircleTests.cs" />
     <Compile Include="Shapes\RectangleFTests.cs" />
@@ -101,6 +102,7 @@
   <ItemGroup>
     <Folder Include="Gui\" />
     <Folder Include="Particles\Modifiers\" />
+    <Folder Include="Shapes" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Source/MonoGame.Extended.Tests/Shapes/EllipseFTest.cs
+++ b/Source/MonoGame.Extended.Tests/Shapes/EllipseFTest.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Xna.Framework;
+using MonoGame.Extended.Shapes;
+using NUnit.Framework;
+
+namespace MonoGame.Extended.Tests.Shapes
+{
+    [TestFixture]
+    public class EllipseFTest
+    {
+        [Test]
+        [TestCase(-1, -1, Result = false)]
+        [TestCase(110, 300, Result = true)]
+        [TestCase(200, 300, Result = true)]
+        [TestCase(290, 300, Result = true)]
+        [TestCase(400, 400, Result = false)]
+        public bool ContainsPoint_Circle(int x, int y)
+        {
+            var ellipse = new EllipseF(new Vector2(200.0f, 300.0f), 100.0f, 100.0f);
+
+            return ellipse.Contains(x, y);
+        }
+
+        [Test]
+        [TestCase(299, 400, Result = false)]
+        [TestCase(501, 400, Result = false)]
+        [TestCase(400, 199, Result = false)]
+        [TestCase(400, 601, Result = false)]
+        [TestCase(301, 400, Result = true)]
+        [TestCase(499, 400, Result = true)]
+        [TestCase(400, 201, Result = true)]
+        [TestCase(400, 599, Result = true)]
+        public bool ContainsPoint_NonCircle(int x, int y)
+        {
+            var ellipse = new EllipseF(new Vector2(400.0f, 400.0f), 100.0f, 200.0f);
+
+            return ellipse.Contains(x, y);
+        }
+    }
+}

--- a/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
+++ b/Source/MonoGame.Extended/Maps/Tiled/TiledObject.cs
@@ -6,18 +6,17 @@ namespace MonoGame.Extended.Maps.Tiled
 {
     public class TiledObject : ITiledAnimated
     {
-        public TiledObject(TiledObjectType objectType, int id, int? gid, float x, float y, float width, float height, TiledTilesetTile tilesetTile = null)
-            : this(objectType, id, gid, new Vector2(x, y), width, height, tilesetTile)
+        public TiledObject(TiledObjectType objectType, int id, int? gid, IShapeF shape, float x, float y, TiledTilesetTile tilesetTile = null)
+            : this(objectType, id, gid, shape, new Vector2(x, y), tilesetTile)
         {
         }
 
-        public TiledObject(TiledObjectType objectType, int id, int? gid, Vector2 position, float width, float height, TiledTilesetTile tilesetTile = null)
+        public TiledObject(TiledObjectType objectType, int id, int? gid, IShapeF shape, Vector2 position, TiledTilesetTile tilesetTile = null)
         {
             ObjectType = objectType;
             Id = id;
             Gid = gid;
-            Width = width;
-            Height = height;
+            Shape = shape;
             Points = new List<Vector2>();
             Properties = new TiledProperties();
             Position = position;
@@ -28,17 +27,20 @@ namespace MonoGame.Extended.Maps.Tiled
         public int? Gid { get; }
         public TiledObjectType ObjectType { get; }
         public string Name { get; set; }
-        public float Width { get; }
-        public float Height { get; }
+
         public Vector2 Position { get; }
-        public SizeF Size => new SizeF(Width, Height);
-        public RectangleF BoundingRectangle => new RectangleF(Position, Size);
         public TiledProperties Properties { get; }
         public List<Vector2> Points { get; }
         public bool IsVisible { get; set; }
         public float Opacity { get; set; }
         public float Rotation { get; set; }
         public string Type { get; set; }
+
+        public IShapeF Shape { get; private set; }
+        public float Width => Shape.BoundingRectangle.Width;
+        public float Height => Shape.BoundingRectangle.Height;
+        public SizeF Size => Shape.BoundingRectangle.Size;
+        public RectangleF BoundingRectangle => Shape.BoundingRectangle;
 
         public TiledTilesetTile TilesetTile { get; }
         public bool HasAnimation => TilesetTile != null && TilesetTile.Frames.Count != 0;

--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -52,6 +52,8 @@
     <Compile Include="Primitives\RayHelper.cs" />
     <Compile Include="Primitives\Segment2D.cs" />
     <Compile Include="Primitives\Size2.cs" />
+    <Compile Include="Shapes\EllipseF.cs" />
+    <Compile Include="Shapes\PolylineF.cs" />
     <Compile Include="Sprites\AnimatedSprite.cs" />
     <Compile Include="Animations\Tweens\DelayTween.cs" />
     <Compile Include="Animations\Tweens\FluentTweening.cs" />

--- a/Source/MonoGame.Extended/Shapes/EllipseF.cs
+++ b/Source/MonoGame.Extended/Shapes/EllipseF.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended.Shapes
+{
+    public class EllipseF : IShapeF
+    {
+        public EllipseF(Vector2 center, float radiusX, float radiusY)
+        {
+            Center = center;
+            RadiusX = radiusX;
+            RadiusY = radiusY;
+        }
+
+        public Vector2 Center { get; set; }
+        public float RadiusX { get; set; }
+        public float RadiusY { get; set; }
+        public float Left => Center.X - RadiusX;
+        public float Top => Center.Y - RadiusY;
+        public float Right => Center.X + RadiusX;
+        public float Bottom => Center.Y + RadiusY;
+
+        public RectangleF BoundingRectangle
+        {
+            get
+            {
+                var minX = Left;
+                var minY = Top;
+                var maxX = Right;
+                var maxY = Bottom;
+                return new RectangleF(minX, minY, maxX - minX, maxY - minY);
+            }
+        }
+
+        public bool Contains(float x, float y)
+        {
+            float xCalc = (float) (Math.Pow(x - Center.X, 2) / Math.Pow(RadiusX, 2));
+            float yCalc = (float) (Math.Pow(y - Center.Y, 2) / Math.Pow(RadiusY, 2));
+
+            return xCalc + yCalc <= 1;
+        }
+
+        public bool Contains(Vector2 point)
+        {
+            return Contains(point.X, point.Y);
+        }
+    }
+}

--- a/Source/MonoGame.Extended/Shapes/PolylineF.cs
+++ b/Source/MonoGame.Extended/Shapes/PolylineF.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended.Shapes
+{
+    public class PolylineF : IShapeF
+    {
+        public PolylineF(IEnumerable<Vector2> points)
+        {
+            Points = points;
+        }
+
+        public IEnumerable<Vector2> Points { get; private set; }
+        public float Left => Points.Min(p => p.X);
+        public float Top => Points.Min(p => p.Y);
+        public float Right => Points.Max(p => p.X);
+        public float Bottom => Points.Max(p => p.Y);
+
+        public RectangleF BoundingRectangle
+        {
+            get
+            {
+                var minX = Left;
+                var minY = Top;
+                var maxX = Right;
+                var maxY = Bottom;
+                return new RectangleF(minX, minY, maxX - minX, maxY - minY);
+            }
+        }
+
+        public bool Contains(float x, float y)
+        {
+            return false;
+        }
+
+        public bool Contains(Vector2 point)
+        {
+            return Contains(point.X, point.Y);
+        }
+    }
+}


### PR DESCRIPTION
I noticed we're not parsing out TiledObjects into their associated Shapes and instead just storing the bounding rectangle.  I've updated the TiledMapReader and TiledObject to now store the shape for easy access.  This required creating 2 new shapes: EllipseF and PolylineF.  I realize that having both an EllipseF and CircleF is a little redundant but CircleF had a few methods I wasn't ready to implement on EllipseF.