### PR TITLE
Update GitHub Workflow to Automate Build, Test, and Package Deployment

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -2,7 +2,7 @@ name: "Build test deploy"
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, test/feature]
     tags: [v*]
   pull_request:
     branches: [develop]
@@ -16,23 +16,14 @@ jobs:
     steps:
       - name: "Clone Repository"
         uses: actions/checkout@v4
-      - name: "CAKE (Build)"
-        run: dotnet run --project ./build/Build.csproj -- --target=BuildTask
-      - name: "CAKE (Test)"
-        run: dotnet run --project ./build/Build.csproj -- --target=TestTask
-
-      # Creating packages does not need ot run on pull requets, just the build and
-      # test above.
-      - name: "CAKE (Package)"
-        if: github.event_name != 'pull_request'
-        run: dotnet run --project ./build/Build.csproj -- --target=PackageTask
-      - name: "Package Artifacts"
+      - name: "CAKE (Build -> Test -> Package)"
+        run: dotnet run --project ./build/Build.csproj -- --target=Default
+      - name: "Upload Artifacts For Deploy"
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@main
         with:
           name: MonoGame.Extended
           path: artifacts/*
-
 
   deploy-job:
       name: "Deploy Nugets"
@@ -45,25 +36,14 @@ jobs:
       steps:
         - name: "Clone Repository"
           uses: actions/checkout@v4
-        - name: Download Artifacts
+        - name: "Download Artifacts For Deploy"
           uses: actions/download-artifact@v3
           with:
             name: MonoGame.Extended
             path: artifacts
-        - name: "Push Package (GitHub Feed)"
-          run: dotnet nuget push artifacts/*.nupkg --source https://nuget.pkg.github.com/$GITHUB_REPOSITORY_OWNER/index.json --api-key ${GITHUB_TOKEN}
+        - name: "Push Package"
+          run: dotnet run --project ./build/Build.csproj -- --target=Deploy
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - name: "Push Packages (MyGet Feed)"
-          run: dotnet nuget push artifacts/*.nupkg --source ${MYGET_SOURCE_URL} --api-key ${MYGET_ACCESS_TOKEN}
-          env:
             MYGET_ACCESS_TOKEN: ${{ secrets.MYGET_ACCESS_TOKEN }}
-            MYGET_SOURCE_URL: 'https://www.myget.org/F/lithiumtoast/api/v3/index.json'
-
-        # Pushes packages to nuget, but only if this is a tag release.
-        - name: "Push Packages (NuGet Feed)"
-          if: github.ref_type == 'tag' && github.repository_owner == 'craftworkgames'
-          run: dotnet nuget push artifacts/*.nupkg --source ${NUGET_SOURCE_URL} --api-key ${NUGET_ACCESS_TOKEN}
-          env:
             NUGET_ACCESS_TOKEN: ${{ secrets.NUGET_ACCESS_TOKEN }}
-            NUGET_SOURCE_URL: "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -62,7 +62,7 @@ jobs:
 
         # Pushes packages to nuget, but only if this is a tag release.
         - name: "Push Packages (NuGet Feed)"
-          if: github.ref_type == 'tag'
+          if: github.ref_type == 'tag' && github.repository_owner == 'craftworkgames'
           run: dotnet nuget push artifacts/*.nupkg --source ${NUGET_SOURCE_URL} --api-key ${NUGET_ACCESS_TOKEN}
           env:
             NUGET_ACCESS_TOKEN: ${{ secrets.NUGET_ACCESS_TOKEN }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,12 +1,5 @@
 name: "Build test deploy"
 
-env:
-  DOTNET_CLI_TELEMETRY_OPTOUT: 1
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  DOTNET_CORE_SDK_VERSION: 6.0.302
-  MYGET_ACCESS_TOKEN: ${{ secrets.MYGET_ACCESS_TOKEN }}
-  MYGET_SOURCE_URL: 'https://www.myget.org/F/lithiumtoast/api/v3/index.json'
-
 on:
   push:
     branches: [develop]
@@ -17,99 +10,60 @@ on:
     branches: [develop]
 
 jobs:
-
-  version-job:
-    name: "Version"
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: "Checkout Git repository"
-      uses: actions/checkout@v2
-
-    - name: "Fetch all history for all tags and branches"
-      run: git fetch --prune --unshallow
-
-    - name: "Install GitVersion"
-      uses: gittools/actions/gitversion/setup@v0.9.6
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true # workaround for https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ until the execute action is updated
-      with:
-        versionSpec: '5.x'
-
-    - name: "Use GitVersion"
-      uses: gittools/actions/gitversion/execute@v0.9.6
-
-    - run: echo "$GitVersion_NuGetVersionV2" >> version.txt
-
-    - name: "Upload NuGetVersion version artifact"
-      uses: actions/upload-artifact@v2
-      with:
-        name: version
-        path: version.txt
-
   build-test-pack-job:
-    name: "Build"
-    needs: [version-job]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-
+    name: "Build-Test-Pack"
+    runs-on: ubuntu-latest
     steps:
+      - name: "Clone Repository"
+        uses: actions/checkout@v4
+      - name: "CAKE (Build)"
+        run: dotnet run --project ./build/Build.csproj -- --target=BuildTask
+      - name: "CAKE (Test)"
+        run: dotnet run --project ./build/Build.csproj -- --target=TestTask
 
-    - name: "Download version artifact"
-      uses: actions/download-artifact@v2
-      with:
-        name: version
+      # Creating packages does not need ot run on pull requets, just the build and
+      # test above.
+      - name: "Run CAKE Build -> Test -> Package"
+        if: github.event_name != 'pull_request'
+        run: dotnet run --project ./build/Build.csproj -- --target=Default
+      - name: "Package Artifacts"
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@main
+        with:
+          name: MonoGame.Extended
+          path: artifacts/*
 
-    - name: "Read Version"
-      id: version
-      shell: bash
-      run: |
-        echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV
 
-    - name: "Print Version"
-      shell: bash
-      run: |
-        echo $VERSION
+  deploy-job:
+      name: "Deploy Nugets"
+      runs-on: ubuntu-latest
+      permissions:
+        packages: write
+        contents: write
+      needs: [build-test-pack-job]
+      if: ${{ github.event_name == 'push' }}
+      steps:
+        - name: "Clone Repository"
+          uses: actions/checkout@v4
+        - name: Download Artifacts
+          uses: actions/download-artifact@v3
+          with:
+            name: MonoGame.Extended
+            path: artifacts
+        - name: "Push Package (GitHub Feed)"
+          run: dotnet nuget push artifacts/*.nupkg --source https://nuget.pkg.github.com/$GITHUB_REPOSITORY_OWNER/index.json --api-key ${GITHUB_TOKEN}
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        - name: "Push Packages (MyGet Feed)"
+          run: dotnet nuget push artifacts/*.nupkg --source ${MYGET_SOURCE_URL} --api-key ${MYGET_ACCESS_TOKEN}
+          env:
+            MYGET_ACCESS_TOKEN: ${{ secrets.MYGET_ACCESS_TOKEN }}
+            MYGET_SOURCE_URL: 'https://www.myget.org/F/lithiumtoast/api/v3/index.json'
 
-    - name: "Checkout repository"
-      uses: actions/checkout@master
-      with:
-        submodules: true
-        lfs: true
-
-    - name: "Setup .NET Core CLI"
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '${{ env.DOTNET_CORE_SDK_VERSION }}'
-
-    - name: "Install fonts (Ubuntu)"
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
-        sudo apt-get install -y ttf-mscorefonts-installer
-        sudo apt-get install -y fontconfig
-        sudo fc-cache -f -v
-        sudo fc-match Arial
-
-    - name: "Download NuGet packages"
-      run: dotnet restore --verbosity quiet
-
-    - name: "Build solution"
-      run: dotnet build --nologo --verbosity minimal --configuration Release --no-restore /p:Version='${{ env.VERSION }}'
-
-    - name: "Test solution"
-      run: dotnet test --nologo --verbosity normal --configuration Release --no-build
-
-    - name: "Pack solution"
-      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
-      run: dotnet pack --nologo --output "./nuget-packages" --verbosity minimal --configuration Release --no-build -p:PackageVersion='${{ env.VERSION }}'
-
-    - name: "Add Packages Source: MyGet"
-      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
-      run: dotnet nuget add source $MYGET_SOURCE_URL --name "MyGet"
-
-    - name: "Upload Packages: MyGet"
-      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
-      run: dotnet nuget push "./**/*.nupkg" --source "MyGet" --skip-duplicate --api-key $MYGET_ACCESS_TOKEN
+        # Pushes packages to nuget, but only if this is a tag release.
+        - name: "Push Packages (NuGet Feed)"
+          if: github.ref_type == 'tag'
+          run: dotnet nuget push artifacts/*.nupkg --source ${NUGET_SOURCE_URL} --api-key ${NUGET_ACCESS_TOKEN}
+          env:
+            NUGET_ACCESS_TOKEN: ${{ secrets.NUGET_ACCESS_TOKEN }}
+            NUGET_SOURCE_URL: "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -23,9 +23,9 @@ jobs:
 
       # Creating packages does not need ot run on pull requets, just the build and
       # test above.
-      - name: "Run CAKE Build -> Test -> Package"
+      - name: "CAKE (Package)"
         if: github.event_name != 'pull_request'
-        run: dotnet run --project ./build/Build.csproj -- --target=Default
+        run: dotnet run --project ./build/Build.csproj -- --target=PackageTask
       - name: "Package Artifacts"
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@main

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # macOS
 .DS_Store
 *.user
+
+# cake build output
+artifacts

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,8 +4,12 @@
         <Authors>craftworkgames</Authors>
         <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
         <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryBranch>develop</RepositoryBranch>
+        <NeutralLanguage>en</NeutralLanguage>
         <PackageIcon>logo-nuget-128.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,6 +4,11 @@
         <Authors>craftworkgames</Authors>
         <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
         <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-        <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
+        <PackageIcon>logo-nuget-128.png</PackageIcon>
     </PropertyGroup>
+
+    <ItemGroup>
+        <!-- path must be relative to the individual csproj's not this .targets file -->
+        <None Include="../../../Logos/logo-nuget-128.png" Pack="true" PackagePath="" />
+    </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
+        <Version>3.9.0</Version>
         <Authors>craftworkgames</Authors>
         <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
         <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+        <Authors>craftworkgames</Authors>
+        <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
+        <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
+    </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,10 +5,12 @@
         <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
         <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
         <PackageIcon>logo-nuget-128.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
         <!-- path must be relative to the individual csproj's not this .targets file -->
         <None Include="../../../Logos/logo-nuget-128.png" Pack="true" PackagePath="" />
+        <None Include="../../../README.md" Pack="true" PackagePath="" />
     </ItemGroup>
 </Project>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Cake.Frosting" Version="3.1.0" />
+  </ItemGroup>
+</Project>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq;
+using Cake.Common;
+using Cake.Common.Build;
+using Cake.Common.Xml;
+using Cake.Core;
+using Cake.Frosting;
+
+namespace BuildScripts;
+
+public sealed class BuildContext : FrostingContext
+{
+    public string ArtifactsDirectory { get; }
+    public string Version { get; }
+
+    public BuildContext(ICakeContext context) : base(context)
+    {
+        ArtifactsDirectory = context.Arguments(nameof(ArtifactsDirectory), "artifacts").FirstOrDefault();
+        Version = context.XmlPeek("Directory.Build.targets", "/Project/PropertyGroup/Version");
+
+        if (context.BuildSystem().IsRunningOnGitHubActions)
+        {
+            Version += "." + context.EnvironmentVariable("GITHUB_RUN_NUMBER");
+        }
+    }
+}

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Cake.Common;
 using Cake.Common.Build;

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -11,15 +11,31 @@ public sealed class BuildContext : FrostingContext
 {
     public string ArtifactsDirectory { get; }
     public string Version { get; }
+    public string SolutionPath { get; }
+    public string? RepositoryOwner { get; }
+    public string? RepositoryUrl { get; }
+    public bool IsTag { get; }
+    public bool IsRunningOnGitHubActions { get; }
+    public string? GitHubToken { get; }
+    public string? MyGetAccessToken { get; }
+    public string? NuGetAccessToken { get; }
 
     public BuildContext(ICakeContext context) : base(context)
     {
-        ArtifactsDirectory = context.Arguments(nameof(ArtifactsDirectory), "artifacts").FirstOrDefault();
+        ArtifactsDirectory = context.Argument(nameof(ArtifactsDirectory), "artifacts");
         Version = context.XmlPeek("Directory.Build.targets", "/Project/PropertyGroup/Version");
+        SolutionPath = "./MonoGame.Extended.sln";
+        IsRunningOnGitHubActions = context.BuildSystem().IsRunningOnGitHubActions;
 
-        if (context.BuildSystem().IsRunningOnGitHubActions)
+        if (IsRunningOnGitHubActions)
         {
             Version += "." + context.EnvironmentVariable("GITHUB_RUN_NUMBER");
+            RepositoryOwner = context.EnvironmentVariable("GITHUB_REPOSITORY_OWNER");
+            RepositoryUrl = $"https://github.com/{context.EnvironmentVariable("GITHUB_REPOSITORY")}";
+            IsTag = context.EnvironmentVariable("GITHUB_REF_TYPE") == "tag";
+            GitHubToken = context.EnvironmentVariable("GITHUB_TOKEN");
+            MyGetAccessToken = context.EnvironmentVariable("MYGET_ACCESS_TOKEN");
+            NuGetAccessToken = context.EnvironmentVariable("NUGET_ACCESS_TOKEN");
         }
     }
 }

--- a/build/BuildTask.cs
+++ b/build/BuildTask.cs
@@ -17,8 +17,11 @@ public sealed class BuildTask : FrostingTask<BuildContext>
         {
             MSBuildSettings = msBuildSettings,
             Configuration = "Release",
+            Verbosity = DotNetVerbosity.Minimal,
+            NoRestore = true,
+            NoLogo = true
         };
 
-        context.DotNetBuild("./MonoGame.Extended.sln", buildSettings);
+        context.DotNetBuild(context.SolutionPath, buildSettings);
     }
 }

--- a/build/BuildTask.cs
+++ b/build/BuildTask.cs
@@ -1,0 +1,24 @@
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Build;
+using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Frosting;
+
+namespace BuildScripts;
+
+[TaskName(nameof(BuildTask))]
+public sealed class BuildTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        DotNetMSBuildSettings msBuildSettings = new DotNetMSBuildSettings();
+        msBuildSettings.WithProperty("Version", context.Version);
+
+        DotNetBuildSettings buildSettings = new DotNetBuildSettings()
+        {
+            MSBuildSettings = msBuildSettings,
+            Configuration = "Release",
+        };
+
+        context.DotNetBuild("./MonoGame.Extended.sln", buildSettings);
+    }
+}

--- a/build/BuildTask.cs
+++ b/build/BuildTask.cs
@@ -12,6 +12,8 @@ public sealed class BuildTask : FrostingTask<BuildContext>
     {
         DotNetMSBuildSettings msBuildSettings = new DotNetMSBuildSettings();
         msBuildSettings.WithProperty("Version", context.Version);
+        msBuildSettings.WithProperty("NoWarn", "CS1591");
+
 
         DotNetBuildSettings buildSettings = new DotNetBuildSettings()
         {

--- a/build/DeployToGithubTask.cs
+++ b/build/DeployToGithubTask.cs
@@ -1,0 +1,25 @@
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.NuGet.Push;
+using Cake.Frosting;
+
+namespace BuildScripts;
+
+[TaskName(nameof(DeployToGitHubTask))]
+public sealed class DeployToGitHubTask : FrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context)
+    {
+        return context.IsRunningOnGitHubActions;
+    }
+
+    public override void Run(BuildContext context)
+    {
+        DotNetNuGetPushSettings pushSettings = new DotNetNuGetPushSettings()
+        {
+            Source = $"https://nuget.pkg.github.com/{context.RepositoryOwner}/index.json",
+            ApiKey = context.GitHubToken
+        };
+
+        context.DotNetNuGetPush("artifacts/*.nupkg", pushSettings);
+    }
+}

--- a/build/DeployToMyGetTask.cs
+++ b/build/DeployToMyGetTask.cs
@@ -1,0 +1,25 @@
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.NuGet.Push;
+using Cake.Frosting;
+
+namespace BuildScripts;
+
+[TaskName(nameof(DeployToMyGetTask))]
+public sealed class DeployToMyGetTask : FrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context)
+    {
+        return context.IsRunningOnGitHubActions;
+    }
+
+    public override void Run(BuildContext context)
+    {
+        DotNetNuGetPushSettings pushSettings = new DotNetNuGetPushSettings()
+        {
+            Source = $"https://www.myget.org/F/lithiumtoast/api/v3/index.json",
+            ApiKey = context.MyGetAccessToken
+        };
+
+        context.DotNetNuGetPush("artifacts/*.nupkg", pushSettings);
+    }
+}

--- a/build/DeployToNuGetTask.cs
+++ b/build/DeployToNuGetTask.cs
@@ -1,0 +1,27 @@
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.NuGet.Push;
+using Cake.Frosting;
+
+namespace BuildScripts;
+
+[TaskName(nameof(DeployToNuGetTask))]
+public sealed class DeployToNuGetTask : FrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context)
+    {
+        return context.IsRunningOnGitHubActions &&
+               context.IsTag &&
+               context.RepositoryOwner == "craftworksgames";
+    }
+
+    public override void Run(BuildContext context)
+    {
+        DotNetNuGetPushSettings pushSettings = new DotNetNuGetPushSettings()
+        {
+            Source = $"https://api.nuget.org/v3/index.json",
+            ApiKey = context.NuGetAccessToken
+        };
+
+        context.DotNetNuGetPush("artifacts/*.nupkg", pushSettings);
+    }
+}

--- a/build/PackageTask.cs
+++ b/build/PackageTask.cs
@@ -1,3 +1,4 @@
+using Cake.Common.Build;
 using Cake.Common.IO;
 using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.MSBuild;
@@ -10,13 +11,16 @@ namespace BuildScripts;
 [TaskName(nameof(PackageTask))]
 public sealed class PackageTask : FrostingTask<BuildContext>
 {
-    public override async void Run(BuildContext context)
+    public override void Run(BuildContext context)
     {
         context.CleanDirectories(context.ArtifactsDirectory);
         context.CreateDirectory(context.ArtifactsDirectory);
 
         DotNetMSBuildSettings msBuildSettings = new DotNetMSBuildSettings();
         msBuildSettings.WithProperty("Version", context.Version);
+
+        //  Ignore warnings about adding duplicate items added to package
+        msBuildSettings.WithProperty("NoWarn", "NU5118")
 
         DotNetPackSettings packSettings = new DotNetPackSettings()
         {

--- a/build/PackageTask.cs
+++ b/build/PackageTask.cs
@@ -1,0 +1,34 @@
+using Cake.Common.IO;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.MSBuild;
+using Cake.Common.Tools.DotNet.Pack;
+using Cake.Core.IO;
+using Cake.Frosting;
+
+namespace BuildScripts;
+
+[TaskName(nameof(PackageTask))]
+public sealed class PackageTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        context.CleanDirectories(context.ArtifactsDirectory);
+        context.CreateDirectory(context.ArtifactsDirectory);
+
+        DotNetMSBuildSettings msBuildSettings = new DotNetMSBuildSettings();
+        msBuildSettings.WithProperty("Version", context.Version);
+
+        DotNetPackSettings packSettings = new DotNetPackSettings()
+        {
+            MSBuildSettings = msBuildSettings,
+            Configuration = "Release",
+            OutputDirectory = context.ArtifactsDirectory,
+        };
+
+        FilePathCollection files = context.GetFiles("./src/cs/MonoGame.Extended*/**/*.csproj");
+        foreach(FilePath file in files)
+        {
+            context.DotNetPack(file.FullPath, packSettings);
+        }
+    }
+}

--- a/build/PackageTask.cs
+++ b/build/PackageTask.cs
@@ -20,7 +20,7 @@ public sealed class PackageTask : FrostingTask<BuildContext>
         msBuildSettings.WithProperty("Version", context.Version);
 
         //  Ignore warnings about adding duplicate items added to package
-        msBuildSettings.WithProperty("NoWarn", "NU5118")
+        msBuildSettings.WithProperty("NoWarn", "NU5118");
 
         DotNetPackSettings packSettings = new DotNetPackSettings()
         {

--- a/build/PackageTask.cs
+++ b/build/PackageTask.cs
@@ -10,7 +10,7 @@ namespace BuildScripts;
 [TaskName(nameof(PackageTask))]
 public sealed class PackageTask : FrostingTask<BuildContext>
 {
-    public override void Run(BuildContext context)
+    public override async void Run(BuildContext context)
     {
         context.CleanDirectories(context.ArtifactsDirectory);
         context.CreateDirectory(context.ArtifactsDirectory);
@@ -22,6 +22,8 @@ public sealed class PackageTask : FrostingTask<BuildContext>
         {
             MSBuildSettings = msBuildSettings,
             Configuration = "Release",
+            Verbosity = DotNetVerbosity.Minimal,
+            NoLogo = true,
             OutputDirectory = context.ArtifactsDirectory,
         };
 

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Frosting;
+
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        return new CakeHost()
+            .UseContext<BuildContext>()
+            .Run(args);
+    }
+}
+
+public class BuildContext : FrostingContext
+{
+    public bool Delay { get; set; }
+
+    public BuildContext(ICakeContext context)
+        : base(context)
+    {
+        Delay = context.Arguments.HasArgument("delay");
+    }
+}
+
+[TaskName("Hello")]
+public sealed class HelloTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        context.Log.Information("Hello");
+    }
+}
+
+[TaskName("World")]
+[IsDependentOn(typeof(HelloTask))]
+public sealed class WorldTask : AsyncFrostingTask<BuildContext>
+{
+    // Tasks can be asynchronous
+    public override async Task RunAsync(BuildContext context)
+    {
+        if (context.Delay)
+        {
+            context.Log.Information("Waiting...");
+            await Task.Delay(1500);
+        }
+
+        context.Log.Information("World");
+    }
+}
+
+[TaskName("Default")]
+[IsDependentOn(typeof(WorldTask))]
+public class DefaultTask : FrostingTask
+{
+}

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -13,3 +13,10 @@ public static class Program
             .Run(args);
     }
 }
+
+
+[TaskName("Default")]
+[IsDependentOn(typeof(BuildTask))]
+[IsDependentOn(typeof(TestTask))]
+[IsDependentOn(typeof(PackageTask))]
+public sealed class DefaultTask : FrostingTask {}

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -9,49 +9,7 @@ public static class Program
     {
         return new CakeHost()
             .UseContext<BuildContext>()
+            .UseWorkingDirectory("../")
             .Run(args);
     }
-}
-
-public class BuildContext : FrostingContext
-{
-    public bool Delay { get; set; }
-
-    public BuildContext(ICakeContext context)
-        : base(context)
-    {
-        Delay = context.Arguments.HasArgument("delay");
-    }
-}
-
-[TaskName("Hello")]
-public sealed class HelloTask : FrostingTask<BuildContext>
-{
-    public override void Run(BuildContext context)
-    {
-        context.Log.Information("Hello");
-    }
-}
-
-[TaskName("World")]
-[IsDependentOn(typeof(HelloTask))]
-public sealed class WorldTask : AsyncFrostingTask<BuildContext>
-{
-    // Tasks can be asynchronous
-    public override async Task RunAsync(BuildContext context)
-    {
-        if (context.Delay)
-        {
-            context.Log.Information("Waiting...");
-            await Task.Delay(1500);
-        }
-
-        context.Log.Information("World");
-    }
-}
-
-[TaskName("Default")]
-[IsDependentOn(typeof(WorldTask))]
-public class DefaultTask : FrostingTask
-{
 }

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -1,4 +1,9 @@
+using System.Threading.Tasks;
+using Cake.Common.Build;
+using Cake.Common.IO;
+using Cake.Common.Tools.ReportUnit;
 using Cake.Core;
+using Cake.Core.IO;
 using Cake.Frosting;
 
 namespace BuildScripts;
@@ -14,9 +19,16 @@ public static class Program
     }
 }
 
-
 [TaskName("Default")]
+[IsDependentOn(typeof(RestoreTask))]
 [IsDependentOn(typeof(BuildTask))]
 [IsDependentOn(typeof(TestTask))]
 [IsDependentOn(typeof(PackageTask))]
 public sealed class DefaultTask : FrostingTask {}
+
+
+[TaskName("Deploy")]
+[IsDependentOn(typeof(DeployToGitHubTask))]
+[IsDependentOn(typeof(DeployToMyGetTask))]
+[IsDependentOn(typeof(DeployToNuGetTask))]
+public sealed class DeployTask : FrostingTask {}

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -1,6 +1,4 @@
-using System.Threading.Tasks;
 using Cake.Core;
-using Cake.Core.Diagnostics;
 using Cake.Frosting;
 
 namespace BuildScripts;

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -3,6 +3,8 @@ using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Frosting;
 
+namespace BuildScripts;
+
 public static class Program
 {
     public static int Main(string[] args)

--- a/build/RestoreTask.cs
+++ b/build/RestoreTask.cs
@@ -1,0 +1,18 @@
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Restore;
+using Cake.Frosting;
+
+namespace BuildScripts;
+
+public sealed class RestoreTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        DotNetRestoreSettings restoreSettings = new DotNetRestoreSettings()
+        {
+            Verbosity = DotNetVerbosity.Quiet
+        };
+
+        context.DotNetRestore(context.SolutionPath, restoreSettings);
+    }
+}

--- a/build/TestTask.cs
+++ b/build/TestTask.cs
@@ -1,0 +1,22 @@
+
+using Cake.Common.IO;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Test;
+using Cake.Core.IO;
+using Cake.Frosting;
+
+namespace BuildScripts;
+
+[TaskName(nameof(TestTask))]
+public class TestTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        DotNetTestSettings settings = new DotNetTestSettings()
+        {
+            Configuration = "Release",
+        };
+
+        context.DotNetTest("MonoGame.Extended.sln");
+    }
+}

--- a/build/TestTask.cs
+++ b/build/TestTask.cs
@@ -1,8 +1,6 @@
 
-using Cake.Common.IO;
 using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.Test;
-using Cake.Core.IO;
 using Cake.Frosting;
 
 namespace BuildScripts;

--- a/build/TestTask.cs
+++ b/build/TestTask.cs
@@ -1,4 +1,3 @@
-
 using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.Test;
 using Cake.Frosting;
@@ -10,11 +9,14 @@ public class TestTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
-        DotNetTestSettings settings = new DotNetTestSettings()
+        DotNetTestSettings testSettings = new DotNetTestSettings()
         {
             Configuration = "Release",
+            Verbosity = DotNetVerbosity.Normal,
+            NoLogo = true,
+            NoBuild = true
         };
 
-        context.DotNetTest("MonoGame.Extended.sln");
+        context.DotNetTest(context.SolutionPath, testSettings);
     }
 }

--- a/src/cs/MonoGame.Extended.Animations/MonoGame.Extended.Animations.csproj
+++ b/src/cs/MonoGame.Extended.Animations/MonoGame.Extended.Animations.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>Animations to make MonoGame more awesome.</Description>
     <PackageTags>monogame animations spritesheet sprite</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/cs/MonoGame.Extended.Collisions/MonoGame.Extended.Collisions.csproj
+++ b/src/cs/MonoGame.Extended.Collisions/MonoGame.Extended.Collisions.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>Collisions to make MonoGame more awesome.</Description>
     <PackageTags>monogame collisions</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/cs/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
+++ b/src/cs/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
@@ -12,9 +12,6 @@
     <Authors>craftworkgames</Authors>
     <Description>Content Pipeline importers and processors to make MonoGame more awesome.</Description>
     <PackageTags>monogame content importer processor reader tiled texturepacker bmfont animations</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/cs/MonoGame.Extended.Entities/MonoGame.Extended.Entities.csproj
+++ b/src/cs/MonoGame.Extended.Entities/MonoGame.Extended.Entities.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>An Entity Component System to make MonoGame more awesome.</Description>
     <PackageTags>monogame ecs entity component system</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/cs/MonoGame.Extended.Graphics/MonoGame.Extended.Graphics.csproj
+++ b/src/cs/MonoGame.Extended.Graphics/MonoGame.Extended.Graphics.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>Graphics makes MonoGame more awesome.</Description>
     <PackageTags>monogame graphics batcher effects</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/cs/MonoGame.Extended.Gui/MonoGame.Extended.Gui.csproj
+++ b/src/cs/MonoGame.Extended.Gui/MonoGame.Extended.Gui.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>A GUI system for MonoGame written from the ground up to make MonoGame more awesome.</Description>
     <PackageTags>monogame gui</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/cs/MonoGame.Extended.Input/MonoGame.Extended.Input.csproj
+++ b/src/cs/MonoGame.Extended.Input/MonoGame.Extended.Input.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>An event based input system to MonoGame more awesome.</Description>
     <PackageTags>monogame input event based listeners</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/cs/MonoGame.Extended.Particles/MonoGame.Extended.Particles.csproj
+++ b/src/cs/MonoGame.Extended.Particles/MonoGame.Extended.Particles.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>A high performance particle system to make MonoGame more awesome.</Description>
     <PackageTags>monogame particle system</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/cs/MonoGame.Extended.Tiled/MonoGame.Extended.Tiled.csproj
+++ b/src/cs/MonoGame.Extended.Tiled/MonoGame.Extended.Tiled.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>Support for Tiled maps to make MonoGame more awesome. See http://www.mapeditor.org</Description>
     <PackageTags>monogame tiled maps orthographic isometric</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/cs/MonoGame.Extended.Tweening/MonoGame.Extended.Tweening.csproj
+++ b/src/cs/MonoGame.Extended.Tweening/MonoGame.Extended.Tweening.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>A tweening system to make MonoGame more awesome.</Description>
     <PackageTags>monogame animations tweening</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/cs/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/src/cs/MonoGame.Extended/MonoGame.Extended.csproj
@@ -7,9 +7,6 @@
     <Authors>craftworkgames</Authors>
     <Description>It makes MonoGame more awesome.</Description>
     <PackageTags>monogame extended pipeline bmfont tiled texture atlas input viewport fps shapes sprite</PackageTags>
-    <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/craftworkgames/MonoGame.Extended/master/Logos/logo-nuget-128.png</PackageIconUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -26,5 +23,5 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/cs/Tests/MonoGame.Extended.Tests/Collections/BagTests.cs
+++ b/src/cs/Tests/MonoGame.Extended.Tests/Collections/BagTests.cs
@@ -35,7 +35,12 @@ namespace MonoGame.Extended.Tests.Collections
                     Assert.True(false);
             }
 
-            GC.EndNoGCRegion();
+            //  Wrap in if statement due to exception thrown when running test through
+            //  cake build script or when debugging test script manually.
+            if(GCSettings.LatencyMode == GCLatencyMode.NoGCRegion)
+            {
+                GC.EndNoGCRegion();
+            }
         }
 
     }

--- a/src/cs/Tests/MonoGame.Extended.Tests/Collections/BagTests.cs
+++ b/src/cs/Tests/MonoGame.Extended.Tests/Collections/BagTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;


### PR DESCRIPTION
## Description
After speaking with Lithium earlier, I have created this PR to update the GitHub Actions workflow for automating the NuGet pacakge releases both for the official NuGet source and Lithium's MyGet source.

This PR updates the GitHub Action to automate the build, test, package, and NuGet deployment.  The build, test, and package steps have been moved into a Cake Frosting project which is called from the GitHub Action.

 Note that the package task does not execute unless a push is made into the `develop` branch.  This is so packaging is not run during a PR, and only runs when a PR is merged into `develop` or a direct push is made to `develop`

The GitHub Action was also updated to automate NuGet package deployment to the following locations
- GitHub Packages within this repository
- Lithium's MyGet feed
- Official NuGet feed

Note that the NuGet package pushes **will only occur when a push is made to the `develop` branch**.  This can be from a direct push or from a merged pull request.  Furthermore, only the GitHub Packages and Lithium's MyGet feeds will be deployed too initially.  To deploy to the official NuGet feed, a new release tag has to be made in this repository first.