### PR TITLE
Some input listener code for migrating games from System.Windows.Forms

### DIFF
--- a/Source/MonoGame.Extended.Input/InputListeners/KeyboardEventArgs.cs
+++ b/Source/MonoGame.Extended.Input/InputListeners/KeyboardEventArgs.cs
@@ -21,6 +21,7 @@ namespace MonoGame.Extended.Input.InputListeners
                 Modifiers |= KeyboardModifiers.Alt;
         }
 
+        public bool Handled { get; set; } = false;
         public Keys Key { get; }
         public KeyboardModifiers Modifiers { get; }
 

--- a/Source/MonoGame.Extended.Input/MouseButton.cs
+++ b/Source/MonoGame.Extended.Input/MouseButton.cs
@@ -5,11 +5,11 @@ namespace MonoGame.Extended.Input
     [Flags]
     public enum MouseButton
     {
-        None,
-        Left,
-        Middle,
-        Right,
-        XButton1,
-        XButton2
+        None = 0,
+        Left = 1048576,
+        Middle = 4194304,
+        Right = 2097152,
+        XButton1 = 8388608,
+        XButton2 = 16777216
     }
 }


### PR DESCRIPTION
1.  Add Handled property to KeybordEventArgs for migrating games code using System.Windows.KeyEventArgs
2. Let MouseButton enum can be used as bit flags, as the System.Windows.Forms.MouseButton do