### PR TITLE
Add power of two values to MouseButton

### DIFF
--- a/src/cs/MonoGame.Extended.Input/MouseButton.cs
+++ b/src/cs/MonoGame.Extended.Input/MouseButton.cs
@@ -5,11 +5,11 @@ namespace MonoGame.Extended.Input
     [Flags]
     public enum MouseButton
     {
-        None,
-        Left,
-        Middle,
-        Right,
-        XButton1,
-        XButton2
+        None = 0,
+        Left = 1,
+        Middle = 2,
+        Right = 4,
+        XButton1 = 8,
+        XButton2 = 16
     }
 }


### PR DESCRIPTION
Add power of two values to `MouseButton` so `MouseButton.HasFlags` can be used.