### PR TITLE
Tests moved MonoGame from Portable to WindowsDX

### DIFF
--- a/Source/Tests/MonoGame.Extended.Content.Pipeline.Tests.Tiled/MonoGame.Extended.Content.Pipeline.Tests.Tiled.csproj
+++ b/Source/Tests/MonoGame.Extended.Content.Pipeline.Tests.Tiled/MonoGame.Extended.Content.Pipeline.Tests.Tiled.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework, Version=3.6.0.1625, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MonoGame.Framework.Portable.3.6.0.1625\lib\portable-net45+win8+wpa81\MonoGame.Framework.dll</HintPath>
+      <HintPath>..\..\packages\MonoGame.Framework.WindowsDX.3.6.0.1625\lib\net40\MonoGame.Framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">

--- a/Source/Tests/MonoGame.Extended.Content.Pipeline.Tests.Tiled/packages.config
+++ b/Source/Tests/MonoGame.Extended.Content.Pipeline.Tests.Tiled/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Framework.Portable" version="3.6.0.1625" targetFramework="net45" />
+  <package id="MonoGame.Framework.WindowsDX" version="3.6.0.1625" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Source/Tests/MonoGame.Extended.Content.Pipeline.Tests/MonoGame.Extended.Content.Pipeline.Tests.csproj
+++ b/Source/Tests/MonoGame.Extended.Content.Pipeline.Tests/MonoGame.Extended.Content.Pipeline.Tests.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework, Version=3.6.0.1625, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MonoGame.Framework.Portable.3.6.0.1625\lib\portable-net45+win8+wpa81\MonoGame.Framework.dll</HintPath>
+      <HintPath>..\..\packages\MonoGame.Framework.WindowsDX.3.6.0.1625\lib\net40\MonoGame.Framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MonoGame.Framework.Content.Pipeline">

--- a/Source/Tests/MonoGame.Extended.Content.Pipeline.Tests/packages.config
+++ b/Source/Tests/MonoGame.Extended.Content.Pipeline.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Framework.Portable" version="3.6.0.1625" targetFramework="net45" />
+  <package id="MonoGame.Framework.WindowsDX" version="3.6.0.1625" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Source/Tests/MonoGame.Extended.Gui.Tests/MonoGame.Extended.Gui.Tests.csproj
+++ b/Source/Tests/MonoGame.Extended.Gui.Tests/MonoGame.Extended.Gui.Tests.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework, Version=3.6.0.1625, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MonoGame.Framework.Portable.3.6.0.1625\lib\portable-net45+win8+wpa81\MonoGame.Framework.dll</HintPath>
+      <HintPath>..\..\packages\MonoGame.Framework.WindowsDX.3.6.0.1625\lib\net40\MonoGame.Framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">

--- a/Source/Tests/MonoGame.Extended.Gui.Tests/packages.config
+++ b/Source/Tests/MonoGame.Extended.Gui.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Framework.Portable" version="3.6.0.1625" targetFramework="net452" />
+  <package id="MonoGame.Framework.WindowsDX" version="3.6.0.1625" targetFramework="net452" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
 </packages>

--- a/Source/Tests/MonoGame.Extended.Tests/MonoGame.Extended.Tests.csproj
+++ b/Source/Tests/MonoGame.Extended.Tests/MonoGame.Extended.Tests.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework, Version=3.6.0.1625, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MonoGame.Framework.Portable.3.6.0.1625\lib\portable-net45+win8+wpa81\MonoGame.Framework.dll</HintPath>
+      <HintPath>..\..\packages\MonoGame.Framework.WindowsDX.3.6.0.1625\lib\net40\MonoGame.Framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Source/Tests/MonoGame.Extended.Tests/packages.config
+++ b/Source/Tests/MonoGame.Extended.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Framework.Portable" version="3.6.0.1625" targetFramework="net45" />
+  <package id="MonoGame.Framework.WindowsDX" version="3.6.0.1625" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />

--- a/Source/Tests/MonoGame.Extended.Tiled.Tests/MonoGame.Extended.Tiled.Tests.csproj
+++ b/Source/Tests/MonoGame.Extended.Tiled.Tests/MonoGame.Extended.Tiled.Tests.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework, Version=3.6.0.1625, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MonoGame.Framework.Portable.3.6.0.1625\lib\portable-net45+win8+wpa81\MonoGame.Framework.dll</HintPath>
+      <HintPath>..\..\packages\MonoGame.Framework.WindowsDX.3.6.0.1625\lib\net40\MonoGame.Framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MonoGame.Framework.Content.Pipeline">

--- a/Source/Tests/MonoGame.Extended.Tiled.Tests/packages.config
+++ b/Source/Tests/MonoGame.Extended.Tiled.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Framework.Portable" version="3.6.0.1625" targetFramework="net45" />
+  <package id="MonoGame.Framework.WindowsDX" version="3.6.0.1625" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Without this change, the tests fail in Visual Studio.  Because they are trying to use functionality that is missing in the Portable version of MonoGame. 

For example `MathHelper.Clamp` always returns `0f` in the portable version, because it has no implementation.