### PR TITLE
Remove isLoaded when load screen

### DIFF
--- a/Source/MonoGame.Extended/Screens/ScreenManager.cs
+++ b/Source/MonoGame.Extended/Screens/ScreenManager.cs
@@ -35,11 +35,9 @@ namespace MonoGame.Extended.Screens
 
             screen.ScreenManager = this;
 
-            if (!_isInitialized)
-                screen.Initialize();
+            screen.Initialize();
 
-            if (!_isLoaded)
-                screen.LoadContent();
+            screen.LoadContent();
 
             _activeScreen = screen;
         }


### PR DESCRIPTION
It seems the two IF conditions is not needed.
When using the function of ScreenManager.LoadScreen(),  the isLoaded variable has already been setted to true.