### PR TITLE
fix reflection bug

### DIFF
--- a/Source/MonoGame.Extended.Gui/Controls/TextBox.cs
+++ b/Source/MonoGame.Extended.Gui/Controls/TextBox.cs
@@ -10,8 +10,13 @@ namespace MonoGame.Extended.Gui.Controls
     public sealed class TextBox : Control
     {
         public TextBox(string text = null)
+            : this()
         {
             Text = text ?? string.Empty;
+        }
+
+        public TextBox()
+        {
             HorizontalTextAlignment = HorizontalAlignment.Left;
         }
 

--- a/Source/MonoGame.Extended.Gui/Controls/TextBox.cs
+++ b/Source/MonoGame.Extended.Gui/Controls/TextBox.cs
@@ -10,14 +10,14 @@ namespace MonoGame.Extended.Gui.Controls
     public sealed class TextBox : Control
     {
         public TextBox(string text = null)
-            : this()
         {
             Text = text ?? string.Empty;
+            HorizontalTextAlignment = HorizontalAlignment.Left;
         }
 
         public TextBox()
+            : this(null)
         {
-            HorizontalTextAlignment = HorizontalAlignment.Left;
         }
 
         public int SelectionStart { get; set; }

--- a/Source/MonoGame.Extended.Gui/GuiSystem.cs
+++ b/Source/MonoGame.Extended.Gui/GuiSystem.cs
@@ -133,7 +133,7 @@ namespace MonoGame.Extended.Gui
         //    }
         //}
 
-        private void UpdateControl(Control control, float deltaSeconds)
+        public void UpdateControl(Control control, float deltaSeconds)
         {
             if (control.IsVisible)
             {


### PR DESCRIPTION
When I want to create an instantiated control by means of reflection, it has an error and requires a constructor with no arguments. So I want to fix it.

Another one is to change the readability of updatecontrol to public, because when I want to use this library, there is a conflict, I have to manually update the state of the control. I can't update the state with guisystem.update. Because it will happen to find an instance of TouchPad.

https://github.com/MarcStan/MonoGame.Framework.WpfInterop/issues/10