### PR TITLE
Fix crash at loading AnimationSprite on Android.

### DIFF
--- a/src/cs/MonoGame.Extended/TextureAtlases/TextureAtlasJsonConverter.cs
+++ b/src/cs/MonoGame.Extended/TextureAtlases/TextureAtlasJsonConverter.cs
@@ -53,8 +53,17 @@ namespace MonoGame.Extended.TextureAtlases
                 var directory = Path.GetDirectoryName(_path);
                 var relativePath = Path.Combine(_contentManager.RootDirectory, directory, textureDirectory, textureName);
                 var resolvedAssetName = Path.GetFullPath(relativePath);
-                var texture = _contentManager.Load<Texture2D>(resolvedAssetName);
-
+                Texture2D texture;
+                try
+                {
+                    texture = _contentManager.Load<Texture2D>(resolvedAssetName);
+                }
+                catch (Exception ex) {
+                    if (textureDirectory == null || textureDirectory == "") 
+                        texture = _contentManager.Load<Texture2D>(textureName);
+                    else
+                        texture = _contentManager.Load<Texture2D>(textureDirectory + "/" + textureName);
+                }
                 return TextureAtlas.Create(resolvedAssetName, texture, metadata.RegionWidth, metadata.RegionHeight);
             }
         }


### PR DESCRIPTION
If I use AnimationSprite on Android, App happened exception 'TitleContainer.OpenStream requires a relative path' at TextureAtlasJsonConverter.
MonoGame's content loader need relative path on Android.
This fix is load content by relative path if happened exception.
