### PR TITLE
Add Edge Test for `Polygon.Contains`

### DIFF
--- a/tests/MonoGame.Extended.Tests/Shapes/PolygonFTests.cs
+++ b/tests/MonoGame.Extended.Tests/Shapes/PolygonFTests.cs
@@ -24,6 +24,11 @@ namespace MonoGame.Extended.Tests.Shapes
             Assert.True(polygon.Contains(new Vector2(9.99f, 9.99f)));
             Assert.False(polygon.Contains(new Vector2(-1f, -1f)));
             Assert.False(polygon.Contains(new Vector2(-11f, -11f)));
+
+            //  Reference: https://github.com/craftworkgames/MonoGame.Extended/issues/214
+            //  To maintain consistency with behavior in MonoGame, a point that exists at the edge of a polygon is
+            //  -not- contained within the polygon and should return false
+            Assert.False(polygon.Contains(new Vector2(10.0f, 10.0f)));
         }
 
         [Fact]

--- a/tests/MonoGame.Extended.Tests/Shapes/PolygonTests.cs
+++ b/tests/MonoGame.Extended.Tests/Shapes/PolygonTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace MonoGame.Extended.Tests.Shapes
 {
-    public class PolygonFTests
+    public class PolygonTests
     {
         [Fact]
         public void Polygon_Contains_Point_Test()


### PR DESCRIPTION
## Description
In order to ensure consistency in behavior with MonoGame and MonoGame.Extended, a new test was added to the `Polygon` tests that ensures a point that exists on an edge of a polygon is not "contained" within the polygon.

## Reference
- https://github.com/craftworkgames/MonoGame.Extended/issues/214