### PR TITLE
ICollisionActor casting support for CollisionComponent 

### DIFF
--- a/src/cs/MonoGame.Extended.Collisions/ISpaceAlgorithm.cs
+++ b/src/cs/MonoGame.Extended.Collisions/ISpaceAlgorithm.cs
@@ -21,10 +21,15 @@ public interface ISpaceAlgorithm
     bool Remove(ICollisionActor actor);
 
     /// <summary>
-    /// Removes the actor into the space.
-    /// The actor will have its OnCollision called when collisions occur.
+    /// Checks if an actor is within the space.
     /// </summary>
-    /// <param name="actor">Actor to remove.</param>
+    /// <param name="actor">Actor to check for.</param>
+    bool Contains(ICollisionActor actor);
+
+    /// <summary>
+    /// Queries the space for collisions within a bounding rectangle.
+    /// </summary>
+    /// <param name="boundsBoundingRectangle">Rectangle to check against.</param>
     IEnumerable<ICollisionActor> Query(RectangleF boundsBoundingRectangle);
 
     /// <summary>

--- a/src/cs/MonoGame.Extended.Collisions/QuadTree/QuadTreeSpace.cs
+++ b/src/cs/MonoGame.Extended.Collisions/QuadTree/QuadTreeSpace.cs
@@ -49,8 +49,15 @@ public class QuadTreeSpace: ISpaceAlgorithm
         return false;
     }
 
+
     /// <summary>
-    /// Restructure a inner collection, if layer is dynamic, because actors can change own position
+    /// Checks if the target is within the space.
+    /// </summary>
+    /// <param name="target">Target to check for.</param>
+    public bool Contains(ICollisionActor target) => _actors.Contains(target);
+
+    /// <summary>
+    /// Restructure an inner collection, if layer is dynamic, because actors can change own position
     /// </summary>
     public void Reset()
     {

--- a/src/cs/MonoGame.Extended.Collisions/SpatialHash.cs
+++ b/src/cs/MonoGame.Extended.Collisions/SpatialHash.cs
@@ -16,6 +16,8 @@ public class SpatialHash: ISpaceAlgorithm
         _size = size;
     }
 
+    public bool Contains(ICollisionActor actor) => _actors.Contains(actor);
+
     public void Insert(ICollisionActor actor)
     {
         InsertToHash(actor);


### PR DESCRIPTION
This is a Cast function in CollisionComponent that ICollisionActor objects can use (not unlike the one that rigidbodies get in unity).