### PR TITLE
Scale Particles without Maintaining Aspect Ratio

### DIFF
--- a/Source/MonoGame.Extended.Particles/ParticleEmitter.cs
+++ b/Source/MonoGame.Extended.Particles/ParticleEmitter.cs
@@ -196,8 +196,17 @@ namespace MonoGame.Extended.Particles
                 _random.NextColor(out particle->Color, Parameters.Color);
 
                 particle->Opacity = _random.NextSingle(Parameters.Opacity);
-                var scale = _random.NextSingle(Parameters.Scale);
-                particle->Scale = new Vector2(scale, scale);
+                
+                if(Parameters.MaintainAspectRatioOnScale)
+                {
+                    var scale = _random.NextSingle(Parameters.Scale);
+                    particle->Scale = new Vector2(scale, scale);
+                }
+                else
+                {
+                    particle->Scale = new Vector2(_random.NextSingle(Parameters.ScaleX), _random.NextSingle(Parameters.ScaleY));
+                }
+                
                 particle->Rotation = _random.NextSingle(Parameters.Rotation);
                 particle->Mass = _random.NextSingle(Parameters.Mass);
                 particle->LayerDepth = layerDepth;

--- a/Source/MonoGame.Extended.Particles/ParticleReleaseParameters.cs
+++ b/Source/MonoGame.Extended.Particles/ParticleReleaseParameters.cs
@@ -14,6 +14,9 @@ namespace MonoGame.Extended.Particles
             Scale = new Range<float>(1f, 1f);
             Rotation = new Range<float>(-MathHelper.Pi, MathHelper.Pi);
             Mass = 1f;
+            MaintainAspectRatioOnScale = true;
+            ScaleX = new Range<float>(1f, 1f);
+            ScaleY = new Range<float>(1f, 1f);
         }
 
         public Range<int> Quantity { get; set; }
@@ -23,5 +26,9 @@ namespace MonoGame.Extended.Particles
         public Range<float> Scale { get; set; }
         public Range<float> Rotation { get; set; }
         public Range<float> Mass { get; set; }
+        public bool MaintainAspectRatioOnScale { get; set; }
+        public Range<float> ScaleX { get; set; }
+        public Range<float> ScaleY { get; set; }
+
     }
 }


### PR DESCRIPTION
Basically added a ScaleX and ScaleY, and a MaintainAspectRatio switch to ParticleReleaseParametes. Pretty simple change that adds some additional functionality to the particle system that shouldn't have any performance impacts.

Example:

```csharp
            _particleEffect = new ParticleEffect
            {
                Emitters = new List<ParticleEmitter>
                {
                    new ParticleEmitter(textureRegion, 500, TimeSpan.FromSeconds(2.5),
                        Profile.Ring(150f, Profile.CircleRadiation.In))
                    {
                        Parameters = new ParticleReleaseParameters
                        {
                            Speed = new Range<float>(0f, 50f),
                            Quantity = 1,
                            MaintainAspectRatioOnScale = false,
                            ScaleX = new Range<float>(10f, 60f),
                            ScaleY = new Range<float>(10f, 50f),
                            Rotation = 0
                        }
                    }
                }
            };
````

![image](https://user-images.githubusercontent.com/2897796/37482740-a1046d2c-284a-11e8-86ad-3ebc124adfbf.png)
(Video:https://i.imgur.com/Aqx0Xzy.gifv)
