### PR TITLE
TryGetTile no longer returns a value if width is outside the map

### DIFF
--- a/src/cs/MonoGame.Extended.Tiled/TiledMapTileLayer.cs
+++ b/src/cs/MonoGame.Extended.Tiled/TiledMapTileLayer.cs
@@ -28,6 +28,11 @@ namespace MonoGame.Extended.Tiled
 
         public bool TryGetTile(ushort x, ushort y, out TiledMapTile? tile)
         {
+            if (x >= Width)
+            {
+                tile = null;
+                return false;
+            }
             var index = GetTileIndex(x, y);
 
             if (index < 0 || index >= Tiles.Length)


### PR DESCRIPTION
when calling `TryGetTile` on `TileMapTileLayer` and using a `y`  coordinate greater then the height the method returns `false`.
Doing the same with `x` while `y` is not at maximum will return `true`.

This will check the `x` used and returns false if it is over the width.