### PR TITLE
Add new ViewportAdapter : ScalingCenteredViewportAdapter

### DIFF
--- a/Source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/Source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Transform.cs" />
     <Compile Include="ViewportAdapters\BoxingViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\DefaultViewportAdapter.cs" />
+    <Compile Include="ViewportAdapters\ScalingCenteredViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\WindowViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\ScalingViewportAdapter.cs" />
     <Compile Include="ViewportAdapters\ViewportAdapter.cs" />

--- a/Source/MonoGame.Extended/ViewportAdapters/ScalingCenteredViewportAdapter.cs
+++ b/Source/MonoGame.Extended/ViewportAdapters/ScalingCenteredViewportAdapter.cs
@@ -1,0 +1,87 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+
+// ReSharper disable once CheckNamespace
+
+namespace MonoGame.Extended.ViewportAdapters
+{
+    public class ScalingCenteredViewportAdapter : ScalingViewportAdapter
+    {
+        protected readonly GameWindow Window;
+        protected Matrix _transform;
+
+        public ScalingCenteredViewportAdapter(GameWindow window, GraphicsDevice graphicsDevice, int virtualWidth, int virtualHeight)
+            : base(graphicsDevice, virtualWidth, virtualHeight)
+        {
+            Window = window;
+            window.ClientSizeChanged += OnClientSizeChanged;
+
+            ComputeMatrix();
+        }
+
+        public override int ViewportWidth => Window.ClientBounds.Width;
+        public override int ViewportHeight => Window.ClientBounds.Height;
+        public float MarginWidth { get; protected set; }
+        public float MarginHeight { get; protected set; }
+
+        public override Matrix GetScaleMatrix()
+        {
+            return _transform;
+        }
+
+        public override Point PointToScreen(int x, int y)
+        {
+            var viewport = GraphicsDevice.Viewport;
+            return base.PointToScreen(x - viewport.X, y - viewport.Y);
+        }
+
+        private void OnClientSizeChanged(object sender, EventArgs eventArgs)
+        {
+            var x = Window.ClientBounds.Width;
+            var y = Window.ClientBounds.Height;
+
+            GraphicsDevice.Viewport = new Viewport(0, 0, x, y);
+
+            ComputeMatrix();
+        }
+
+        protected void ComputeMatrix()
+        {
+            var viewport = GraphicsDevice.Viewport;
+
+            var actualScale = (float)viewport.Width / viewport.Height;
+            var wantedScale = (float)VirtualWidth / VirtualHeight;
+
+            Vector2 scale = Vector2.Zero;
+
+            if (actualScale == wantedScale)
+            {
+                scale = new Vector2((float)viewport.Width / VirtualWidth, (float)viewport.Height / VirtualHeight);
+            }
+            else if (actualScale > wantedScale)
+            {
+                float wantedWidth = ((float)viewport.Height / VirtualHeight) * VirtualWidth;
+                float totalMargin = viewport.Width - wantedWidth;
+
+                scale = new Vector2((float)wantedWidth / VirtualWidth, (float)viewport.Height / VirtualHeight);
+
+                MarginWidth = totalMargin / 2;
+                MarginHeight = 0;
+            }
+            else if (actualScale < wantedScale)
+            {
+                float wantedHeight = ((float)viewport.Width / VirtualWidth) * VirtualHeight;
+                float totalMargin = viewport.Height - wantedHeight;
+
+                scale = new Vector2((float)viewport.Width / VirtualWidth, (float)wantedHeight / VirtualHeight);
+
+                MarginWidth = 0;
+                MarginHeight = totalMargin / 2;
+            }
+
+            _transform = Matrix.CreateScale(scale.X, scale.Y, 1.0f)
+                * Matrix.CreateTranslation(MarginWidth, MarginHeight, 0);
+        }
+    }
+}


### PR DESCRIPTION
This PR add a new viewport adapter : ScalingCenteredViewportAdapter.

This viewport adapter allows to scale content and keep the ratio of virtual size, independently of the window size.

Some examples:
![example_1](https://cloud.githubusercontent.com/assets/1212944/24903240/25bc74fe-1ead-11e7-805d-e6ae6bd0022a.jpg)
![example_2](https://cloud.githubusercontent.com/assets/1212944/24903241/25bed690-1ead-11e7-9421-499f376e5164.jpg)
![example_3](https://cloud.githubusercontent.com/assets/1212944/24903242/25c3f3c8-1ead-11e7-81d0-4413e28e8730.jpg)




