### PR TITLE
Improved collision performance and Re-added collision demo

### DIFF
--- a/Source/Demos/Tutorials/Demos/CollisionDemo.cs
+++ b/Source/Demos/Tutorials/Demos/CollisionDemo.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using MonoGame.Extended;
+using MonoGame.Extended.Collisions;
+using MonoGame.Extended.Sprites;
+
+namespace Tutorials.Demos
+{
+    public class CollisionDemo : DemoBase
+    {
+        private CollisionComponent _collisionComponent;
+        private List<DemoActor> _actors;
+        private SpriteBatch _spriteBatch;
+        private Texture2D _spikyBallTexture;
+        private Texture2D _blankTexture;
+        private DemoBall _controllableBall;
+
+        public CollisionDemo(GameMain game) : base(game)
+        {
+        }
+
+        public override string Name { get; } = "Collisions";
+
+        protected override void LoadContent()
+        {
+            _collisionComponent = new CollisionComponent(new RectangleF(-10000, -5000, 20000, 10000));
+            _actors = new List<DemoActor>();
+
+
+            _spriteBatch = new SpriteBatch(GraphicsDevice);
+            var spikeyBallTexture = Content.Load<Texture2D>("Textures/spike_ball");
+            _spikyBallTexture = spikeyBallTexture;
+
+            _blankTexture = new Texture2D(GraphicsDevice, 1, 1);
+            _blankTexture.SetData(new[] { Color.WhiteSmoke });
+
+            var spikeyBallRight = new DemoBall(new Sprite(_spikyBallTexture))
+            {
+                Position = new Vector2(600, 240),
+                Velocity = new Vector2(0, 120)
+            };
+            _actors.Add(spikeyBallRight);
+
+            var controllableBall = new ControllableBall(new Sprite(_spikyBallTexture))
+            {
+                Position = new Vector2(400, 240),
+                Velocity = new Vector2(0, 0)
+            };
+            _actors.Add(controllableBall);
+            _controllableBall = controllableBall;
+
+            var topWall = new DemoWall(new Sprite(_blankTexture))
+            {
+                Bounds = new RectangleF(0, 0, 800, 20),
+                Position = new Vector2(0, 0)
+            };
+            _actors.Add(topWall);
+
+            var bottomWall = new DemoWall(new Sprite(_blankTexture))
+            {
+                Position = new Vector2(0, 460),
+                Bounds = new RectangleF(0, 0, 800, 20)
+            };
+            _actors.Add(bottomWall);
+
+            var spikeyBallCenter = new StationaryBall(new Sprite(_spikyBallTexture))
+            {
+                Position = new Vector2(400, 240),
+                Velocity = Vector2.Zero,
+            };
+            _actors.Add(spikeyBallCenter);
+
+            foreach (var actor in _actors)
+            {
+                _collisionComponent.Insert(actor);
+            }
+
+            base.LoadContent();
+        }
+
+        protected override void Update(GameTime gameTime)
+        {
+            UpdateControlledBall(gameTime, _controllableBall);
+
+            foreach (var actor in _actors)
+            {
+                actor.Update(gameTime);
+            }
+            _collisionComponent.Update(gameTime);
+            base.Update(gameTime);
+        }
+
+        private void UpdateControlledBall(GameTime gameTime, DemoActor actor)
+        {
+            var kb = Keyboard.GetState();
+            var speed = 150.0f;
+
+            var position = actor.Position;
+            var distance = speed * gameTime.GetElapsedSeconds();
+
+            if (kb.IsKeyDown(Keys.W)) position.Y -= distance;
+            if (kb.IsKeyDown(Keys.S)) position.Y += distance;
+            if (kb.IsKeyDown(Keys.A)) position.X -= distance;
+            if (kb.IsKeyDown(Keys.D)) position.X += distance;
+
+            actor.Position = position;
+        }
+
+        protected override void Draw(GameTime gameTime)
+        {
+            _spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp);
+            foreach (var actor in _actors)
+            {
+                actor.Draw(_spriteBatch);
+            }
+            _spriteBatch.End();
+
+            base.Draw(gameTime);
+        }
+    }
+
+    class DemoActor : ICollisionActor, IUpdate
+    {
+        private readonly Sprite _sprite;
+        private Vector2 _position;
+
+        public DemoActor(Sprite sprite)
+        {
+            _sprite = sprite;
+            Bounds = sprite.GetBoundingRectangle(new Transform2());
+        }
+
+        /// <summary>
+        /// Gets or sets the actor's position and updates teh actor's bounds
+        /// position.
+        /// </summary>
+        public Vector2 Position
+        {
+            get => _position;
+            set
+            {
+                _position = value;
+                Bounds.Position = value + Offset;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the actor's collision bounds.
+        /// </summary>
+        public IShapeF Bounds { get; set; }
+
+        /// <summary>
+        /// Gets or sets how far the actor's collision bounds are offset from 
+        /// the actor's position.
+        /// </summary>
+        public Vector2 Offset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the actor's velocity.
+        /// </summary>
+        public Vector2 Velocity { get; set; }
+
+        public virtual void OnCollision(CollisionEventArgs collisionInfo)
+        {
+
+        }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            _sprite.Draw(spriteBatch, Position, 0, Vector2.One);
+        }
+
+        public virtual void Update(GameTime gameTime)
+        {
+            Position += gameTime.GetElapsedSeconds() * Velocity;
+        }
+    }
+
+    class DemoWall : DemoActor
+    {
+        public DemoWall(Sprite sprite) : base(sprite)
+        {
+
+        }
+    }
+
+    /// <summary>
+    /// Ball that bounces on wall
+    /// </summary>
+    class DemoBall : DemoActor
+    {
+        public DemoBall(Sprite sprite) : base(sprite)
+        {
+            Bounds = new CircleF(Position + Offset, 60);
+        }
+
+        public override void OnCollision(CollisionEventArgs collisionInfo)
+        {
+            Velocity *= -1;
+            Position -= collisionInfo.PenetrationVector;
+            base.OnCollision(collisionInfo);
+        }
+    }
+
+    /// <summary>
+    /// Ball that doesn't move when collided with.
+    /// </summary>
+    class StationaryBall : DemoBall
+    {
+        public StationaryBall(Sprite sprite) : base(sprite)
+        {
+        }
+
+        public override void OnCollision(CollisionEventArgs collisionInfo)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Player controlled ball.
+    /// </summary>
+    class ControllableBall : DemoBall
+    {
+        public ControllableBall(Sprite sprite) : base(sprite)
+        {
+            Bounds = new CircleF(Position + Offset, 60);
+        }
+
+        public override void OnCollision(CollisionEventArgs collisionInfo)
+        {
+            Position -= collisionInfo.PenetrationVector;
+        }
+    }
+}

--- a/Source/Demos/Tutorials/GameMain.cs
+++ b/Source/Demos/Tutorials/GameMain.cs
@@ -36,17 +36,13 @@ namespace Tutorials
 
             _demos = new DemoBase[]
             {
-                //new GuiLayoutDemo(this),
-                //new GuiDemo(this),
-                //new ScreensDemo(this),
                 new ShapesDemo(this),
                 new ViewportAdaptersDemo(this),
-                //new CollisionDemo(this),
+                new CollisionDemo(this),
                 new TiledMapsDemo(this),
                 new AnimationsDemo(this),
                 new SpritesDemo(this),
                 new BatchingDemo(this),
-                //new TweeningDemo(this),
                 new InputListenersDemo(this),
                 new SceneGraphsDemo(this),
                 new ParticlesDemo(this),

--- a/Source/Demos/Tutorials/Tutorials.csproj
+++ b/Source/Demos/Tutorials/Tutorials.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\MonoGame.Extended.Collisions\MonoGame.Extended.Collisions.csproj" />
     <ProjectReference Include="..\..\MonoGame.Extended.Content.Pipeline\MonoGame.Extended.Content.Pipeline.csproj">
       <Private>true</Private>
     </ProjectReference>

--- a/Source/MonoGame.Extended.Collisions/QuadTree/CollisionComponent.cs
+++ b/Source/MonoGame.Extended.Collisions/QuadTree/CollisionComponent.cs
@@ -39,7 +39,7 @@ namespace MonoGame.Extended.Collisions
             // Detect collisions
             foreach (var value in _targetDataDictionary.Values)
             {
-                _collisionTree.Remove(value);
+                value.RemoveFromAllParents();
 
                 var target = value.Target;
                 var collisions =_collisionTree.Query(target.Bounds);
@@ -58,6 +58,7 @@ namespace MonoGame.Extended.Collisions
                 }
                 _collisionTree.Insert(value);
             }
+            _collisionTree.Shake();
         }
 
         /// <summary>
@@ -84,8 +85,9 @@ namespace MonoGame.Extended.Collisions
             if (_targetDataDictionary.ContainsKey(target))
             {
                 var data = _targetDataDictionary[target];
-                _collisionTree.Remove(data);
+                data.RemoveFromAllParents();
                 _targetDataDictionary.Remove(target);
+                _collisionTree.Shake();
             }
         }
 

--- a/Source/MonoGame.Extended.Collisions/QuadTree/QuadTree.cs
+++ b/Source/MonoGame.Extended.Collisions/QuadTree/QuadTree.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace MonoGame.Extended.Collisions
 {
@@ -11,7 +12,7 @@ namespace MonoGame.Extended.Collisions
         public const int DefaultMaxObjectsPerNode = 25;
 
         protected List<Quadtree> Children = new List<Quadtree>();
-        protected List<QuadtreeData> Contents = new List<QuadtreeData>();
+        protected HashSet<QuadtreeData> Contents = new HashSet<QuadtreeData>();
 
         /// <summary>
         ///     Creates a quad tree with the given bounds.
@@ -44,8 +45,7 @@ namespace MonoGame.Extended.Collisions
         /// <returns>Returns the targets of objects found.</returns>
         public int NumTargets()
         {
-            Reset();
-
+            List<QuadtreeData> dirtyItems = new List<QuadtreeData>();
             var objectCount = 0;
 
             // Do BFS on nodes to count children.
@@ -56,23 +56,28 @@ namespace MonoGame.Extended.Collisions
                 var processing = process.Dequeue();
                 if (!processing.IsLeaf)
                 {
-                    foreach (var child in processing.Children) process.Enqueue(child);
+                    foreach (var child in processing.Children)
+                    {
+                        process.Enqueue(child);
+                    }
                 }
                 else
                 {
-                    var contents = processing.Contents;
-                    foreach (var data in contents)
+                    foreach (var data in processing.Contents)
                     {
-                        if (!data.Flag)
+                        if (data.Dirty == false)
                         {
                             objectCount++;
-                            data.Flag = true;
+                            data.MarkDirty();
+                            dirtyItems.Add(data);
                         }
                     }
                 }
             }
-
-            Reset();
+            for (var i = 0; i < dirtyItems.Count; i++)
+            {
+                dirtyItems[i].MarkClean();
+            }
             return objectCount;
         }
 
@@ -90,11 +95,14 @@ namespace MonoGame.Extended.Collisions
                 return;
             }
 
-            if (IsLeaf && Contents.Count >= MaxObjectsPerNode) Split();
+            if (IsLeaf && Contents.Count >= MaxObjectsPerNode)
+            {
+                Split();
+            }
 
             if (IsLeaf)
             {
-                Contents.Add(data);
+                AddToLeaf(data);
             }
             else
             {
@@ -113,52 +121,12 @@ namespace MonoGame.Extended.Collisions
         {
             if (IsLeaf)
             {
-                var removeIndex = -1;
-
-                for (int i = 0, size = Contents.Count; i < size; i++)
-                {
-                    if (Contents[i].Target == data.Target)
-                    {
-                        removeIndex = i;
-                        break;
-                    }
-                }
-
-                if (removeIndex != -1)
-                {
-                    Contents.RemoveAt(removeIndex);
-                }
+                data.RemoveParent(this);
+                Contents.Remove(data);
             }
             else
             {
-                foreach (var quadTree in Children)
-                {
-                    quadTree.Remove(data);
-                }
-            }
-
-            Shake();
-        }
-
-        /// <summary>
-        ///     Resets all QuadtreeData.Flag to false.
-        /// </summary>
-        /// <remarks>
-        ///     Used internally to query and count contents without duplicates.
-        /// </remarks>
-        public void Reset()
-        {
-            if (IsLeaf)
-                for (int i = 0, size = Contents.Count; i < size; i++)
-                {
-                    var quadTreeData = Contents[i];
-                    quadTreeData.Flag = false;
-                    Contents[i] = quadTreeData;
-                }
-            else
-            {
-                for (int i = 0, size = Children.Count; i < size; i++)
-                    Children[i].Reset();
+                throw new InvalidOperationException($"Cannot remove from a non leaf {nameof(Quadtree)}"); 
             }
         }
 
@@ -169,6 +137,8 @@ namespace MonoGame.Extended.Collisions
         {
             if (!IsLeaf)
             {
+                List<QuadtreeData> dirtyItems = new List<QuadtreeData>();
+
                 var numObjects = NumTargets();
                 if (numObjects == 0)
                 {
@@ -182,26 +152,39 @@ namespace MonoGame.Extended.Collisions
                     {
                         var processing = process.Dequeue();
                         if (!processing.IsLeaf)
+                        {
                             foreach (var subTree in processing.Children)
                             {
                                 process.Enqueue(subTree);
                             }
+                        }
                         else
                         {
                             foreach (var data in processing.Contents)
                             {
-                                if (!data.Flag)
+                                if (data.Dirty == false)
                                 {
-                                    Contents.Add(data);
-                                    data.Flag = true;
+                                    AddToLeaf(data);
+                                    data.MarkDirty();
+                                    dirtyItems.Add(data);
                                 }
                             }
                         }
                     }
-
                     Children.Clear();
                 }
+
+                for (var i = 0; i < dirtyItems.Count; i++)
+                {
+                    dirtyItems[i].MarkClean();
+                }
             }
+        }
+
+        private void AddToLeaf(QuadtreeData data)
+        {
+            data.AddParent(this);
+            Contents.Add(data);
         }
 
         /// <summary>
@@ -230,14 +213,22 @@ namespace MonoGame.Extended.Collisions
                 Children[i].CurrentDepth = CurrentDepth + 1;
             }
 
-            for (int i = 0, size = Contents.Count; i < size; ++i)
+            foreach (QuadtreeData contentQuadtree in Contents)
             {
-                for (int j = 0; j < Children.Count; j++)
+                foreach (Quadtree childQuadtree in Children)
                 {
-                    Children[j].Insert(Contents[i]);
+                    childQuadtree.Insert(contentQuadtree);
                 }
             }
+            Clear();
+        }
 
+        private void Clear()
+        {
+            foreach (QuadtreeData quadtreeData in Contents)
+            {
+                quadtreeData.RemoveParent(this);
+            }
             Contents.Clear();
         }
 
@@ -248,25 +239,28 @@ namespace MonoGame.Extended.Collisions
         /// <returns>A unique list of targets intersected by area.</returns>
         public List<QuadtreeData> Query(IShapeF area)
         {
-            Reset();
-            return QueryWithoutReset(area);
+            var recursiveResult = new List<QuadtreeData>();
+            QueryWithoutReset(area, recursiveResult);
+            for (var i = 0; i < recursiveResult.Count; i++)
+            {
+                recursiveResult[i].MarkClean();
+            }
+            return recursiveResult;
         }
 
-        private List<QuadtreeData> QueryWithoutReset(IShapeF area)
+        private void QueryWithoutReset(IShapeF area, List<QuadtreeData> recursiveResult)
         {
-            var result = new List<QuadtreeData>();
-
-            if (!NodeBounds.Intersects(area)) return result;
+            if (!NodeBounds.Intersects(area)) 
+                return;
 
             if (IsLeaf)
             {
-                for (int i = 0, size = Contents.Count; i < size; i++)
+                foreach (QuadtreeData quadtreeData in Contents)
                 {
-                    if (Contents[i].Bounds.Intersects(area) 
-                        && !Contents[i].Flag)
+                    if (quadtreeData.Dirty == false && quadtreeData.Bounds.Intersects(area))
                     {
-                        result.Add(Contents[i]);
-                        Contents[i].Flag = true;
+                        recursiveResult.Add(quadtreeData);
+                        quadtreeData.MarkDirty();
                     }
                 }
             }
@@ -274,13 +268,9 @@ namespace MonoGame.Extended.Collisions
             {
                 for (int i = 0, size = Children.Count; i < size; i++)
                 {
-                    var recurse = Children[i].QueryWithoutReset(area);
-                    result.AddRange(recurse);
+                    Children[i].QueryWithoutReset(area, recursiveResult);
                 }
             }
-
-
-            return result;
         }
     }
 }

--- a/Source/MonoGame.Extended.Collisions/QuadTree/QuadTreeData.cs
+++ b/Source/MonoGame.Extended.Collisions/QuadTree/QuadTreeData.cs
@@ -1,4 +1,7 @@
-﻿namespace MonoGame.Extended.Collisions
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace MonoGame.Extended.Collisions
 {
     /// <summary>
     ///     Data structure for the quad tree.
@@ -10,8 +13,28 @@
         {
             Target = target;
             Bounds = target.Bounds;
-            Flag = false;
         }
+
+        public void RemoveParent(Quadtree parent)
+        {
+            Parents.Remove(parent);
+        }
+
+        public void AddParent(Quadtree parent)
+        {
+            Parents.Add(parent);
+        }
+
+        public void RemoveFromAllParents()
+        {
+            foreach (Quadtree parent in Parents.ToList())
+            {
+                parent.Remove(this);
+            }
+            Parents.Clear();
+        }
+
+        public HashSet<Quadtree> Parents = new HashSet<Quadtree>();
 
         /// <summary>
         ///     Gets or sets the Target for collision.
@@ -22,7 +45,17 @@
         ///     Gets or sets whether Target has had its collision handled this
         ///     iteration.
         /// </summary>
-        public bool Flag { get; set; }
+        public bool Dirty { get; private set; }
+
+        public void MarkDirty()
+        {
+            Dirty = true;
+        }
+
+        public void MarkClean()
+        {
+            Dirty = false;
+        }
 
         /// <summary>
         ///     Gets or sets the bounding box for collision detection.

--- a/Source/Tests/MonoGame.Extended.Collisions.Tests/QuadTreeTests.cs
+++ b/Source/Tests/MonoGame.Extended.Collisions.Tests/QuadTreeTests.cs
@@ -241,7 +241,7 @@ namespace MonoGame.Extended.Collisions.Tests
 
             foreach (var data in inserted)
             {
-                tree.Remove(data);
+                data.RemoveFromAllParents();
                 Assert.Equal(--inTree, tree.NumTargets());
             }
         }


### PR DESCRIPTION
Performance Improvements
- `QuadtreeData `now keeps track of its parents. This makes removing it from a `Quadtree `a lot faster.
- `Reset()` is removed and Dirty `QuadtreeData `is now tracked and reset inside the functions that use the Dirty flag.
- `Quadtree.Contents` is now a `HashSet`. This makes removing faster
- `Shake()` now only gets called at the end of update and explicit remove

I tested this with 1000 colliders and the fps went from ~1 to 60


