### PR TITLE
Build Textures With Prefered Transparent Color

### DIFF
--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapImageContent.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapImageContent.cs
@@ -1,3 +1,4 @@
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using System.Xml.Serialization;
@@ -24,8 +25,15 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
         [XmlAttribute(AttributeName = "format")]
         public string Format { get; set; }
 
-        [XmlAttribute(AttributeName = "trans")]
-        public string TransparentColor { get; set; }
+		[XmlAttribute(AttributeName = "trans")]
+		public string RawTransparentColor { get; set; } = string.Empty;
+
+		[XmlIgnore]
+		public Color TransparentColor
+		{
+			get => RawTransparentColor == string.Empty ? Color.TransparentBlack : ColorHelper.FromHex(RawTransparentColor);
+			set => RawTransparentColor = ColorHelper.ToHex(value);
+		}
 
         [XmlElement(ElementName = "data")]
         public TiledMapTileLayerDataContent Data { get; set; }

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapProcessor.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
@@ -27,7 +28,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 				{
 					if (String.IsNullOrWhiteSpace(tileset.Source))
 						// Load the Texture2DContent for the tileset as it will be saved into the map content file.
-						tileset.Image.ContentRef = context.BuildAsset<Texture2DContent, Texture2DContent>(new ExternalReference<Texture2DContent>(tileset.Image.Source), "");
+						tileset.Image.ContentRef = context.BuildAsset<Texture2DContent, Texture2DContent>(new ExternalReference<Texture2DContent>(tileset.Image.Source), "", new OpaqueDataDictionary() { { "ColorKeyColor", tileset.Image.TransparentColor }, { "ColorKeyEnabled", true } }, "", "");
 					else
 						// Link to the tileset for the content loader to load at runtime.
 						tileset.Content = context.BuildAsset<TiledMapTilesetContent, TiledMapTilesetContent>(new ExternalReference<TiledMapTilesetContent>(tileset.Source), "");
@@ -58,7 +59,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 				if (layer is TiledMapImageLayerContent imageLayer)
 				{
 					ContentLogger.Log($"Processing image layer '{imageLayer.Name}'");
-					imageLayer.Image.ContentRef = context.BuildAsset<Texture2DContent, Texture2DContent>(new ExternalReference<Texture2DContent>(imageLayer.Image.Source), "");
+					imageLayer.Image.ContentRef = context.BuildAsset<Texture2DContent, Texture2DContent>(new ExternalReference<Texture2DContent>(imageLayer.Image.Source), "", new OpaqueDataDictionary() { { "ColorKeyColor", imageLayer.Image.TransparentColor }, { "ColorKeyEnabled", true } }, "", "");
 					ContentLogger.Log($"Processed image layer '{imageLayer.Name}'");
 				}
 

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapTilesetProcessor.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapTilesetProcessor.cs
@@ -17,7 +17,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 
 				ContentLogger.Log($"Processing tileset '{tileset.Name}'");
 				// Build the Texture2D asset and load it as it will be saved as part of this tileset file.
-				tileset.Image.ContentRef = context.BuildAsset<Texture2DContent, Texture2DContent>(new ExternalReference<Texture2DContent>(tileset.Image.Source), "");
+				tileset.Image.ContentRef = context.BuildAsset<Texture2DContent, Texture2DContent>(new ExternalReference<Texture2DContent>(tileset.Image.Source), "", new OpaqueDataDictionary() { { "ColorKeyColor", tileset.Image.TransparentColor }, { "ColorKeyEnabled", true } }, "", "");
 
 				foreach (var tile in tileset.Tiles)
 					foreach (var obj in tile.Objects)


### PR DESCRIPTION
Pass the transparent color provided by the .TMX or .TSX file to the Texture processor for custom transparency.