### PR TITLE
Resolves Infinite Recursion with Shape.Intersects(this IShapeF, IShapeF)

### DIFF
--- a/src/cs/MonoGame.Extended/Math/ShapeF.cs
+++ b/src/cs/MonoGame.Extended/Math/ShapeF.cs
@@ -42,7 +42,7 @@ namespace MonoGame.Extended
                     CircleF circleA when b is OrientedRectangle orientedRectangleB => Intersects(circleA, orientedRectangleB),
 
                     RectangleF rectangleA when b is CircleF circleB => Intersects(circleB, rectangleA),
-                    RectangleF rectangleA when b is RectangleF rectangleB => Intersects(rectangleA, rectangleB),
+                    RectangleF rectangleA when b is RectangleF rectangleB => rectangleA.Intersects(rectangleB),
                     RectangleF rectangleA when b is OrientedRectangle orientedRectangleB => Intersects(rectangleA, orientedRectangleB).Intersects,
 
                     OrientedRectangle orientedRectangleA when b is CircleF circleB => Intersects(circleB, orientedRectangleA),


### PR DESCRIPTION
## Description
This PR resolves the infinite recursion bug in `Shape.Intersects(this IShapeF, IShapeF)` when both parameters are of type `RectangleF`.

## Related Issues
- Closes #850 
- #849 