### PR TITLE
Fix ParticleEmitters always using same random seed

### DIFF
--- a/src/dotnet/MonoGame.Extended.Particles/ParticleEmitter.cs
+++ b/src/dotnet/MonoGame.Extended.Particles/ParticleEmitter.cs
@@ -11,7 +11,7 @@ namespace MonoGame.Extended.Particles
 {
     public unsafe class ParticleEmitter : IDisposable
     {
-        private readonly FastRandom _random = new FastRandom(Guid.NewGuid().GetHashCode());
+        private readonly FastRandom _random = new FastRandom(Math.Abs(Guid.NewGuid().GetHashCode()));
         private float _totalSeconds;
 
         [JsonConstructor]

--- a/src/dotnet/MonoGame.Extended.Particles/ParticleEmitter.cs
+++ b/src/dotnet/MonoGame.Extended.Particles/ParticleEmitter.cs
@@ -11,7 +11,7 @@ namespace MonoGame.Extended.Particles
 {
     public unsafe class ParticleEmitter : IDisposable
     {
-        private readonly FastRandom _random = new FastRandom();
+        private readonly FastRandom _random = new FastRandom(Guid.NewGuid().GetHashCode());
         private float _totalSeconds;
 
         [JsonConstructor]


### PR DESCRIPTION
### Problem
Right now, every `ParticleEmitter` generates the same random spread of particles. This isn't so noticeable with lots of particles but with a low number (e.g. 5 particles in a spurt) it's very noticeable.

This is because the default `FastRandom` constructor initialises with a seed of `1`.

### Fix
This simply initialises the `FastRandom` with a random seed used by generating a new guid. We must use `Math.Abs` because FastRandom only accepts positive integers for the seed.