### PR TITLE
Modified Entity's Reset method to clear _name field

### DIFF
--- a/Source/MonoGame.Extended.Entities/Entity.cs
+++ b/Source/MonoGame.Extended.Entities/Entity.cs
@@ -152,6 +152,7 @@ namespace MonoGame.Extended.Entities
 
         private void Reset()
         {
+            _name = null;
             _group = null;
             SystemBits.SetAll(false);
             ComponentBits.SetAll(false);


### PR DESCRIPTION
The reset method was not clearing the name field.  When a "new" entity is retrieved from the pool, it could have the old entity's name. 