### PR TITLE
Tiled: Support class attribute as alias for object types

### DIFF
--- a/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapProcessor.cs
+++ b/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapProcessor.cs
@@ -69,6 +69,9 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 
                 if (string.IsNullOrWhiteSpace(obj.Type) && !string.IsNullOrWhiteSpace(template.Object.Type))
                     obj.Type = template.Object.Type;
+
+                if (string.IsNullOrWhiteSpace(obj.Class) && !string.IsNullOrWhiteSpace(template.Object.Class))
+                    obj.Class = template.Object.Class;
             }
         }
     }

--- a/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapTilesetWriter.cs
+++ b/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapTilesetWriter.cs
@@ -74,7 +74,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 
             writer.Write(@object.Identifier);
             writer.Write(@object.Name ?? string.Empty);
-            writer.Write(@object.Type ?? string.Empty);
+            writer.Write(@object.Class ?? @object.Type ?? string.Empty);
             writer.Write(@object.X);
             writer.Write(@object.Y);
             writer.Write(@object.Width);

--- a/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
+++ b/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
@@ -152,7 +152,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
 
             writer.Write(@object.Identifier);
             writer.Write(@object.Name ?? string.Empty);
-            writer.Write(@object.Type ?? string.Empty);
+            writer.Write(@object.Class ?? @object.Type ?? string.Empty);
             writer.Write(@object.X);
             writer.Write(@object.Y);
             writer.Write(@object.Width);

--- a/src/cs/MonoGame.Extended.Tiled/Serialization/TiledMapObjectContent.cs
+++ b/src/cs/MonoGame.Extended.Tiled/Serialization/TiledMapObjectContent.cs
@@ -29,8 +29,12 @@ namespace MonoGame.Extended.Tiled.Serialization
 		[XmlAttribute(DataType = "string", AttributeName = "name")]
 		public string Name { get; set; }
 
+        // Deprecated as of Tiled 1.9.0 (replaced by "class" attribute)
 		[XmlAttribute(DataType = "string", AttributeName = "type")]
 		public string Type { get; set; }
+
+		[XmlAttribute(DataType = "string", AttributeName = "class")]
+		public string Class { get; set; }
 
 		[XmlAttribute(DataType = "float", AttributeName = "x")]
 		public float X { get => _x ?? 0; set => _x = value; }

--- a/src/cs/Tests/MonoGame.Extended.Content.Pipeline.Tests.Tiled/TestData/test-object-layer.tmx
+++ b/src/cs/Tests/MonoGame.Extended.Content.Pipeline.Tests.Tiled/TestData/test-object-layer.tmx
@@ -7,7 +7,7 @@
    </properties>
    <ellipse/>
   </object>
-  <object id="7" x="240" y="440" width="322" height="186" visible="0"/>
+  <object id="7" class="sprite" x="240" y="440" width="322" height="186" visible="0"/>
   <object id="8" type="rectangle" x="506" y="142" width="136" height="234">
    <properties>
     <property name="area" value="player-spawn"/>

--- a/src/cs/Tests/MonoGame.Extended.Content.Pipeline.Tests.Tiled/TiledMapImporterProcessorTests.cs
+++ b/src/cs/Tests/MonoGame.Extended.Content.Pipeline.Tests.Tiled/TiledMapImporterProcessorTests.cs
@@ -177,6 +177,7 @@ namespace MonoGame.Extended.Content.Pipeline.Tests.Tiled
             Assert.Equal((uint)0, tmxObjectGroup.Objects[1].GlobalIdentifier);
             Assert.Equal((uint)23, tmxObjectGroup.Objects[5].GlobalIdentifier);
             Assert.Equal("rectangle", tmxObjectGroup.Objects[2].Type);
+            Assert.Equal("sprite", tmxObjectGroup.Objects[1].Class);
             Assert.NotNull(tmxPolygon);
             Assert.Equal("0,0 180,90 -8,275 -45,81 38,77", tmxPolygon.Points);
             Assert.NotNull(tmxPolyline);


### PR DESCRIPTION
As of Tiled version 1.9.0 the `type` attribute of objects has been replaced by the `class` attribute, as is reflected by the documentation [here](https://doc.mapeditor.org/en/stable/manual/custom-properties/#custom-classes). This change prefers the `class` attribute and falls back to the `type` attribute. For compatibility reasons I haven't updated the name of the `Type` field in [`TiledMapObject`](https://github.com/craftworkgames/MonoGame.Extended/blob/9a539d0517b9299a3e381547d47c6a2771f34bbe/src/cs/MonoGame.Extended.Tiled/TiledMapObject.cs#L22).