### PR TITLE
Decrease allocation overhead on KeyboardStateExtended

### DIFF
--- a/src/cs/MonoGame.Extended.Input/KeyboardStateExtended.cs
+++ b/src/cs/MonoGame.Extended.Input/KeyboardStateExtended.cs
@@ -22,9 +22,9 @@ namespace MonoGame.Extended.Input
         public bool IsKeyDown(Keys key) => _currentKeyboardState.IsKeyDown(key);
         public bool IsKeyUp(Keys key) => _currentKeyboardState.IsKeyUp(key);
         public Keys[] GetPressedKeys() => _currentKeyboardState.GetPressedKeys();
-
+        public void GetPressedKeys(Keys[] keys) => _currentKeyboardState.GetPressedKeys(keys);
         public bool WasKeyJustDown(Keys key) => _previousKeyboardState.IsKeyDown(key) && _currentKeyboardState.IsKeyUp(key);
         public bool WasKeyJustUp(Keys key) => _previousKeyboardState.IsKeyUp(key) && _currentKeyboardState.IsKeyDown(key);
-        public bool WasAnyKeyJustDown() => _previousKeyboardState.GetPressedKeys().Any();
+        public bool WasAnyKeyJustDown() => _previousKeyboardState.GetPressedKeyCount() > 0;
    }
 }


### PR DESCRIPTION
`WasAnyKeyJustDown()` called a MonoGame method that allocated, when a better one was available.

Additionally, `GetPressedKeys(Keys[] keys)` overload to allow the caller to cache was present on `KeyboardState`, but missing on `KeyboardStateExtended`. 

Fixed both things.