### PR TITLE
Add OnAddedToEntity and OnRemovedFromEntity methods to components

### DIFF
--- a/Source/MonoGame.Extended.Entities/EntityComponent.cs
+++ b/Source/MonoGame.Extended.Entities/EntityComponent.cs
@@ -80,6 +80,9 @@ namespace MonoGame.Extended.Entities
             _returnToPoolDelegate = null;
         }
 
+        public virtual void OnAddedToEntity() { }
+        public virtual void OnRemovedFromEntity() { }
+
         public override string ToString()
         {
             return $"Entity: {Entity}";

--- a/Source/MonoGame.Extended.Entities/EntityManager.cs
+++ b/Source/MonoGame.Extended.Entities/EntityManager.cs
@@ -322,6 +322,8 @@ namespace MonoGame.Extended.Entities
 
             MarkEntityToBeRefreshed(entity);
 
+            component.OnAddedToEntity();
+
             return component;
         }
 
@@ -383,6 +385,8 @@ namespace MonoGame.Extended.Entities
 
                 components.Remove(entity);
                 component.Return();
+
+                component.OnRemovedFromEntity();
             }
 
             _componentsToRemove.Clear();

--- a/Source/MonoGame.Extended.Entities/EntityManager.cs
+++ b/Source/MonoGame.Extended.Entities/EntityManager.cs
@@ -410,6 +410,7 @@ namespace MonoGame.Extended.Entities
                     continue;
 
                 components.Remove(entity);
+                component.OnRemovedFromEntity();
             }
         }
 


### PR DESCRIPTION
This allows the components to safely use `Get` on the entity without getting a `NullReferenceException`.