### PR TITLE
Fix Demo.SpaceGame aiming and spaceship control

### DIFF
--- a/Source/Demos/Demo.SpaceGame/Entities/Spaceship.cs
+++ b/Source/Demos/Demo.SpaceGame/Entities/Spaceship.cs
@@ -16,7 +16,7 @@ namespace Demo.SpaceGame.Entities
         private float _fireCooldown;
         public CircleF BoundingCircle;
 
-        public Vector2 Direction => Vector2.UnitX.Rotate(Rotation);
+        public Vector2 Direction => (-Vector2.UnitX).Rotate(-Rotation);
 
         public Vector2 Position
         {
@@ -72,7 +72,7 @@ namespace Demo.SpaceGame.Entities
 
         public void LookAt(Vector2 point)
         {
-            Rotation = (float)Math.Atan2(point.Y - Position.Y, point.X - Position.X);
+            Rotation = (float)Math.Atan2(point.Y - Position.Y, Position.X - point.X);
         }
 
         public void Fire()
@@ -83,8 +83,8 @@ namespace Demo.SpaceGame.Entities
             }
 
             var angle = Rotation + MathHelper.ToRadians(90);
-            var muzzle1Position = Position + new Vector2(14, 0).Rotate(angle);
-            var muzzle2Position = Position + new Vector2(-14, 0).Rotate(angle);
+            var muzzle1Position = Position + new Vector2(14, 0).Rotate(-angle);
+            var muzzle2Position = Position + new Vector2(-14, 0).Rotate(-angle);
             _bulletFactory.Create(muzzle1Position, Direction, angle, 550f);
             _bulletFactory.Create(muzzle2Position, Direction, angle, 550f);
             _fireCooldown = 0.2f;

--- a/Source/Demos/Demo.SpaceGame/Game1.cs
+++ b/Source/Demos/Demo.SpaceGame/Game1.cs
@@ -108,10 +108,10 @@ namespace Demo.SpaceGame
                     _player.Accelerate(-acceleration);
 
                 if (keyboardState.IsKeyDown(Keys.A) || keyboardState.IsKeyDown(Keys.Left))
-                    _player.Rotation -= deltaTime*3f;
+                    _player.Rotation += deltaTime*3f;
 
                 if (keyboardState.IsKeyDown(Keys.D) || keyboardState.IsKeyDown(Keys.Right))
-                    _player.Rotation += deltaTime*3f;
+                    _player.Rotation -= deltaTime*3f;
 
                 if (keyboardState.IsKeyDown(Keys.Space) || mouseState.LeftButton == ButtonState.Pressed)
                     _player.Fire();

--- a/Source/Demos/Demo.StarWarrior/packages.config
+++ b/Source/Demos/Demo.StarWarrior/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MonoGame.Extended.Content.Pipeline" version="1.0.617" targetFramework="net45" />
   <package id="MonoGame.Framework.DesktopGL" version="3.6.0.1625" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I was learning how to use MonoGame.Extended from the demos and noticed that the aim for SpaceGame was off. I went ahead and fixed it for myself.
It looked like the person who wrote had their axis backwards, since in MonoGame increasing y value means the sprite will move down the screen.

I wasn't sure if this was fixed in 2.0, as when I downloaded 2.0, this demo wasn't working.

Thanks
