### PR TITLE
Removed patreon added aristurtledev

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: craftworkgames
-patreon: craftworkgames
+github: aristurtledev


### PR DESCRIPTION
This removes the patreon link from the funding section and adds aristurtledev as a sponserable maintainer