### PR TITLE
Check for undefined layer and throw on collision actor insertion

### DIFF
--- a/src/cs/MonoGame.Extended.Collisions/CollisionComponent.cs
+++ b/src/cs/MonoGame.Extended.Collisions/CollisionComponent.cs
@@ -104,7 +104,13 @@ namespace MonoGame.Extended.Collisions
         /// <param name="target">Target to insert.</param>
         public void Insert(ICollisionActor target)
         {
-            _layers[target.LayerName ?? DEFAULT_LAYER_NAME].Space.Insert(target);
+            var layerName = target.LayerName ?? DEFAULT_LAYER_NAME;
+            if (!_layers.TryGetValue(layerName, out var layer))
+            {
+                throw new UndefinedLayerException(layerName);
+            }
+
+            layer.Space.Insert(target);
         }
 
         /// <summary>

--- a/src/cs/MonoGame.Extended.Collisions/Layers/UndefinedLayerException.cs
+++ b/src/cs/MonoGame.Extended.Collisions/Layers/UndefinedLayerException.cs
@@ -1,0 +1,18 @@
+﻿namespace MonoGame.Extended.Collisions.Layers;
+
+using System;
+
+/// <summary>
+/// Thrown when the collision system has no layer defined with the specified name
+/// </summary>
+public class UndefinedLayerException : Exception
+{
+    /// <summary>
+    /// Thrown when the collision system has no layer defined with the specified name
+    /// </summary>
+    /// <param name="layerName">The undefined layer name</param>
+    public UndefinedLayerException(string layerName)
+        : base($"Layer with name '{layerName}' is undefined")
+    {
+    }
+}


### PR DESCRIPTION
When calling the CollisionComponent constructor, I incorrectly assumed that providing no arguments (i.e. layer = null) would define a default layer automatically. This is not the case, and attempting to insert an actor into a collision layer will result in a .NET exception being thrown as we try to index a dictionary entry that does not exist.

Wrapped this in a check which will now throw a custom exception, to make it clear from a public API perspective what has occurred.