### PR TITLE
Fix Tile Animation Textures

### DIFF
--- a/Source/MonoGame.Extended.Tiled/TiledMapTilesetTileAnimationFrame.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMapTilesetTileAnimationFrame.cs
@@ -21,8 +21,8 @@ namespace MonoGame.Extended.Tiled
         {
             var sourceRectangle = tileset.GetTileRegion(LocalTileIdentifier);
             var texture = tileset.Texture;
-            var texelLeft = sourceRectangle.X / texture.Width;
-            var texelTop = sourceRectangle.Y / texture.Height;
+            var texelLeft = (sourceRectangle.X + 0.5f) / texture.Width;
+            var texelTop = (sourceRectangle.Y + 0.5f) / texture.Height;
             var texelRight = (sourceRectangle.X + sourceRectangle.Width) / (float)texture.Width;
             var texelBottom = (sourceRectangle.Y + sourceRectangle.Height) / (float)texture.Height;
 


### PR DESCRIPTION
Noticed when upgrading MonoGame.Extended.Tiled NuGet from 1.0.617 to 1.1.0 that the Tiled tile animation textures were not rendering correctly.  This adjustment (which effectively reverts part of a check-in after 1.0.617) fixes the issue.