### PR TITLE
Importing pivot data

### DIFF
--- a/Source/MonoGame.Extended.Content.Pipeline/TextureAtlases/TexturePackerWriter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/TextureAtlases/TexturePackerWriter.cs
@@ -29,6 +29,7 @@ namespace MonoGame.Extended.Content.Pipeline.TextureAtlases
                 writer.Write(region.Frame.Y);
                 writer.Write(region.Frame.Width);
                 writer.Write(region.Frame.Height);
+                writer.Write(new Microsoft.Xna.Framework.Vector2((float)region.PivotPoint.X,(float)region.PivotPoint.Y));
             }
         }
 

--- a/Source/MonoGame.Extended/Sprites/Sprite.cs
+++ b/Source/MonoGame.Extended/Sprites/Sprite.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -34,15 +34,7 @@ namespace MonoGame.Extended.Sprites
         public float Depth { get; set; }
         public object Tag { get; set; }
 
-        public Vector2 OriginNormalized
-        {
-            get { return new Vector2(Origin.X/TextureRegion.Width, Origin.Y/TextureRegion.Height); }
-            set {
-                  Origin = Effect == SpriteEffects.None
-                      ? new Vector2(value.X * TextureRegion.Width, value.Y * TextureRegion.Height)
-                      : new Vector2((1 - value.X) * TextureRegion.Width, value.Y * TextureRegion.Height);
-                }
-        }
+        public Vector2 OriginNormalized { get; set; }
 
         public Color Color { get; set; }
 
@@ -59,7 +51,9 @@ namespace MonoGame.Extended.Sprites
 
         public bool IsVisible { get; set; }
         public Vector2 Origin { get; set; }
-        public SpriteEffects Effect { get; set; }
+
+        private SpriteEffects effect;
+        public SpriteEffects Effect { get { return effect; } set { effect = value; GetOrigin(); } }
 
         public TextureRegion2D TextureRegion
         {
@@ -70,9 +64,12 @@ namespace MonoGame.Extended.Sprites
                     throw new InvalidOperationException("TextureRegion cannot be null");
 
                 // preserve the origin if the texture size changes
-                //var originNormalized = OriginNormalized;
+                /*var originNormalized = OriginNormalized;
                 _textureRegion = value;
-                OriginNormalized = _textureRegion.Anchor;
+                OriginNormalized = originNormalized;*/
+                _textureRegion = value;
+                OriginNormalized = _textureRegion.OriginNormalized;
+                GetOrigin();
             }
         }
 
@@ -84,8 +81,8 @@ namespace MonoGame.Extended.Sprites
 
             if (Scale != Vector2.One)
             {
-                min = min*Scale;
-                max = max*Scale;
+                min = min * Scale;
+                max = max * Scale;
             }
 
             var corners = new Vector2[4];
@@ -107,6 +104,14 @@ namespace MonoGame.Extended.Sprites
                 corners[i] += offset;
 
             return corners;
+        }
+
+        private void GetOrigin()
+        {
+            Origin = TextureRegion.Size *
+                                            new Vector2(
+                                                (int)Effect % 2 == 0 ? OriginNormalized.X : 1 - OriginNormalized.X,
+                                                (int)Effect < 2 ? OriginNormalized.Y : 1 - OriginNormalized.Y);
         }
     }
 }

--- a/Source/MonoGame.Extended/Sprites/Sprite.cs
+++ b/Source/MonoGame.Extended/Sprites/Sprite.cs
@@ -37,7 +37,11 @@ namespace MonoGame.Extended.Sprites
         public Vector2 OriginNormalized
         {
             get { return new Vector2(Origin.X/TextureRegion.Width, Origin.Y/TextureRegion.Height); }
-            set { Origin = new Vector2(value.X*TextureRegion.Width, value.Y*TextureRegion.Height); }
+            set {
+                  Origin = Effect == SpriteEffects.None
+                      ? new Vector2(value.X * TextureRegion.Width, value.Y * TextureRegion.Height)
+                      : new Vector2((1 - value.X) * TextureRegion.Width, value.Y * TextureRegion.Height);
+                }
         }
 
         public Color Color { get; set; }
@@ -66,9 +70,9 @@ namespace MonoGame.Extended.Sprites
                     throw new InvalidOperationException("TextureRegion cannot be null");
 
                 // preserve the origin if the texture size changes
-                var originNormalized = OriginNormalized;
+                //var originNormalized = OriginNormalized;
                 _textureRegion = value;
-                OriginNormalized = originNormalized;
+                OriginNormalized = _textureRegion.Anchor;
             }
         }
 

--- a/Source/MonoGame.Extended/TextureAtlases/TextureAtlas.cs
+++ b/Source/MonoGame.Extended/TextureAtlases/TextureAtlas.cs
@@ -48,7 +48,7 @@ namespace MonoGame.Extended.TextureAtlases
             : this(name, texture)
         {
             foreach (var region in regions)
-                CreateRegion(region.Key, region.Value.X, region.Value.Y, region.Value.Width, region.Value.Height, default(Vector2));
+                CreateRegion(region.Key, region.Value.X, region.Value.Y, region.Value.Width, region.Value.Height);
         }
 
         private readonly Dictionary<string, int> _regionMap;
@@ -122,12 +122,12 @@ namespace MonoGame.Extended.TextureAtlases
         /// <param name="width">Width of the texture region.</param>
         /// <param name="height">Height of the texture region.</param>
         /// <returns>Created texture region.</returns>
-        public TextureRegion2D CreateRegion(string name, int x, int y, int width, int height, Vector2 anchor)
+        public TextureRegion2D CreateRegion(string name, int x, int y, int width, int height, Vector2 originNormalized = default(Vector2))
         {
             if (_regionMap.ContainsKey(name))
                 throw new InvalidOperationException($"Region {name} already exists in the texture atlas");
 
-            var region = new TextureRegion2D(name, Texture, x, y, width, height, anchor);
+            var region = new TextureRegion2D(name, Texture, x, y, width, height, originNormalized);
             AddRegion(region);
             return region;
         }
@@ -243,7 +243,7 @@ namespace MonoGame.Extended.TextureAtlases
                 for (var x = margin; x < width; x += xIncrement)
                 {
                     var regionName = $"{texture.Name ?? "region"}{count}";
-                    textureAtlas.CreateRegion(regionName, x, y, regionWidth, regionHeight, default(Vector2));
+                    textureAtlas.CreateRegion(regionName, x, y, regionWidth, regionHeight);
                     count++;
 
                     if (count >= maxRegionCount)

--- a/Source/MonoGame.Extended/TextureAtlases/TextureAtlas.cs
+++ b/Source/MonoGame.Extended/TextureAtlases/TextureAtlas.cs
@@ -48,7 +48,7 @@ namespace MonoGame.Extended.TextureAtlases
             : this(name, texture)
         {
             foreach (var region in regions)
-                CreateRegion(region.Key, region.Value.X, region.Value.Y, region.Value.Width, region.Value.Height);
+                CreateRegion(region.Key, region.Value.X, region.Value.Y, region.Value.Width, region.Value.Height, default(Vector2));
         }
 
         private readonly Dictionary<string, int> _regionMap;
@@ -122,12 +122,12 @@ namespace MonoGame.Extended.TextureAtlases
         /// <param name="width">Width of the texture region.</param>
         /// <param name="height">Height of the texture region.</param>
         /// <returns>Created texture region.</returns>
-        public TextureRegion2D CreateRegion(string name, int x, int y, int width, int height)
+        public TextureRegion2D CreateRegion(string name, int x, int y, int width, int height, Vector2 anchor)
         {
             if (_regionMap.ContainsKey(name))
                 throw new InvalidOperationException($"Region {name} already exists in the texture atlas");
 
-            var region = new TextureRegion2D(name, Texture, x, y, width, height);
+            var region = new TextureRegion2D(name, Texture, x, y, width, height, anchor);
             AddRegion(region);
             return region;
         }
@@ -243,7 +243,7 @@ namespace MonoGame.Extended.TextureAtlases
                 for (var x = margin; x < width; x += xIncrement)
                 {
                     var regionName = $"{texture.Name ?? "region"}{count}";
-                    textureAtlas.CreateRegion(regionName, x, y, regionWidth, regionHeight);
+                    textureAtlas.CreateRegion(regionName, x, y, regionWidth, regionHeight, default(Vector2));
                     count++;
 
                     if (count >= maxRegionCount)

--- a/Source/MonoGame.Extended/TextureAtlases/TextureAtlasReader.cs
+++ b/Source/MonoGame.Extended/TextureAtlases/TextureAtlasReader.cs
@@ -21,7 +21,8 @@ namespace MonoGame.Extended.TextureAtlases
                     reader.ReadInt32(),
                     reader.ReadInt32(),
                     reader.ReadInt32(),
-                    reader.ReadInt32());
+                    reader.ReadInt32()
+                    reader.ReadVector2());
             }
 
             return atlas;

--- a/Source/MonoGame.Extended/TextureAtlases/TextureRegion2D.cs
+++ b/Source/MonoGame.Extended/TextureAtlases/TextureRegion2D.cs
@@ -15,7 +15,7 @@ namespace MonoGame.Extended.TextureAtlases
             : this(null, texture, region.X, region.Y, region.Width, region.Height)
         {
         }
-        
+
         public TextureRegion2D(string name, Texture2D texture, Rectangle region)
             : this(name, texture, region.X, region.Y, region.Width, region.Height)
         {
@@ -26,7 +26,7 @@ namespace MonoGame.Extended.TextureAtlases
         {
         }
 
-        public TextureRegion2D(string name, Texture2D texture, int x, int y, int width, int height)
+        public TextureRegion2D(string name, Texture2D texture, int x, int y, int width, int height, Vector2 anchor = default(Vector2))
         {
             if (texture == null) throw new ArgumentNullException(nameof(texture));
 
@@ -36,6 +36,7 @@ namespace MonoGame.Extended.TextureAtlases
             Y = y;
             Width = width;
             Height = height;
+            Anchor = anchor;
         }
 
         public string Name { get; }
@@ -47,6 +48,7 @@ namespace MonoGame.Extended.TextureAtlases
         public Size2 Size => new Size2(Width, Height);
         public object Tag { get; set; }
         public Rectangle Bounds => new Rectangle(X, Y, Width, Height);
+        public Vector2 Anchor { get; }
 
         public override string ToString()
         {

--- a/Source/MonoGame.Extended/TextureAtlases/TextureRegion2D.cs
+++ b/Source/MonoGame.Extended/TextureAtlases/TextureRegion2D.cs
@@ -6,27 +6,27 @@ namespace MonoGame.Extended.TextureAtlases
 {
     public class TextureRegion2D
     {
-        public TextureRegion2D(Texture2D texture, int x, int y, int width, int height)
-            : this(null, texture, x, y, width, height)
+        public TextureRegion2D(Texture2D texture, int x, int y, int width, int height, Vector2 originNormalized = default(Vector2))
+            : this(null, texture, x, y, width, height, originNormalized)
         {
         }
 
-        public TextureRegion2D(Texture2D texture, Rectangle region)
-            : this(null, texture, region.X, region.Y, region.Width, region.Height)
+        public TextureRegion2D(Texture2D texture, Rectangle region, Vector2 originNormalized = default(Vector2))
+            : this(null, texture, region.X, region.Y, region.Width, region.Height, originNormalized)
         {
         }
 
-        public TextureRegion2D(string name, Texture2D texture, Rectangle region)
-            : this(name, texture, region.X, region.Y, region.Width, region.Height)
+        public TextureRegion2D(string name, Texture2D texture, Rectangle region, Vector2 originNormalized = default(Vector2))
+            : this(name, texture, region.X, region.Y, region.Width, region.Height, originNormalized)
         {
         }
 
-        public TextureRegion2D(Texture2D texture)
-            : this(texture.Name, texture, 0, 0, texture.Width, texture.Height)
+        public TextureRegion2D(Texture2D texture, Vector2 originNormalized = default(Vector2))
+            : this(texture.Name, texture, 0, 0, texture.Width, texture.Height, originNormalized)
         {
         }
 
-        public TextureRegion2D(string name, Texture2D texture, int x, int y, int width, int height, Vector2 anchor = default(Vector2))
+        public TextureRegion2D(string name, Texture2D texture, int x, int y, int width, int height, Vector2 originNormalized = default(Vector2))
         {
             if (texture == null) throw new ArgumentNullException(nameof(texture));
 
@@ -36,7 +36,7 @@ namespace MonoGame.Extended.TextureAtlases
             Y = y;
             Width = width;
             Height = height;
-            Anchor = anchor;
+            OriginNormalized = originNormalized;
         }
 
         public string Name { get; }
@@ -48,7 +48,7 @@ namespace MonoGame.Extended.TextureAtlases
         public Size2 Size => new Size2(Width, Height);
         public object Tag { get; set; }
         public Rectangle Bounds => new Rectangle(X, Y, Width, Height);
-        public Vector2 Anchor { get; }
+        public Vector2 OriginNormalized { get; }
 
         public override string ToString()
         {


### PR DESCRIPTION
Added anchor (pivot) property to TextureRegion2D class, it is applied to each frame.
Values were properly imported, but were not going further **TexturePackerRegion** class, I've make a bridge between input data & **Sprite** class:

**Vector2 Pivot ===> TexturePackerRegion => TexturePackerWriter =>
=> TextureAtlasReader => TextureAtlas => TextureRegion2D ===> Sprite.OriginNormalized**