### PR TITLE
Implemented Tiled Group Layers

### DIFF
--- a/Source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
+++ b/Source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Tiled\ContentWriterExtensions.cs" />
     <Compile Include="Tiled\TiledMapContent.cs" />
     <Compile Include="Tiled\TiledMapEllipseContent.cs" />
+    <Compile Include="Tiled\TiledMapGroupLayerContent.cs" />
     <Compile Include="Tiled\TiledMapImageContent.cs" />
     <Compile Include="Tiled\TiledMapImageLayerContent.cs" />
     <Compile Include="Tiled\TiledMapImporter.cs" />

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapContent.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapContent.cs
@@ -42,6 +42,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
         [XmlElement(ElementName = "layer", Type = typeof(TiledMapTileLayerContent))]
         [XmlElement(ElementName = "imagelayer", Type = typeof(TiledMapImageLayerContent))]
         [XmlElement(ElementName = "objectgroup", Type = typeof(TiledMapObjectLayerContent))]
+        [XmlElement(ElementName = "group", Type = typeof(TiledMapGroupLayerContent))]
         public List<TiledMapLayerContent> Layers { get; set; }
 
         [XmlArray("properties")]

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapGroupLayerContent.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapGroupLayerContent.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+using MonoGame.Extended.Tiled;
+
+namespace MonoGame.Extended.Content.Pipeline.Tiled
+{
+    public class TiledMapGroupLayerContent : TiledMapLayerContent
+    {
+
+        [XmlElement(ElementName = "layer", Type = typeof(TiledMapTileLayerContent))]
+        [XmlElement(ElementName = "imagelayer", Type = typeof(TiledMapImageLayerContent))]
+        [XmlElement(ElementName = "objectgroup", Type = typeof(TiledMapObjectLayerContent))]
+        [XmlElement(ElementName = "group", Type = typeof(TiledMapGroupLayerContent))]
+        public List<TiledMapLayerContent> Layers { get; set; }
+
+        public TiledMapGroupLayerContent()
+            : base(TiledMapLayerType.GroupLayer)
+        {
+            Layers = new List<TiledMapLayerContent>();
+        }
+    }
+}

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
@@ -107,6 +107,9 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
                 case TiledMapLayerType.ObjectLayer:
                     WriteObjectLayer(output, (TiledMapObjectLayerContent)layer);
                     break;
+                case TiledMapLayerType.GroupLayer:
+                    WriteLayers(output, ((TiledMapGroupLayerContent)layer).Layers);
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(layer.Type));
             }

--- a/Source/MonoGame.Extended.Tiled/Graphics/TiledMapRenderer.cs
+++ b/Source/MonoGame.Extended.Tiled/Graphics/TiledMapRenderer.cs
@@ -76,11 +76,6 @@ namespace MonoGame.Extended.Tiled.Graphics
 
         public void Draw(TiledMapLayer layer, ref Matrix viewMatrix, ref Matrix projectionMatrix, Effect effect = null, float depth = 0.0f)
         {
-            Draw(layer, ref viewMatrix, ref projectionMatrix, effect, depth, layer.OffsetX, layer.OffsetY);
-        }
-
-        private void Draw(TiledMapLayer layer, ref Matrix viewMatrix, ref Matrix projectionMatrix, Effect effect, float depth, float offsetX, float offsetY)
-        {
             if (!layer.IsVisible)
                 return;
 
@@ -92,12 +87,12 @@ namespace MonoGame.Extended.Tiled.Graphics
                 var group = layer as TiledMapGroupLayer;
 
                 for (int i = 0; i < group.Layers.Count; i++)
-                    Draw(group.Layers[i], ref viewMatrix, ref projectionMatrix, effect, depth, offsetX + group.OffsetX, offsetY + group.OffsetY);
+                    Draw(group.Layers[i], ref viewMatrix, ref projectionMatrix, effect, depth);
 
                 return;
             }
 
-            _worldMatrix.Translation = new Vector3(offsetX, offsetY, depth);
+            _worldMatrix.Translation = new Vector3(layer.OffsetX, layer.OffsetY, depth);
 
             var effect1 = effect ?? _defaultEffect;
             var tiledMapEffect = effect1 as ITiledMapEffect;

--- a/Source/MonoGame.Extended.Tiled/Graphics/TiledMapRenderer.cs
+++ b/Source/MonoGame.Extended.Tiled/Graphics/TiledMapRenderer.cs
@@ -76,13 +76,28 @@ namespace MonoGame.Extended.Tiled.Graphics
 
         public void Draw(TiledMapLayer layer, ref Matrix viewMatrix, ref Matrix projectionMatrix, Effect effect = null, float depth = 0.0f)
         {
+            Draw(layer, ref viewMatrix, ref projectionMatrix, effect, depth, layer.OffsetX, layer.OffsetY);
+        }
+
+        private void Draw(TiledMapLayer layer, ref Matrix viewMatrix, ref Matrix projectionMatrix, Effect effect, float depth, float offsetX, float offsetY)
+        {
             if (!layer.IsVisible)
                 return;
 
             if (layer is TiledMapObjectLayer)
                 return;
 
-            _worldMatrix.Translation = new Vector3(layer.OffsetX, layer.OffsetY, depth);
+            if (layer is TiledMapGroupLayer)
+            {
+                var group = layer as TiledMapGroupLayer;
+
+                for (int i = 0; i < group.Layers.Count; i++)
+                    Draw(group.Layers[i], ref viewMatrix, ref projectionMatrix, effect, depth, offsetX + group.OffsetX, offsetY + group.OffsetY);
+
+                return;
+            }
+
+            _worldMatrix.Translation = new Vector3(offsetX, offsetY, depth);
 
             var effect1 = effect ?? _defaultEffect;
             var tiledMapEffect = effect1 as ITiledMapEffect;

--- a/Source/MonoGame.Extended.Tiled/MonoGame.Extended.Tiled.csproj
+++ b/Source/MonoGame.Extended.Tiled/MonoGame.Extended.Tiled.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Graphics\TiledMapRenderer.cs" />
     <Compile Include="Graphics\TiledMapLayerModel.cs" />
     <Compile Include="TiledMapEllipseObject.cs" />
+    <Compile Include="TiledMapGroupLayer.cs" />
     <Compile Include="TiledMapHelper.cs" />
     <Compile Include="TiledMapImageLayer.cs" />
     <Compile Include="TiledMapLayer.cs" />

--- a/Source/MonoGame.Extended.Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMap.cs
@@ -75,9 +75,10 @@ namespace MonoGame.Extended.Tiled
             _tilesets.Add(tileset);
         }
 
-        public void AddLayer(TiledMapLayer layer)
+        public void AddLayer(TiledMapLayer layer, bool nested = false)
         {
-            _layers.Add(layer);
+            if (!nested)
+                _layers.Add(layer);
             _layersByName.Add(layer.Name, layer);
 
             var imageLayer = layer as TiledMapImageLayer;

--- a/Source/MonoGame.Extended.Tiled/TiledMapGroupLayer.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapGroupLayer.cs
@@ -7,10 +7,10 @@ namespace MonoGame.Extended.Tiled
     {
         public ReadOnlyCollection<TiledMapLayer> Layers { get; }
 
-        internal TiledMapGroupLayer(ContentReader input, TiledMap map) 
-            : base(input)
+        internal TiledMapGroupLayer(ContentReader input, TiledMap map, TiledMapGroupLayer parent) 
+            : base(input, parent)
         {
-            TiledMapReader.ReadLayers(input, map, true);
+            TiledMapReader.ReadLayers(input, map, true, this);
         }
     }
 }

--- a/Source/MonoGame.Extended.Tiled/TiledMapGroupLayer.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapGroupLayer.cs
@@ -1,0 +1,16 @@
+using System.Collections.ObjectModel;
+using Microsoft.Xna.Framework.Content;
+
+namespace MonoGame.Extended.Tiled
+{
+    public class TiledMapGroupLayer : TiledMapLayer
+    {
+        public ReadOnlyCollection<TiledMapLayer> Layers { get; }
+
+        internal TiledMapGroupLayer(ContentReader input, TiledMap map) 
+            : base(input)
+        {
+            TiledMapReader.ReadLayers(input, map, true);
+        }
+    }
+}

--- a/Source/MonoGame.Extended.Tiled/TiledMapImageLayer.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapImageLayer.cs
@@ -10,8 +10,8 @@ namespace MonoGame.Extended.Tiled
         public Vector2 Position { get; set; }
         public Texture2D Texture { get; }
 
-        internal TiledMapImageLayer(ContentReader input)
-            : base(input)
+        internal TiledMapImageLayer(ContentReader input, TiledMapGroupLayer parent)
+            : base(input, parent)
         {
             var textureAssetName = input.GetRelativeAssetName(input.ReadString());
             Texture = input.ContentManager.Load<Texture2D>(textureAssetName);

--- a/Source/MonoGame.Extended.Tiled/TiledMapLayer.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapLayer.cs
@@ -10,13 +10,29 @@ namespace MonoGame.Extended.Tiled
         internal TiledMapLayerAnimatedModel[] AnimatedModels;
 
         public string Name { get; }
+        public TiledMapGroupLayer Parent { get; }
         public TiledMapProperties Properties { get; }
         public bool IsVisible { get; set; }
         public float Opacity { get; set; }
-        public float OffsetX { get; }
-        public float OffsetY { get; }
+        public float OffsetX
+        {
+            get
+            {
+                return (Parent?.OffsetX ?? 0) + _offsetX;
+            }
+        }
+        public float OffsetY
+        {
+            get
+            {
+                return (Parent?.OffsetY ?? 0) + _offsetY;
+            }
+        }
 
-        internal TiledMapLayer(ContentReader input)
+        private float _offsetX;
+        private float _offsetY;
+
+        internal TiledMapLayer(ContentReader input, TiledMapGroupLayer parent)
         {
             Models = null;
             AnimatedModels = null;
@@ -25,8 +41,9 @@ namespace MonoGame.Extended.Tiled
             Properties = new TiledMapProperties();
             IsVisible = input.ReadBoolean();
             Opacity = input.ReadSingle();
-            OffsetX = input.ReadSingle();
-            OffsetY = input.ReadSingle();
+            _offsetX = input.ReadSingle();
+            _offsetY = input.ReadSingle();
+            Parent = parent;
 
             input.ReadTiledMapProperties(Properties);
         }

--- a/Source/MonoGame.Extended.Tiled/TiledMapLayerType.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapLayerType.cs
@@ -4,6 +4,7 @@
     {
         ImageLayer = 0,
         TileLayer = 1,
-        ObjectLayer = 2
+        ObjectLayer = 2,
+        GroupLayer = 3
     }
 }

--- a/Source/MonoGame.Extended.Tiled/TiledMapObjectLayer.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapObjectLayer.cs
@@ -10,8 +10,8 @@ namespace MonoGame.Extended.Tiled
         public TiledMapObjectDrawOrder DrawOrder { get; }
         public TiledMapObject[] Objects { get; }
 
-        internal TiledMapObjectLayer(ContentReader input, TiledMap map)
-            : base(input)
+        internal TiledMapObjectLayer(ContentReader input, TiledMap map, TiledMapGroupLayer parent)
+            : base(input, parent)
         {
             Color = input.ReadColor();
             DrawOrder = (TiledMapObjectDrawOrder)input.ReadByte();

--- a/Source/MonoGame.Extended.Tiled/TiledMapReader.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapReader.cs
@@ -51,7 +51,7 @@ namespace MonoGame.Extended.Tiled
             }
         }
 
-        internal static void ReadLayers(ContentReader input, TiledMap map, bool nested = false)
+        internal static void ReadLayers(ContentReader input, TiledMap map, bool nested = false, TiledMapGroupLayer parent = null)
         {
             var layerCount = input.ReadInt32();
 
@@ -63,16 +63,16 @@ namespace MonoGame.Extended.Tiled
                 switch (layerType)
                 {
                     case TiledMapLayerType.ImageLayer:
-                        layer = new TiledMapImageLayer(input);
+                        layer = new TiledMapImageLayer(input, parent);
                         break;
                     case TiledMapLayerType.TileLayer:
-                        layer = new TiledMapTileLayer(input, map);
+                        layer = new TiledMapTileLayer(input, map, parent);
                         break;
                     case TiledMapLayerType.ObjectLayer:
-                        layer = new TiledMapObjectLayer(input, map);
+                        layer = new TiledMapObjectLayer(input, map, parent);
                         break;
                     case TiledMapLayerType.GroupLayer:
-                        layer = new TiledMapGroupLayer(input, map);
+                        layer = new TiledMapGroupLayer(input, map, parent);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/Source/MonoGame.Extended.Tiled/TiledMapReader.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapReader.cs
@@ -51,7 +51,7 @@ namespace MonoGame.Extended.Tiled
             }
         }
 
-        private static void ReadLayers(ContentReader input, TiledMap map)
+        internal static void ReadLayers(ContentReader input, TiledMap map, bool nested = false)
         {
             var layerCount = input.ReadInt32();
 
@@ -71,6 +71,9 @@ namespace MonoGame.Extended.Tiled
                     case TiledMapLayerType.ObjectLayer:
                         layer = new TiledMapObjectLayer(input, map);
                         break;
+                    case TiledMapLayerType.GroupLayer:
+                        layer = new TiledMapGroupLayer(input, map);
+                        break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -78,7 +81,7 @@ namespace MonoGame.Extended.Tiled
                 if (layerType != TiledMapLayerType.ObjectLayer)
                     ReadModels(input, layer, map);
 
-                map.AddLayer(layer);
+                map.AddLayer(layer, nested);
             }
         }
 

--- a/Source/MonoGame.Extended.Tiled/TiledMapTileLayer.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapTileLayer.cs
@@ -15,8 +15,8 @@ namespace MonoGame.Extended.Tiled
         public int TileHeight { get; }
         public ReadOnlyCollection<TiledMapTile> Tiles { get; }
 
-        internal TiledMapTileLayer(ContentReader input, TiledMap map) 
-            : base(input)
+        internal TiledMapTileLayer(ContentReader input, TiledMap map, TiledMapGroupLayer parent) 
+            : base(input, parent)
         {
             Width = input.ReadInt32();
             Height = input.ReadInt32();


### PR DESCRIPTION
I added the support for layer groups for Tiled files (Issue  #435 ).

The changes are integrated into the Content Pipeline for reading and writing as well as the drawing logic. To prevent duplicate drawing calls, grouped layers will show as a single "TiledMapGroupLayer" in the TiledMap.Layers list, but will still appear in the specialized TileLayers, ImageLayers, and ObjectLayers lists as well as the private _layersByName dictionary. 