### PR TITLE
Fix Texture Alignment

### DIFF
--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapLayerModelContent.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapLayerModelContent.cs
@@ -44,8 +44,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
             {
                 var reciprocalWidth = 1f / ImageSize.Width;
                 var reciprocalHeight = 1f / ImageSize.Height;
-                texelLeft = (sourceRectangle1.X + 0.5f) * reciprocalWidth;
-                texelTop = (sourceRectangle1.Y + 0.5f) * reciprocalHeight;
+                texelLeft = sourceRectangle1.X * reciprocalWidth;
+                texelTop = sourceRectangle1.Y * reciprocalHeight;
                 texelRight = (sourceRectangle1.X + sourceRectangle1.Width) * reciprocalWidth;
                 texelBottom = (sourceRectangle1.Y + sourceRectangle1.Height) * reciprocalHeight;
             }

--- a/Source/MonoGame.Extended.Graphics/Geometry/GeometryBuilder2D.cs
+++ b/Source/MonoGame.Extended.Graphics/Geometry/GeometryBuilder2D.cs
@@ -26,8 +26,8 @@ namespace MonoGame.Extended.Graphics.Geometry
 
             if (sourceRectangle.Width > 0)
             {
-                texelLeft = (sourceRectangle.X + 0.5f) / texture.Width;
-                texelTop = (sourceRectangle.Y + 0.5f) / texture.Height;
+                texelLeft = sourceRectangle.X / texture.Width;
+                texelTop = sourceRectangle.Y / texture.Height;
                 texelRight = (sourceRectangle.X + sourceRectangle.Width) / (float)texture.Width;
                 texelBottom = (sourceRectangle.Y + sourceRectangle.Height) / (float)texture.Height;
             }

--- a/Source/MonoGame.Extended.Tiled/TiledMapTilesetTileAnimationFrame.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapTilesetTileAnimationFrame.cs
@@ -21,8 +21,8 @@ namespace MonoGame.Extended.Tiled
         {
             var sourceRectangle = tileset.GetTileRegion(LocalTileIdentifier);
             var texture = tileset.Texture;
-            var texelLeft = (sourceRectangle.X + 0.5f) / texture.Width;
-            var texelTop = (sourceRectangle.Y + 0.5f) / texture.Height;
+            var texelLeft = sourceRectangle.X / texture.Width;
+            var texelTop = sourceRectangle.Y / texture.Height;
             var texelRight = (sourceRectangle.X + sourceRectangle.Width) / (float)texture.Width;
             var texelBottom = (sourceRectangle.Y + sourceRectangle.Height) / (float)texture.Height;
 


### PR DESCRIPTION
Fixes rendering issue from #476. `0.5f` was added to the texture rendering logic to prevent tile bleeding, but causes the tile to be rendered 1/2 pixel less in width and height, then stretched to the full size of the tile. The other bleeding issues I found in that issue appear to be unrelated.