### PR TITLE
Apply kerning to the current glyph.

### DIFF
--- a/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/Source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -187,7 +187,10 @@ namespace MonoGame.Extended.BitmapFonts
                 {
                     int amount;
                     if (_previousGlyph.Value.FontRegion.Kernings.TryGetValue(character, out amount))
+                    { 
                         _positionDelta.X += amount;
+                        _currentGlyph.Position.X += amount;
+                    }
                 }
 
                 _previousGlyph = _currentGlyph;
@@ -302,7 +305,10 @@ namespace MonoGame.Extended.BitmapFonts
                 {
                     int amount;
                     if (_previousGlyph.Value.FontRegion.Kernings.TryGetValue(character, out amount))
+                    { 
                         _positionDelta.X += amount;
+                        _currentGlyph.Position.X += amount;
+                    }
                 }
 
                 _previousGlyph = _currentGlyph;


### PR DESCRIPTION
Kerning value 'amount' wasn't being applied to the '_currentGlyph.Position.X' in either MoveNext() methods, only '_positionDelta.X'. Both are needed for proper positioning.