### PR TITLE
Use ArtifactsPath When Resolving dlls to pack with MonoGame.Extended.Content.Pipeline

### DIFF
--- a/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
+++ b/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Content Include="bin\net6.0\*.dll" Pack="True" PackagePath="tools\" />
+    <Content Include="$(ArtifactsPath)/bin/MonoGame.Extended.Content.Pipeline/release/*.dll" Pack="True" PackagePath="tools" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Description
This updates the path to use for resolving the dlls to include with the pack of the MonoGame.Extended.Content.Pipeline to use the ArtifactsPath.