### PR TITLE
Fixed pathing issues creating problems loading Tiled assets

### DIFF
--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapImporter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapImporter.cs
@@ -52,14 +52,14 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 
 					if (!string.IsNullOrWhiteSpace(tileset.Source))
 					{
-						tileset.Source = $"{Path.GetDirectoryName(mapFilePath)}/{tileset.Source}";
-						ContentLogger.Log($"Adding dependency for {tileset.Source}");
+                        tileset.Source = Path.Combine(Path.GetDirectoryName(mapFilePath), tileset.Source);
+                        ContentLogger.Log($"Adding dependency for {tileset.Source}");
 						// We depend on the tileset. If the tileset changes, the map also needs to rebuild.
 						context.AddDependency(tileset.Source);
 					}
 					else
 					{
-						tileset.Image.Source = $"{Path.GetDirectoryName(mapFilePath)}/{tileset.Image.Source}";
+                        tileset.Image.Source = Path.Combine(Path.GetDirectoryName(mapFilePath), tileset.Image.Source);
 						ContentLogger.Log($"Adding dependency for {tileset.Image.Source}");
 						context.AddDependency(tileset.Image.Source);
 					}
@@ -78,7 +78,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 			{
 				if (layers[i] is TiledMapImageLayerContent imageLayer)
 				{
-					imageLayer.Image.Source = $"{path}/{imageLayer.Image.Source}";
+                    imageLayer.Image.Source = Path.Combine(path, imageLayer.Image.Source);
 					ContentLogger.Log($"Adding dependency for '{imageLayer.Image.Source}'");
 
 					// Tell the pipeline that we depend on this image and need to rebuild the map if the image changes.
@@ -89,8 +89,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 					foreach (var obj in objectLayer.Objects)
 						if (!String.IsNullOrWhiteSpace(obj.TemplateSource))
 						{
-							obj.TemplateSource = $"{path}/{obj.TemplateSource}";
-							ContentLogger.Log($"Adding dependency for '{obj.TemplateSource}'");
+                            obj.TemplateSource = Path.Combine(path, obj.TemplateSource);
+                            ContentLogger.Log($"Adding dependency for '{obj.TemplateSource}'");
 							// Tell the pipeline that we depend on this template and need to rebuild the map if the template changes.
 							// (Templates are loaded into objects on process, so all objects which depend on the template file
 							//  need the change to the template)

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapObjectTemplateImporter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapObjectTemplateImporter.cs
@@ -41,8 +41,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 
 				if (!string.IsNullOrWhiteSpace(template.Tileset?.Source))
 				{
-					template.Tileset.Source = $"{Path.GetDirectoryName(filePath)}/{template.Tileset.Source}";
-					ContentLogger.Log($"Adding dependency '{template.Tileset.Source}'");
+                    template.Tileset.Source = Path.Combine(Path.GetDirectoryName(filePath), template.Tileset.Source);
+                    ContentLogger.Log($"Adding dependency '{template.Tileset.Source}'");
 					// We depend on this tileset.
 					context.AddDependency(template.Tileset.Source);
 				}

--- a/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapTilesetImporter.cs
+++ b/Source/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapTilesetImporter.cs
@@ -39,8 +39,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 				var tilesetSerializer = new XmlSerializer(typeof(TiledMapTilesetContent));
 				var tileset = (TiledMapTilesetContent)tilesetSerializer.Deserialize(reader);
 
-				tileset.Image.Source = $"{Path.GetDirectoryName(filePath)}/{tileset.Image.Source}";
-				ContentLogger.Log($"Adding dependency '{tileset.Image.Source}'");
+                tileset.Image.Source = Path.Combine(Path.GetDirectoryName(filePath), tileset.Image.Source);
+                ContentLogger.Log($"Adding dependency '{tileset.Image.Source}'");
 				context.AddDependency(tileset.Image.Source);
 
 				foreach (var tile in tileset.Tiles)
@@ -49,8 +49,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 				    {
 				        if (!string.IsNullOrWhiteSpace(obj.TemplateSource))
 				        {
-				            obj.TemplateSource = $"{Path.GetDirectoryName(filePath)}/{obj.TemplateSource}";
-				            ContentLogger.Log($"Adding dependency '{obj.TemplateSource}'");
+				            obj.TemplateSource = Path.Combine(Path.GetDirectoryName(filePath), obj.TemplateSource);
+                            ContentLogger.Log($"Adding dependency '{obj.TemplateSource}'");
 
 				            // We depend on the template.
 				            context.AddDependency(obj.TemplateSource);


### PR DESCRIPTION
I was having an issue loading Tiled maps, since in some cases the path to the asset contained \\ and / along the same path.  When debugging the pipeline writers, I would see things like this for the path:
"C:\\Users\\Cory\\source\\repos\\MonoGame\\Tools\\Pipeline\\Content/CollisionTileSet.tsx"

Using Path.Combine instead kept the slashes consistent and fixed the issue.

I looked for other placed in MonoGame.Extended with this same pattern and replaced them with Path.Combine.