### PR TITLE
Texture bug fix

### DIFF
--- a/Source/MonoGame.Extended.Graphics/Geometry/GeometryBuilder2D.cs
+++ b/Source/MonoGame.Extended.Graphics/Geometry/GeometryBuilder2D.cs
@@ -26,8 +26,8 @@ namespace MonoGame.Extended.Graphics.Geometry
 
             if (sourceRectangle.Width > 0)
             {
-                texelLeft = sourceRectangle.X / texture.Width;
-                texelTop = sourceRectangle.Y / texture.Height;
+                texelLeft = (float)sourceRectangle.X / texture.Width;
+                texelTop = (float)sourceRectangle.Y / texture.Height;
                 texelRight = (sourceRectangle.X + sourceRectangle.Width) / (float)texture.Width;
                 texelBottom = (sourceRectangle.Y + sourceRectangle.Height) / (float)texture.Height;
             }

--- a/Source/MonoGame.Extended.Tiled/TiledMapTilesetTileAnimationFrame.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapTilesetTileAnimationFrame.cs
@@ -21,8 +21,8 @@ namespace MonoGame.Extended.Tiled
         {
             var sourceRectangle = tileset.GetTileRegion(LocalTileIdentifier);
             var texture = tileset.Texture;
-            var texelLeft = sourceRectangle.X / texture.Width;
-            var texelTop = sourceRectangle.Y / texture.Height;
+            var texelLeft = (float)sourceRectangle.X / texture.Width;
+            var texelTop = (float)sourceRectangle.Y / texture.Height;
             var texelRight = (sourceRectangle.X + sourceRectangle.Width) / (float)texture.Width;
             var texelBottom = (sourceRectangle.Y + sourceRectangle.Height) / (float)texture.Height;
 


### PR DESCRIPTION
When I released #480 to fix some texture alignment issues, I failed to check the variable types for the math being done. With my original fix by removing the `+ 0.5f` overdraw, the math changed from `float` division to `int` division. I'm now recasting for `float` division as it should be!

My bad!!