### PR TITLE
Fixed issue when GetState() call rewrites previous states.

### DIFF
--- a/src/cs/MonoGame.Extended.Input/KeyboardExtended.cs
+++ b/src/cs/MonoGame.Extended.Input/KeyboardExtended.cs
@@ -10,9 +10,13 @@ namespace MonoGame.Extended.Input
 
         public static KeyboardStateExtended GetState()
         {
+            return new KeyboardStateExtended(_currentKeyboardState, _previousKeyboardState);
+        }
+
+        public static Refresh()
+        {
             _previousKeyboardState = _currentKeyboardState;
             _currentKeyboardState = Keyboard.GetState();
-            return new KeyboardStateExtended(_currentKeyboardState, _previousKeyboardState);
         }
     }
 }

--- a/src/cs/MonoGame.Extended.Input/MouseExtended.cs
+++ b/src/cs/MonoGame.Extended.Input/MouseExtended.cs
@@ -12,9 +12,13 @@ namespace MonoGame.Extended.Input
 
         public static MouseStateExtended GetState()
         {
+            return new MouseStateExtended(_currentMouseState, _previousMouseState);
+        }
+
+        public static Refresh()
+        {
             _previousMouseState = _currentMouseState;
             _currentMouseState = Mouse.GetState();
-            return new MouseStateExtended(_currentMouseState, _previousMouseState);
         }
 
         public static void SetPosition(int x, int y) => Mouse.SetPosition(x, y);


### PR DESCRIPTION
There is a bug In the `GetState()` method of extended keyboard and mouse. 
Every time `GetState()` gets called - previous state get overwritten with current. If done more then one time - previous state gets overwritten and lost.
https://github.com/craftworkgames/MonoGame.Extended/blob/c90365211eaae3ed092d748230f4cbebe490d1b9/src/cs/MonoGame.Extended.Input/KeyboardExtended.cs#L11-L16
The only way to go is to request state only one time, save it in the variable and then use it, which is unhandy.
I think state swap should be performed only once per tick, while allowing multiple `GetState()` calls, so I propose to add `Refresh()` method, that will be called by user at the start of the tick, before any input checks.