### PR TITLE
Check for existing layer name

### DIFF
--- a/Source/MonoGame.Extended.Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMap.cs
@@ -69,10 +69,10 @@ namespace MonoGame.Extended.Tiled
 		private void AddLayer(TiledMapLayer layer, bool root)
         {
 			if (root) _layers.Add(layer);
+			
 			if (_layersByName.ContainsKey(layer.Name))
-			{
-				throw new Exception($"The TiledMap \"{Name}\" contains two or more layers named \"{layer.Name}\". Please ensure all layers have unique names.");
-			}
+				throw new ArgumentException($"The TiledMap '{Name}' contains two or more layers named '{layer.Name}'. Please ensure all layers have unique names.");
+
 			_layersByName.Add(layer.Name, layer);
 
 			switch(layer)

--- a/Source/MonoGame.Extended.Tiled/TiledMap.cs
+++ b/Source/MonoGame.Extended.Tiled/TiledMap.cs
@@ -69,6 +69,10 @@ namespace MonoGame.Extended.Tiled
 		private void AddLayer(TiledMapLayer layer, bool root)
         {
 			if (root) _layers.Add(layer);
+			if (_layersByName.ContainsKey(layer.Name))
+			{
+				throw new Exception($"The TiledMap \"{Name}\" contains two or more layers named \"{layer.Name}\". Please ensure all layers have unique names.");
+			}
 			_layersByName.Add(layer.Name, layer);
 
 			switch(layer)


### PR DESCRIPTION
This PR adds checks for an existing layer by name before adding new layer for a TiledMap (see #617) If layer name already exists, a descriptive exception is thrown instead of the generic ArgumentException.