### PR TITLE
[Content] removing unused ScratchBuffer

### DIFF
--- a/Source/MonoGame.Extended/Content/ContentReaderExtensions.cs
+++ b/Source/MonoGame.Extended/Content/ContentReaderExtensions.cs
@@ -9,7 +9,6 @@ namespace MonoGame.Extended.Content
     public static class ContentReaderExtensions
     {
         private static readonly FieldInfo _contentReaderGraphicsDeviceFieldInfo = typeof(ContentReader).GetTypeInfo().GetDeclaredField("graphicsDevice");
-        private static byte[] _scratchBuffer;
 
         public static GraphicsDevice GetGraphicsDevice(this ContentReader contentReader)
         {
@@ -32,14 +31,6 @@ namespace MonoGame.Extended.Content
             }
 
             return assetName;
-        }
-
-        internal static byte[] GetScratchBuffer(this ContentReader contentReader, int size)
-        {
-            size = Math.Max(size, 1024 * 1024);
-            if (_scratchBuffer == null || _scratchBuffer.Length < size)
-                _scratchBuffer = new byte[size];
-            return _scratchBuffer;
         }
     }
 }


### PR DESCRIPTION
This scratch buffer is `internal`, it has a 1mb limit, and it's unused.

I think if devs want a scratch buffer, maybe there should be a `ScratchBuffer` class with a static internal byte array.

Recompiled whole solution successfully with it removed.