### PR TITLE
Removing MyGet Feed Deploy

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -29,6 +29,5 @@ public sealed class DefaultTask : FrostingTask {}
 
 [TaskName("Deploy")]
 [IsDependentOn(typeof(DeployToGitHubTask))]
-[IsDependentOn(typeof(DeployToMyGetTask))]
 [IsDependentOn(typeof(DeployToNuGetTask))]
 public sealed class DeployTask : FrostingTask {}


### PR DESCRIPTION
## Description
Disabling the deploy to Lithium's MyGet feed.  The MyGet feed is configured to not allow pushes with versions that aren't strictly [Major].[Minor].[Patch].

## Related Issues
- #830