### PR TITLE
Throw exception in ViewportAdapter constructor if the GraphicsDevice is null

### DIFF
--- a/src/cs/MonoGame.Extended/ViewportAdapters/Exceptions/NullGraphicsDeviceException.cs
+++ b/src/cs/MonoGame.Extended/ViewportAdapters/Exceptions/NullGraphicsDeviceException.cs
@@ -1,0 +1,18 @@
+﻿namespace MonoGame.Extended.ViewportAdapters.Exceptions;
+
+using System;
+using Microsoft.Xna.Framework.Graphics;
+
+/// <summary>
+/// Thrown when the <see cref="GraphicsDevice"/> is null
+/// </summary>
+public class NullGraphicsDeviceException : Exception
+{
+    /// <summary>
+    /// Thrown when the <see cref="GraphicsDevice"/> is null
+    /// </summary>
+    /// <param name="message">Exception message</param>
+    public NullGraphicsDeviceException(string message) : base(message)
+    {
+    }
+}

--- a/src/cs/MonoGame.Extended/ViewportAdapters/ViewportAdapter.cs
+++ b/src/cs/MonoGame.Extended/ViewportAdapters/ViewportAdapter.cs
@@ -4,10 +4,17 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.ViewportAdapters
 {
+    using MonoGame.Extended.ViewportAdapters.Exceptions;
+
     public abstract class ViewportAdapter : IDisposable
     {
         protected ViewportAdapter(GraphicsDevice graphicsDevice)
         {
+            if (graphicsDevice is null)
+            {
+                throw new NullGraphicsDeviceException($"Attempted to construct {nameof(ViewportAdapter)} but {nameof(GraphicsDevice)} is null");
+            }
+
             GraphicsDevice = graphicsDevice;
         }
 

--- a/src/cs/Tests/MonoGame.Extended.Tests/ViewportAdapters/ViewportAdapterTests.cs
+++ b/src/cs/Tests/MonoGame.Extended.Tests/ViewportAdapters/ViewportAdapterTests.cs
@@ -1,0 +1,35 @@
+﻿namespace MonoGame.Extended.Tests.ViewportAdapters;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.ViewportAdapters;
+using MonoGame.Extended.ViewportAdapters.Exceptions;
+using Xunit;
+
+public class ViewportAdapterTests
+{
+    [Fact]
+    public void Constructor_ShouldThrowNullGraphicsDeviceException_IfANullGraphicsDeviceIsPassed()
+    {
+        var act = () => new TestViewportAdapter(null);
+
+        Assert.Throws<NullGraphicsDeviceException>(act);
+    }
+
+    class TestViewportAdapter : ViewportAdapter
+    {
+        public TestViewportAdapter(GraphicsDevice graphicsDevice) : base(graphicsDevice)
+        {
+        }
+
+        public override int VirtualWidth { get; }
+
+        public override int VirtualHeight { get; }
+
+        public override int ViewportWidth { get; }
+
+        public override int ViewportHeight { get; }
+
+        public override Matrix GetScaleMatrix() => throw new System.NotImplementedException();
+    }
+}


### PR DESCRIPTION
If the viewport adapter is initialized in the constructor of game, GraphicsDevice will be null. 

There is no check for this, so the null ref only occurs when trying to call GetViewMatrix(). 

This PR aims to improve the public API.