### PR TITLE
TiledMapRenderer allow custom effect

### DIFF
--- a/Source/MonoGame.Extended.Tiled/Graphics/ITiledMapEffect.cs
+++ b/Source/MonoGame.Extended.Tiled/Graphics/ITiledMapEffect.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+
+namespace MonoGame.Extended.Tiled.Graphics
+{
+    public interface ITiledMapEffect : IEffectMatrices
+    {
+        EffectTechnique CurrentTechnique { get; }
+        Texture2D Texture { get; set; }
+        float Alpha { get; set; }
+    }
+}

--- a/Source/MonoGame.Extended.Tiled/Graphics/TiledMapDefaultEffect.cs
+++ b/Source/MonoGame.Extended.Tiled/Graphics/TiledMapDefaultEffect.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+
+namespace MonoGame.Extended.Tiled.Graphics
+{
+    public class TiledMapDefaultEffect : BasicEffect, ITiledMapEffect
+    {
+        public TiledMapDefaultEffect(GraphicsDevice device) 
+            : base(device)
+        {
+            TextureEnabled = true;
+        }
+
+        public TiledMapDefaultEffect(BasicEffect cloneSource) 
+            : base(cloneSource)
+        {
+            TextureEnabled = true;
+        }
+    }
+}

--- a/Source/MonoGame.Extended.Tiled/MonoGame.Extended.Tiled.csproj
+++ b/Source/MonoGame.Extended.Tiled/MonoGame.Extended.Tiled.csproj
@@ -45,6 +45,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ContentReaderExtensions.cs" />
+    <Compile Include="Graphics\TiledMapDefaultEffect.cs" />
+    <Compile Include="Graphics\ITiledMapEffect.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Graphics\TiledMapLayerAnimatedModel.cs" />
     <Compile Include="Graphics\TiledMapRenderer.cs" />


### PR DESCRIPTION
Fixes #343 

Custom effects can be passed  to `Draw` overloads of `TiledMapRenderer`. Custom effects do however require to implement `ITiledMapEffect` to get and set the active texture and alpha transparency for a custom effect.