### PR TITLE
Replace Color.TransparentBlack with Color.Transparent

### DIFF
--- a/src/dotnet/MonoGame.Extended.Tiled/Serialization/TiledMapImageContent.cs
+++ b/src/dotnet/MonoGame.Extended.Tiled/Serialization/TiledMapImageContent.cs
@@ -29,7 +29,7 @@ namespace MonoGame.Extended.Tiled.Serialization
 		[XmlIgnore]
 		public Color TransparentColor
 		{
-			get => RawTransparentColor == string.Empty ? Color.TransparentBlack : ColorHelper.FromHex(RawTransparentColor);
+			get => RawTransparentColor == string.Empty ? Color.Transparent : ColorHelper.FromHex(RawTransparentColor);
 			set => RawTransparentColor = ColorHelper.ToHex(value);
 		}
 


### PR DESCRIPTION
`Color.TransparentBlack` has been removed in Monogame.
https://github.com/MonoGame/MonoGame/commit/c6d916d6983526900869d5e2f189471224f06c14

When using a development version of mgcb-editor (3.8.1.1983-develop) I was unable to build a .tmx file because of the usage of `Color.TransparentBlack` in `TiledMapImageContent.cs`.

I have replaced it with `Color.Tranparent` which is the replacement and has the same value.