### PR TITLE
ensure systems cleanup on world dispose

### DIFF
--- a/Source/MonoGame.Extended.Entities/World.cs
+++ b/Source/MonoGame.Extended.Entities/World.cs
@@ -26,6 +26,9 @@ namespace MonoGame.Extended.Entities
             foreach (var drawSystem in _drawSystems)
                 drawSystem.Dispose();
 
+            _updateSystems.Clear();
+            _drawSystems.Clear();
+            
             base.Dispose();
         }
 


### PR DESCRIPTION
Calling world dispose, _drawSystems and _updateSystems should be cleaned up I think.

If it is not, calling world.Dispose() doesn't not effetctively clean up the world.

In my case I have a TiledMapRenderer used from a RenderSystem to draw the map. If I dispose the world, the render system should be garbage collected. If it is not, the tiledMapRenderer still draws the map because the RenderSystem still exists.

If there is a better way to do this please let me know.