### PR TITLE
ObjectPool Enumeration Bug

### DIFF
--- a/Source/MonoGame.Extended.Entities/Entity.cs
+++ b/Source/MonoGame.Extended.Entities/Entity.cs
@@ -152,6 +152,7 @@ namespace MonoGame.Extended.Entities
 
         private void Reset()
         {
+            _name = null;
             _group = null;
             SystemBits.SetAll(false);
             ComponentBits.SetAll(false);


### PR DESCRIPTION
There were several issues with enumeration of the ObjectPool.

1. _headNode was never getting assigned
2. _tailNode's NextNode field was being set to itself causing infinite loop during enumeration
3. The GetEnumerator method was not including the _headNode in the results.  It was starting with the second node in the pool.



