### PR TITLE
Added kernings support to the BitmapFont.

### DIFF
--- a/Source/Demos/Demo.StarWarrior/GameMain.cs
+++ b/Source/Demos/Demo.StarWarrior/GameMain.cs
@@ -100,9 +100,11 @@ namespace Demo.StarWarrior
             var entityCount = $"Active Entities Count: {_entityManager.ActiveEntitiesCount}";
             //var removedEntityCount = $"Removed Entities TotalCount: {_ecs.TotalEntitiesRemovedCount}";
             var totalEntityCount = $"Allocated Entities Count: {_entityManager.TotalEntitiesCount}";
+            var useKernings = $"Use Kernings: {BitmapFont.UseKernings}";
 
             _spriteBatch.DrawString(_font, entityCount, new Vector2(16, 62), Color.Yellow);
             _spriteBatch.DrawString(_font, totalEntityCount, new Vector2(16, 92), Color.Yellow);
+            _spriteBatch.DrawString(_font, useKernings, new Vector2(16, 122), Color.Yellow);
             //_spriteBatch.DrawString(_font, removedEntityCount, new Vector2(32, 122), Color.Yellow);
 #endif
 

--- a/Source/Demos/Demo.StarWarrior/Systems/PlayerShipControlSystem.cs
+++ b/Source/Demos/Demo.StarWarrior/Systems/PlayerShipControlSystem.cs
@@ -41,6 +41,7 @@ using Demo.StarWarrior.Templates;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using MonoGame.Extended.Entities;
+using MonoGame.Extended.BitmapFonts;
 
 namespace Demo.StarWarrior.Systems
 {
@@ -50,6 +51,7 @@ namespace Demo.StarWarrior.Systems
     {
         private TimeSpan _missileLaunchTimer;
         private readonly TimeSpan _missileLaunchDelay;
+        private KeyboardState _lastState;
 
         public PlayerShipControlSystem()
         {
@@ -77,6 +79,11 @@ namespace Demo.StarWarrior.Systems
             if (keyboard.IsKeyDown(Keys.D) || keyboard.IsKeyDown(Keys.Right))
                 direction += Vector2.UnitX;
 
+            if (keyboard.IsKeyDown(Keys.K) && !_lastState.IsKeyDown(Keys.K))
+            {
+                BitmapFont.UseKernings = !BitmapFont.UseKernings;
+            }
+
             var isMoving = direction != Vector2.Zero;
             if (isMoving)
             {
@@ -98,6 +105,8 @@ namespace Demo.StarWarrior.Systems
                     AddMissile(transform, 91, +9);
                 }
             }
+
+            _lastState = keyboard;
         }
 
         private void AddMissile(TransformComponent parentTransform, float angle = 90.0f, float offsetX = 0.0f)

--- a/Source/MonoGame.Extended.Content.Pipeline/BitmapFonts/BitmapFontWriter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/BitmapFonts/BitmapFontWriter.cs
@@ -29,6 +29,14 @@ namespace MonoGame.Extended.Content.Pipeline.BitmapFonts
                 writer.Write(c.YOffset);
                 writer.Write(c.XAdvance);
             }
+
+            writer.Write(fontFile.Kernings.Count);
+            foreach(var k in fontFile.Kernings)
+            {
+                writer.Write(k.First);
+                writer.Write(k.Second);
+                writer.Write(k.Amount);
+            }
         }
 
         public override string GetRuntimeType(TargetPlatform targetPlatform)

--- a/Source/MonoGame.Extended.Graphics/Batcher2D.cs
+++ b/Source/MonoGame.Extended.Graphics/Batcher2D.cs
@@ -221,6 +221,7 @@ namespace MonoGame.Extended.Graphics
             var lineSpacing = bitmapFont.LineHeight;
             var offset = new Vector2(0, 0);
 
+            BitmapFontRegion lastGlyph = null;
             for (var i = 0; i < text.Length;)
             {
                 int character;
@@ -248,6 +249,7 @@ namespace MonoGame.Extended.Graphics
                     case '\n':
                         offset.X = 0;
                         offset.Y += lineSpacing;
+                        lastGlyph = null;
                         continue;
                 }
 
@@ -263,9 +265,21 @@ namespace MonoGame.Extended.Graphics
                 var bounds = textureRegion.Bounds;
                 DrawSprite(textureRegion.Texture, ref transform1Matrix, ref bounds, color, flags, depth);
 
+                var advance = fontRegion.XAdvance + bitmapFont.LetterSpacing;
+                if (BitmapFont.UseKernings && lastGlyph != null)
+                {
+                    int amount;
+                    if (lastGlyph.Kernings.TryGetValue(character, out amount))
+                    {
+                        advance += amount;
+                    }
+                }
+
                 offset.X += i != text.Length - 1
-                    ? fontRegion.XAdvance + bitmapFont.LetterSpacing
+                    ? advance
                     : fontRegion.XOffset + fontRegion.Width;
+
+                lastGlyph = fontRegion;
             }
         }
 
@@ -337,6 +351,7 @@ namespace MonoGame.Extended.Graphics
             var lineSpacing = bitmapFont.LineHeight;
             var offset = new Vector2(0, 0);
 
+            BitmapFontRegion lastGlyph = null;
             for (var i = 0; i < text.Length;)
             {
                 int character;
@@ -364,6 +379,7 @@ namespace MonoGame.Extended.Graphics
                     case '\n':
                         offset.X = 0;
                         offset.Y += lineSpacing;
+                        lastGlyph = null;
                         continue;
                 }
 
@@ -379,9 +395,21 @@ namespace MonoGame.Extended.Graphics
                 var bounds = textureRegion.Bounds;
                 DrawSprite(textureRegion.Texture, ref transform1Matrix, ref bounds, color, flags, depth);
 
+                var advance = fontRegion.XAdvance + bitmapFont.LetterSpacing;
+                if (BitmapFont.UseKernings && lastGlyph != null)
+                {
+                    int amount;
+                    if (lastGlyph.Kernings.TryGetValue(character, out amount))
+                    {
+                        advance += amount;
+                    }
+                }
+
                 offset.X += i != text.Length - 1
-                    ? fontRegion.XAdvance + bitmapFont.LetterSpacing
+                    ? advance
                     : fontRegion.XOffset + fontRegion.Width;
+
+                lastGlyph = fontRegion;
             }
         }
 

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -19,6 +19,7 @@ namespace MonoGame.Extended.BitmapFonts
         public string Name { get; }
         public int LineHeight { get; }
         public int LetterSpacing { get; set; } = 0;
+        public static bool UseKernings { get; set; } = false;
 
         public BitmapFontRegion GetCharacterRegion(int character)
         {
@@ -73,6 +74,7 @@ namespace MonoGame.Extended.BitmapFonts
             var dx = position.X;
             var dy = position.Y;
 
+            BitmapFontGlyph? lastGlyph = null;
             for (var i = 0; i < text.Length; i++)
             {
                 var character = GetUnicodeCodePoint(text, i);
@@ -90,10 +92,22 @@ namespace MonoGame.Extended.BitmapFonts
                     dx += glyphs[i].FontRegion.XAdvance + LetterSpacing;
                 }
 
+                if (UseKernings && lastGlyph != null && lastGlyph.Value.FontRegion != null)
+                {
+                    int amount;
+                    if (lastGlyph.Value.FontRegion.Kernings.TryGetValue(character, out amount))
+                    {
+                        dx += amount;
+                    }
+                }
+
+                lastGlyph = glyphs[i];
+
                 if (character == '\n')
                 {
                     dy += LineHeight;
                     dx = position.X;
+                    lastGlyph = null;
                 }
             }
 

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontReader.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontReader.cs
@@ -43,6 +43,24 @@ namespace MonoGame.Extended.BitmapFonts
                 regions[r] = new BitmapFontRegion(textureRegion, character, xOffset, yOffset, xAdvance);
             }
 
+            var characterMap = regions.ToDictionary(r => r.Character);
+            var kerningsCount = reader.ReadInt32();
+            for (var k = 0; k < kerningsCount; ++k)
+            {
+                int first = reader.ReadInt32();
+                int second = reader.ReadInt32();
+                int amount = reader.ReadInt32();
+
+                // Find region
+                BitmapFontRegion region = null;
+                if (!characterMap.TryGetValue(first, out region))
+                {
+                    continue;
+                }
+
+                region.Kernings[second] = amount;
+            }
+
             return new BitmapFont(reader.AssetName, regions, lineHeight);
         }
     }

--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFontRegion.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFontRegion.cs
@@ -1,5 +1,6 @@
 using System;
 using MonoGame.Extended.TextureAtlases;
+using System.Collections.Generic;
 
 namespace MonoGame.Extended.BitmapFonts
 {
@@ -7,12 +8,16 @@ namespace MonoGame.Extended.BitmapFonts
     {
         public BitmapFontRegion(TextureRegion2D textureRegion, int character, int xOffset, int yOffset, int xAdvance)
         {
+            _kernings = new Dictionary<int, int>();
+
             TextureRegion = textureRegion;
             Character = character;
             XOffset = xOffset;
             YOffset = yOffset;
             XAdvance = xAdvance;
         }
+
+        private readonly Dictionary<int, int> _kernings;
 
         public int Character { get; }
         public TextureRegion2D TextureRegion { get; }
@@ -21,6 +26,8 @@ namespace MonoGame.Extended.BitmapFonts
         public int XAdvance { get; }
         public int Width => TextureRegion.Width;
         public int Height => TextureRegion.Height;
+
+        public Dictionary<int, int> Kernings => _kernings;
 
         public override string ToString()
         {


### PR DESCRIPTION
Fixes #371 
Following our discussion I've added static property UseKernings(initially set to false) to Bitmap that controls whether kernings are applied during the rendering.
Also I've slightly updated the StarWarrior demo. Now you can turn on/off that property by pressing 'K' key. The difference is visible only in Debug mode(where additional text is drawn).