### PR TITLE
Fix nested transform WorldMatrix calculation

### DIFF
--- a/Source/MonoGame.Extended.Entities/Entities/TransformComponent2D.cs
+++ b/Source/MonoGame.Extended.Entities/Entities/TransformComponent2D.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework;
 namespace MonoGame.Extended.Entities
 {
     [EntityComponent]
-    public class TransformComponent2D : EntityComponent
+    public class TransformComponent2D : EntityComponent, IMovable, IRotatable, IScalable
     {
         private TransformFlags _flags = TransformFlags.All; // dirty flags, set all dirty flags when created
         private Matrix2D _localMatrix; // model space to local space
@@ -180,8 +180,8 @@ namespace MonoGame.Extended.Entities
         {
             matrix = Matrix2D.CreateScale(_scale) *
                      Matrix2D.CreateRotationZ(_rotation) *
-                         Matrix2D.CreateTranslation(_position);
-            }
+                     Matrix2D.CreateTranslation(_position);
+        }
 
         [Flags]
         private enum TransformFlags : byte

--- a/Source/MonoGame.Extended.Entities/Entities/TransformComponent2D.cs
+++ b/Source/MonoGame.Extended.Entities/Entities/TransformComponent2D.cs
@@ -148,6 +148,7 @@ namespace MonoGame.Extended.Entities
 
             RecalculateLocalMatrixIfNecessary();
             RecalculateWorldMatrix(ref _localMatrix, out _worldMatrix);
+
             _flags &= ~TransformFlags.WorldMatrixIsDirty;
         }
 
@@ -167,7 +168,7 @@ namespace MonoGame.Extended.Entities
             if (Parent != null)
             {
                 Parent.GetWorldMatrix(out matrix);
-                Matrix2D.Multiply(ref matrix, ref localMatrix, out matrix);
+                Matrix2D.Multiply(ref localMatrix, ref matrix, out matrix);
             }
             else
             {
@@ -177,19 +178,10 @@ namespace MonoGame.Extended.Entities
 
         private void RecalculateLocalMatrix(out Matrix2D matrix)
         {
-            if (Parent != null)
-            {
-                var parentPosition = Parent.Position;
-                matrix = Matrix2D.CreateTranslation(-parentPosition) * Matrix2D.CreateScale(_scale) *
-                         Matrix2D.CreateRotationZ(-_rotation) * Matrix2D.CreateTranslation(parentPosition) *
+            matrix = Matrix2D.CreateScale(_scale) *
+                     Matrix2D.CreateRotationZ(_rotation) *
                          Matrix2D.CreateTranslation(_position);
             }
-            else
-            {
-                matrix = Matrix2D.CreateScale(_scale) * Matrix2D.CreateRotationZ(-_rotation) *
-                         Matrix2D.CreateTranslation(_position);
-            }
-        }
 
         [Flags]
         private enum TransformFlags : byte

--- a/Source/MonoGame.Extended/Transform.cs
+++ b/Source/MonoGame.Extended/Transform.cs
@@ -165,6 +165,7 @@ namespace MonoGame.Extended
 
             RecalculateLocalMatrixIfNecessary();
             RecalculateWorldMatrix(ref _localMatrix, out _worldMatrix);
+
             _flags &= ~TransformFlags.WorldMatrixIsDirty;
             TranformUpdated?.Invoke();
         }
@@ -287,26 +288,20 @@ namespace MonoGame.Extended
             if (Parent != null)
             {
                 Parent.GetWorldMatrix(out matrix);
-                Matrix2D.Multiply(ref matrix, ref localMatrix, out matrix);
+                Matrix2D.Multiply(ref localMatrix, ref matrix, out matrix);
             }
             else
+            {
                 matrix = localMatrix;
+            }
         }
 
         protected internal override void RecalculateLocalMatrix(out Matrix2D matrix)
         {
-            if (Parent != null)
-            {
-                var parentPosition = Parent.Position;
-                matrix = Matrix2D.CreateTranslation(-parentPosition)*Matrix2D.CreateScale(_scale)*
-                         Matrix2D.CreateRotationZ(-_rotation)*Matrix2D.CreateTranslation(parentPosition)*
-                         Matrix2D.CreateTranslation(_position);
-            }
-            else
-            {
-                matrix = Matrix2D.CreateScale(_scale)*Matrix2D.CreateRotationZ(-_rotation)*
-                         Matrix2D.CreateTranslation(_position);
-            }
+            matrix = Matrix2D.CreateScale(_scale) *
+                     Matrix2D.CreateRotationZ(_rotation) *
+                     Matrix2D.CreateTranslation(_position);
         }
+
     }
 }


### PR DESCRIPTION
Fixes issues discussed in forum thread:
http://community.monogame.net/t/entities-nested-using-transformcomponent2d-parent/9084

Correctly calculates the WorldMatrix for Transform and TransformComponent2D that have parents (any depth) who are rotated and/or scaled.
