### PR TITLE
add ability to configure layerdepth for autotriggered particleeffects

### DIFF
--- a/src/cs/MonoGame.Extended.Particles/ParticleEffect.cs
+++ b/src/cs/MonoGame.Extended.Particles/ParticleEffect.cs
@@ -11,7 +11,7 @@ namespace MonoGame.Extended.Particles
 {
     public class ParticleEffect : Transform2, IDisposable
     {
-        public ParticleEffect(string name = null, bool autoTrigger = true, float autoTriggerDelay = 0f)
+        public ParticleEffect(string name = null)
         {
             Name = name;
             Emitters = new List<ParticleEmitter>();

--- a/src/cs/MonoGame.Extended.Particles/ParticleEffect.cs
+++ b/src/cs/MonoGame.Extended.Particles/ParticleEffect.cs
@@ -74,10 +74,10 @@ namespace MonoGame.Extended.Particles
                 Emitters[i].Trigger(position, layerDepth);
         }
 
-        public void Trigger(LineSegment line)
+        public void Trigger(LineSegment line, float layerDepth = 0)
         {
             for (var i = 0; i < Emitters.Count; i++)
-                Emitters[i].Trigger(line);
+                Emitters[i].Trigger(line, layerDepth);
         }
 
         public override string ToString()

--- a/src/cs/MonoGame.Extended.Particles/ParticleEmitter.cs
+++ b/src/cs/MonoGame.Extended.Particles/ParticleEmitter.cs
@@ -162,7 +162,7 @@ namespace MonoGame.Extended.Particles
             Release(position + Offset, numToRelease, layerDepth);
         }
 
-        public void Trigger(LineSegment line)
+        public void Trigger(LineSegment line, float layerDepth = 0)
         {
             var numToRelease = _random.Next(Parameters.Quantity);
             var lineVector = line.ToVector();
@@ -170,11 +170,11 @@ namespace MonoGame.Extended.Particles
             for (var i = 0; i < numToRelease; i++)
             {
                 var offset = lineVector * _random.NextSingle();
-                Release(line.Origin + offset, 1);
+                Release(line.Origin + offset, 1, layerDepth);
             }
         }
 
-        private void Release(Vector2 position, int numToRelease, float layerDepth = 0)
+        private void Release(Vector2 position, int numToRelease, float layerDepth)
         {
             var iterator = Buffer.Release(numToRelease);
 

--- a/src/cs/MonoGame.Extended.Particles/ParticleEmitter.cs
+++ b/src/cs/MonoGame.Extended.Particles/ParticleEmitter.cs
@@ -53,6 +53,7 @@ namespace MonoGame.Extended.Particles
         public Vector2 Offset { get; set; }
         public List<Modifier> Modifiers { get; }
         public Profile Profile { get; set; }
+        public float LayerDepth { get; set; }
         public ParticleReleaseParameters Parameters { get; set; }
         public TextureRegion2D TextureRegion { get; set; }
 
@@ -132,7 +133,7 @@ namespace MonoGame.Extended.Particles
 
                 if (_nextAutoTrigger <= 0)
                 {
-                    Trigger(position);
+                    Trigger(position, this.LayerDepth);
                     _nextAutoTrigger = _autoTriggerFrequency;
                 }
             }


### PR DESCRIPTION
Hi! I needed the ability to define the layerdepth also for autotriggered particleeffects so I've added this little feature, it was just a few lines and seems to work very well.

This is the first time I contribute something to any OS project, so please be lenient if I did something wrong.
