### PR TITLE
tiled content pipeline bugfixes & new fields

### DIFF
--- a/src/cs/MonoGame.Extended.Collisions/ISpaceAlgorithm.cs
+++ b/src/cs/MonoGame.Extended.Collisions/ISpaceAlgorithm.cs
@@ -21,10 +21,15 @@ public interface ISpaceAlgorithm
     bool Remove(ICollisionActor actor);
 
     /// <summary>
-    /// Removes the actor into the space.
-    /// The actor will have its OnCollision called when collisions occur.
+    /// Checks if an actor is within the space.
     /// </summary>
-    /// <param name="actor">Actor to remove.</param>
+    /// <param name="actor">Actor to check for.</param>
+    bool Contains(ICollisionActor actor);
+
+    /// <summary>
+    /// Queries the space for collisions within a bounding rectangle.
+    /// </summary>
+    /// <param name="boundsBoundingRectangle">Rectangle to check against.</param>
     IEnumerable<ICollisionActor> Query(RectangleF boundsBoundingRectangle);
 
     /// <summary>

--- a/src/cs/MonoGame.Extended.Collisions/QuadTree/QuadTreeSpace.cs
+++ b/src/cs/MonoGame.Extended.Collisions/QuadTree/QuadTreeSpace.cs
@@ -49,8 +49,15 @@ public class QuadTreeSpace: ISpaceAlgorithm
         return false;
     }
 
+
     /// <summary>
-    /// Restructure a inner collection, if layer is dynamic, because actors can change own position
+    /// Checks if the target is within the space.
+    /// </summary>
+    /// <param name="target">Target to check for.</param>
+    public bool Contains(ICollisionActor target) => _actors.Contains(target);
+
+    /// <summary>
+    /// Restructure an inner collection, if layer is dynamic, because actors can change own position
     /// </summary>
     public void Reset()
     {

--- a/src/cs/MonoGame.Extended.Collisions/SpatialHash.cs
+++ b/src/cs/MonoGame.Extended.Collisions/SpatialHash.cs
@@ -16,6 +16,8 @@ public class SpatialHash: ISpaceAlgorithm
         _size = size;
     }
 
+    public bool Contains(ICollisionActor actor) => _actors.Contains(actor);
+
     public void Insert(ICollisionActor actor)
     {
         InsertToHash(actor);

--- a/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/ContentWriterExtensions.cs
+++ b/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/ContentWriterExtensions.cs
@@ -19,6 +19,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
             {
                 writer.Write(property.Name);
                 writer.Write(property.Value ?? string.Empty);
+                writer.Write(property.Type ?? string.Empty);
+                writer.Write(property.PropertyType ?? string.Empty);
                 WriteTiledMapProperties(writer, property.Properties);
             }
         }

--- a/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
+++ b/src/cs/MonoGame.Extended.Content.Pipeline/Tiled/TiledMapWriter.cs
@@ -97,6 +97,8 @@ namespace MonoGame.Extended.Content.Pipeline.Tiled
             switch (layer.LayerType)
             {
                 case TiledMapLayerType.ImageLayer:
+                    writer.Write(((TiledMapImageLayerContent)layer).RepeatX);
+                    writer.Write(((TiledMapImageLayerContent)layer).RepeatY);
                     WriteImageLayer(writer, (TiledMapImageLayerContent)layer);
                     break;
                 case TiledMapLayerType.TileLayer:

--- a/src/cs/MonoGame.Extended.Tiled/ContentReaderExtensions.cs
+++ b/src/cs/MonoGame.Extended.Tiled/ContentReaderExtensions.cs
@@ -11,7 +11,10 @@ namespace MonoGame.Extended.Tiled
             for (var i = 0; i < count; i++)
             {
                 var key = reader.ReadString();
-                var value = new TiledMapPropertyValue(reader.ReadString());
+                var value = new TiledMapPropertyValue(
+                    reader.ReadString(),
+                    reader.ReadString(),
+                    reader.ReadString());
                 ReadTiledMapProperties(reader, value.Properties);
                 properties[key] = value;
             }

--- a/src/cs/MonoGame.Extended.Tiled/Serialization/TiledMapImageLayerContent.cs
+++ b/src/cs/MonoGame.Extended.Tiled/Serialization/TiledMapImageLayerContent.cs
@@ -14,10 +14,18 @@ namespace MonoGame.Extended.Tiled.Serialization
         [XmlElement(ElementName = "image")]
         public TiledMapImageContent Image { get; set; }
 
+        [XmlAttribute(AttributeName = "repeatx")]
+        public bool RepeatX { get; set; }
+
+        [XmlAttribute(AttributeName = "repeaty")]
+        public bool RepeatY { get; set; }
+
         public TiledMapImageLayerContent()
             : base(TiledMapLayerType.ImageLayer)
         {
             Opacity = 1.0f;
+            RepeatX = false;
+            RepeatY = false;
             Visible = true;
             Properties = new List<TiledMapPropertyContent>();
         }

--- a/src/cs/MonoGame.Extended.Tiled/Serialization/TiledMapPropertyContent.cs
+++ b/src/cs/MonoGame.Extended.Tiled/Serialization/TiledMapPropertyContent.cs
@@ -11,6 +11,12 @@ namespace MonoGame.Extended.Tiled.Serialization
         [XmlAttribute(AttributeName = "value")]
         public string ValueAttribute { get; set; }
 
+        [XmlAttribute(AttributeName = "type")]
+        public string Type { get; set; }
+
+        [XmlAttribute(AttributeName = "propertytype")]
+        public string PropertyType { get; set; }
+
         [XmlText]
         public string ValueBody { get; set; }
 

--- a/src/cs/MonoGame.Extended.Tiled/TiledMapImageLayer.cs
+++ b/src/cs/MonoGame.Extended.Tiled/TiledMapImageLayer.cs
@@ -5,14 +5,18 @@ namespace MonoGame.Extended.Tiled
 {
     public class TiledMapImageLayer : TiledMapLayer, IMovable
     {
-        public TiledMapImageLayer(string name, string type, Texture2D image, Vector2? position = null, Vector2? offset = null, Vector2? parallaxFactor = null, float opacity = 1.0f, bool isVisible = true)
+        public TiledMapImageLayer(string name, string type, Texture2D image, Vector2? position = null, Vector2? offset = null, Vector2? parallaxFactor = null, float opacity = 1.0f, bool repeatX = false, bool repeatY = false, bool isVisible = true)
             : base(name, type, offset, parallaxFactor, opacity, isVisible)
         {
             Image = image;
             Position = position ?? Vector2.Zero;
+            RepeatX = repeatX;
+            RepeatY = repeatY;
         }
 
         public Texture2D Image { get; }
         public Vector2 Position { get; set; }
+        public bool RepeatX { get; set; }
+        public bool RepeatY { get; set; }
     }
 }

--- a/src/cs/MonoGame.Extended.Tiled/TiledMapProperties.cs
+++ b/src/cs/MonoGame.Extended.Tiled/TiledMapProperties.cs
@@ -7,7 +7,7 @@ namespace MonoGame.Extended.Tiled
         public bool TryGetValue(string key, out string value)
         {
             bool result = TryGetValue(key, out TiledMapPropertyValue tmpVal);
-            value = result ? null : tmpVal.Value;
+            value = result ? tmpVal.Value : null;
             return result;
         }
     }

--- a/src/cs/MonoGame.Extended.Tiled/TiledMapPropertyValue.cs
+++ b/src/cs/MonoGame.Extended.Tiled/TiledMapPropertyValue.cs
@@ -4,24 +4,18 @@ public class TiledMapPropertyValue
 {
     public string Value { get; }
 
+    public string Type { get; }
+
+    public string PropertyType { get; }
+
     public TiledMapProperties Properties;
 
-    public TiledMapPropertyValue()
-    {
-        Value = string.Empty;
-        Properties = new();
-    }
-
-    public TiledMapPropertyValue(string value)
+    public TiledMapPropertyValue(string value, string type, string propertyType)
     {
         Value = value;
+        Type = type;
+        PropertyType = propertyType;
         Properties = new();
-    }
-
-    public TiledMapPropertyValue(TiledMapProperties properties)
-    {
-        Value = string.Empty;
-        Properties = properties;
     }
 
     public override string ToString() => Value;

--- a/src/cs/MonoGame.Extended.Tiled/TiledMapReader.cs
+++ b/src/cs/MonoGame.Extended.Tiled/TiledMapReader.cs
@@ -95,7 +95,9 @@ namespace MonoGame.Extended.Tiled
             switch (layerType)
             {
                 case TiledMapLayerType.ImageLayer:
-                    layer = ReadImageLayer(reader, name, type, offset, parallaxFactor, opacity, isVisible);
+                    var repeatX = reader.ReadBoolean();
+                    var repeatY = reader.ReadBoolean();
+                    layer = ReadImageLayer(reader, name, type, offset, parallaxFactor, opacity, repeatX, repeatY, isVisible);
                     break;
                 case TiledMapLayerType.TileLayer:
                     layer = ReadTileLayer(reader, name, type, offset, parallaxFactor, opacity, isVisible, map);
@@ -195,13 +197,13 @@ namespace MonoGame.Extended.Tiled
             return points;
         }
 
-        private static TiledMapImageLayer ReadImageLayer(ContentReader reader, string name, string type, Vector2 offset, Vector2 parallaxFactor, float opacity, bool isVisible)
+        private static TiledMapImageLayer ReadImageLayer(ContentReader reader, string name, string type, Vector2 offset, Vector2 parallaxFactor, float opacity, bool repeatX, bool repeatY, bool isVisible)
         {
             var texture = reader.ReadExternalReference<Texture2D>();
             var x = reader.ReadSingle();
             var y = reader.ReadSingle();
             var position = new Vector2(x, y);
-            return new TiledMapImageLayer(name, type, texture, position, offset, parallaxFactor, opacity, isVisible);
+            return new TiledMapImageLayer(name, type, texture, position, offset, parallaxFactor, opacity, repeatX, repeatY, isVisible);
         }
 
         private static TiledMapTileLayer ReadTileLayer(ContentReader reader, string name, string type, Vector2 offset, Vector2 parallaxFactor, float opacity, bool isVisible, TiledMap map)


### PR DESCRIPTION
added support for reading type field from TiledMapPropertyContent (Tiled lets you set it...)
added support for repeatX/repeatY fields from Tiled image layers property (renderer still does not support this yet)

value read bugfix @TiledMapProperties.cs:10 - this got introduced when you pulled my previous pr (sorry)