### PR TITLE
Rename `Size2` to `SizeF`

### DIFF
--- a/source/MonoGame.Extended.Collisions/SpatialHash.cs
+++ b/source/MonoGame.Extended.Collisions/SpatialHash.cs
@@ -9,9 +9,9 @@ public class SpatialHash: ISpaceAlgorithm
     private readonly Dictionary<int, List<ICollisionActor>> _dictionary = new();
     private readonly List<ICollisionActor> _actors = new();
 
-    private readonly Size2 _size;
+    private readonly SizeF _size;
 
-    public SpatialHash(Size2 size)
+    public SpatialHash(SizeF size)
     {
         _size = size;
     }

--- a/source/MonoGame.Extended.Gui/Controls/UniformGrid.cs
+++ b/source/MonoGame.Extended.Gui/Controls/UniformGrid.cs
@@ -57,10 +57,10 @@ namespace MonoGame.Extended.Gui.Controls
             public float MaxCellHeight;
             public float Columns;
             public float Rows;
-            public Size2 MinCellSize => new Size2(MinCellWidth * Columns, MinCellHeight * Rows);
+            public SizeF MinCellSize => new SizeF(MinCellWidth * Columns, MinCellHeight * Rows);
         }
-        
-        private GridInfo CalculateGridInfo(IGuiContext context, Size2 availableSize)
+
+        private GridInfo CalculateGridInfo(IGuiContext context, SizeF availableSize)
         {
             var columns = Columns == 0 ? (int)Math.Ceiling(Math.Sqrt(Items.Count)) : Columns;
             var rows = Rows == 0 ? (int)Math.Ceiling((float)Items.Count / columns) : Rows;

--- a/source/MonoGame.Extended.Gui/Screen.cs
+++ b/source/MonoGame.Extended.Gui/Screen.cs
@@ -41,7 +41,7 @@ namespace MonoGame.Extended.Gui
 
         public float Width { get; private set; }
         public float Height { get; private set; }
-        public Size2 Size => new Size2(Width, Height);
+        public SizeF Size => new SizeF(Width, Height);
         public bool IsVisible { get; set; } = true;
 
         private bool _isLayoutRequired;

--- a/source/MonoGame.Extended.Tiled/Serialization/TiledMapLayerModelContent.cs
+++ b/source/MonoGame.Extended.Tiled/Serialization/TiledMapLayerModelContent.cs
@@ -15,7 +15,7 @@ namespace MonoGame.Extended.Tiled.Serialization
         public string LayerName { get; }
         public ReadOnlyCollection<VertexPositionTexture> Vertices { get; }
         public ReadOnlyCollection<ushort> Indices { get; }
-        public Size2 ImageSize { get; }
+        public SizeF ImageSize { get; }
         public string TextureAssetName { get; }
 
         public TiledMapLayerModelContent(string layerName, TiledMapImageContent image)
@@ -25,7 +25,7 @@ namespace MonoGame.Extended.Tiled.Serialization
             Vertices = new ReadOnlyCollection<VertexPositionTexture>(_vertices);
             _indices = new List<ushort>();
             Indices = new ReadOnlyCollection<ushort>(_indices);
-            ImageSize = new Size2(image.Width, image.Height);
+            ImageSize = new SizeF(image.Width, image.Height);
             TextureAssetName = Path.ChangeExtension(image.Source, null);
         }
 

--- a/source/MonoGame.Extended.Tiled/TiledMapEllipseObject.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapEllipseObject.cs
@@ -4,7 +4,7 @@ namespace MonoGame.Extended.Tiled
 {
     public sealed class TiledMapEllipseObject : TiledMapObject
     {
-        public TiledMapEllipseObject(int identifier, string name, Size2 size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null)
+        public TiledMapEllipseObject(int identifier, string name, SizeF size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null)
             : base(identifier, name, size, position, rotation, opacity, isVisible, type)
         {
             Radius = new Vector2(size.Width / 2.0f, size.Height / 2.0f);

--- a/source/MonoGame.Extended.Tiled/TiledMapObject.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapObject.cs
@@ -4,7 +4,7 @@ namespace MonoGame.Extended.Tiled
 {
     public abstract class TiledMapObject
     {
-        protected TiledMapObject(int identifier, string name, Size2 size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null)
+        protected TiledMapObject(int identifier, string name, SizeF size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null)
         {
             Identifier = identifier;
             Name = name;
@@ -24,7 +24,7 @@ namespace MonoGame.Extended.Tiled
         public float Opacity { get; set; }
         public float Rotation { get; set; }
         public Vector2 Position { get; }
-        public Size2 Size { get; set; }
+        public SizeF Size { get; set; }
         public TiledMapProperties Properties { get; }
 
         public override string ToString()

--- a/source/MonoGame.Extended.Tiled/TiledMapPolygonObject.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapPolygonObject.cs
@@ -4,7 +4,7 @@ namespace MonoGame.Extended.Tiled
 {
     public sealed class TiledMapPolygonObject : TiledMapObject
     {
-        public TiledMapPolygonObject(int identifier, string name, Point2[] points, Size2 size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null) 
+        public TiledMapPolygonObject(int identifier, string name, Point2[] points, SizeF size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null)
             : base(identifier, name, size, position, rotation, opacity, isVisible, type)
         {
             Points = points;

--- a/source/MonoGame.Extended.Tiled/TiledMapPolylineObject.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapPolylineObject.cs
@@ -4,12 +4,12 @@ namespace MonoGame.Extended.Tiled
 {
     public sealed class TiledMapPolylineObject : TiledMapObject
     {
-        public TiledMapPolylineObject(int identifier, string name, Point2[] points, Size2 size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null) 
+        public TiledMapPolylineObject(int identifier, string name, Point2[] points, SizeF size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null)
             : base(identifier, name, size, position, rotation, opacity, isVisible, type)
         {
             Points = points;
         }
-        
+
         public Point2[] Points { get; }
     }
 }

--- a/source/MonoGame.Extended.Tiled/TiledMapReader.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapReader.cs
@@ -138,7 +138,7 @@ namespace MonoGame.Extended.Tiled
             var position = new Vector2(reader.ReadSingle(), reader.ReadSingle());
             var width = reader.ReadSingle();
             var height = reader.ReadSingle();
-            var size = new Size2(width, height);
+            var size = new SizeF(width, height);
             var rotation = reader.ReadSingle();
             var isVisible = reader.ReadBoolean();
             var properties = new TiledMapProperties();

--- a/source/MonoGame.Extended.Tiled/TiledMapRectangleObject.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapRectangleObject.cs
@@ -4,7 +4,7 @@ namespace MonoGame.Extended.Tiled
 {
     public sealed class TiledMapRectangleObject : TiledMapObject
     {
-        public TiledMapRectangleObject(int identifier, string name, Size2 size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null) 
+        public TiledMapRectangleObject(int identifier, string name, SizeF size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null)
             : base(identifier, name, size, position, rotation, opacity, isVisible, type)
         {
         }

--- a/source/MonoGame.Extended.Tiled/TiledMapTileObject.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapTileObject.cs
@@ -4,8 +4,8 @@ namespace MonoGame.Extended.Tiled
 {
     public sealed class TiledMapTileObject : TiledMapObject
     {
-        public TiledMapTileObject(int identifier, string name, TiledMapTileset tileset, TiledMapTilesetTile tile, 
-            Size2 size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null) 
+        public TiledMapTileObject(int identifier, string name, TiledMapTileset tileset, TiledMapTilesetTile tile,
+            SizeF size, Vector2 position, float rotation = 0, float opacity = 1, bool isVisible = true, string type = null)
             : base(identifier, name, size, position, rotation, opacity, isVisible, type)
         {
             Tileset = tileset;

--- a/source/MonoGame.Extended.Tiled/TiledMapTilesetReader.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapTilesetReader.cs
@@ -94,7 +94,7 @@ namespace MonoGame.Extended.Tiled
 			var position = new Vector2(reader.ReadSingle(), reader.ReadSingle());
 			var width = reader.ReadSingle();
 			var height = reader.ReadSingle();
-			var size = new Size2(width, height);
+			var size = new SizeF(width, height);
 			var rotation = reader.ReadSingle();
 			var isVisible = reader.ReadBoolean();
 			var properties = new TiledMapProperties();

--- a/source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -29,22 +29,22 @@ namespace MonoGame.Extended.BitmapFonts
             return _characterMap.TryGetValue(character, out var region) ? region : null;
         }
 
-        public Size2 MeasureString(string text)
+        public SizeF MeasureString(string text)
         {
             if (string.IsNullOrEmpty(text))
-                return Size2.Empty;
+                return SizeF.Empty;
 
             var stringRectangle = GetStringRectangle(text);
-            return new Size2(stringRectangle.Width, stringRectangle.Height);
+            return new SizeF(stringRectangle.Width, stringRectangle.Height);
         }
 
-        public Size2 MeasureString(StringBuilder text)
+        public SizeF MeasureString(StringBuilder text)
         {
             if (text == null || text.Length == 0)
-                return Size2.Empty;
+                return SizeF.Empty;
 
             var stringRectangle = GetStringRectangle(text);
-            return new Size2(stringRectangle.Width, stringRectangle.Height);
+            return new SizeF(stringRectangle.Width, stringRectangle.Height);
         }
 
         public RectangleF GetStringRectangle(string text)
@@ -189,7 +189,7 @@ namespace MonoGame.Extended.BitmapFonts
                 if (UseKernings && _previousGlyph?.FontRegion != null)
                 {
                     if (_previousGlyph.Value.FontRegion.Kernings.TryGetValue(character, out var amount))
-                    { 
+                    {
                         _positionDelta.X += amount;
                         _currentGlyph.Position.X += amount;
                     }
@@ -307,7 +307,7 @@ namespace MonoGame.Extended.BitmapFonts
                 {
                     int amount;
                     if (_previousGlyph.Value.FontRegion.Kernings.TryGetValue(character, out amount))
-                    { 
+                    {
                         _positionDelta.X += amount;
                         _currentGlyph.Position.X += amount;
                     }

--- a/source/MonoGame.Extended/ISizable.cs
+++ b/source/MonoGame.Extended/ISizable.cs
@@ -3,6 +3,6 @@ namespace MonoGame.Extended
 {
     public interface ISizable
     {
-        Size2 Size { get; set; }
+        SizeF Size { get; set; }
     }
 }

--- a/source/MonoGame.Extended/Math/BoundingRectangle.cs
+++ b/source/MonoGame.Extended/Math/BoundingRectangle.cs
@@ -47,11 +47,11 @@ namespace MonoGame.Extended
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="BoundingRectangle" /> structure from the specified centre
-        ///     <see cref="Point2" /> and the radii <see cref="Size2" />.
+        ///     <see cref="Point2" /> and the radii <see cref="SizeF" />.
         /// </summary>
         /// <param name="center">The centre <see cref="Point2" />.</param>
         /// <param name="halfExtents">The radii <see cref="Vector2" />.</param>
-        public BoundingRectangle(Point2 center, Size2 halfExtents)
+        public BoundingRectangle(Point2 center, SizeF halfExtents)
         {
             Center = center;
             HalfExtents = halfExtents;
@@ -516,7 +516,7 @@ namespace MonoGame.Extended
         /// </returns>
         public static implicit operator BoundingRectangle(Rectangle rectangle)
         {
-            var radii = new Size2(rectangle.Width * 0.5f, rectangle.Height * 0.5f);
+            var radii = new SizeF(rectangle.Width * 0.5f, rectangle.Height * 0.5f);
             var centre = new Point2(rectangle.X + radii.Width, rectangle.Y + radii.Height);
             return new BoundingRectangle(centre, radii);
         }
@@ -544,7 +544,7 @@ namespace MonoGame.Extended
         /// </returns>
         public static implicit operator BoundingRectangle(RectangleF rectangle)
         {
-            var radii = new Size2(rectangle.Width * 0.5f, rectangle.Height * 0.5f);
+            var radii = new SizeF(rectangle.Width * 0.5f, rectangle.Height * 0.5f);
             var centre = new Point2(rectangle.X + radii.Width, rectangle.Y + radii.Height);
             return new BoundingRectangle(centre, radii);
         }

--- a/source/MonoGame.Extended/Math/OrientedRectangle.cs
+++ b/source/MonoGame.Extended/Math/OrientedRectangle.cs
@@ -35,12 +35,12 @@ namespace MonoGame.Extended
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BoundingRectangle" /> structure from the specified centre
-        /// <see cref="Point2" /> and the radii <see cref="Size2" />.
+        /// <see cref="Point2" /> and the radii <see cref="SizeF" />.
         /// </summary>
         /// <param name="center">The centre <see cref="Point2" />.</param>
         /// <param name="radii">The radii <see cref="Vector2" />.</param>
         /// <param name="orientation">The orientation <see cref="Matrix3x2" />.</param>
-        public OrientedRectangle(Point2 center, Size2 radii, Matrix3x2 orientation)
+        public OrientedRectangle(Point2 center, SizeF radii, Matrix3x2 orientation)
         {
             Center = center;
             Radii = radii;
@@ -166,7 +166,7 @@ namespace MonoGame.Extended
         /// <returns>The resulting <see cref="OrientedRectangle" />.</returns>
         public static explicit operator OrientedRectangle(RectangleF rectangle)
         {
-            var radii = new Size2(rectangle.Width * 0.5f, rectangle.Height * 0.5f);
+            var radii = new SizeF(rectangle.Width * 0.5f, rectangle.Height * 0.5f);
             var centre = new Point2(rectangle.X + radii.Width, rectangle.Y + radii.Height);
 
             return new OrientedRectangle(centre, radii, Matrix3x2.Identity);

--- a/source/MonoGame.Extended/Math/Point2.cs
+++ b/source/MonoGame.Extended/Math/Point2.cs
@@ -226,53 +226,53 @@ namespace MonoGame.Extended
         }
 
         /// <summary>
-        ///     Translates a <see cref='Point2' /> by a given <see cref='Size2' />.
+        ///     Translates a <see cref='Point2' /> by a given <see cref='SizeF' />.
         /// </summary>
         /// <param name="point">The point.</param>
         /// <param name="size">The size.</param>
         /// <returns>
         ///     The result of the operator.
         /// </returns>
-        public static Point2 operator +(Point2 point, Size2 size)
+        public static Point2 operator +(Point2 point, SizeF size)
         {
             return Add(point, size);
         }
 
         /// <summary>
-        ///     Translates a <see cref='Point2' /> by a given <see cref='Size2' />.
+        ///     Translates a <see cref='Point2' /> by a given <see cref='SizeF' />.
         /// </summary>
         /// <param name="point">The point.</param>
         /// <param name="size">The size.</param>
         /// <returns>
         ///     The result of the operator.
         /// </returns>
-        public static Point2 Add(Point2 point, Size2 size)
+        public static Point2 Add(Point2 point, SizeF size)
         {
             return new Point2(point.X + size.Width, point.Y + size.Height);
         }
 
         /// <summary>
-        ///     Translates a <see cref='Point2' /> by the negative of a given <see cref='Size2' />.
+        ///     Translates a <see cref='Point2' /> by the negative of a given <see cref='SizeF' />.
         /// </summary>
         /// <param name="point">The point.</param>
         /// <param name="size">The size.</param>
         /// <returns>
         ///     The result of the operator.
         /// </returns>
-        public static Point2 operator -(Point2 point, Size2 size)
+        public static Point2 operator -(Point2 point, SizeF size)
         {
             return Subtract(point, size);
         }
 
         /// <summary>
-        ///     Translates a <see cref='Point2' /> by the negative of a given <see cref='Size2' /> .
+        ///     Translates a <see cref='Point2' /> by the negative of a given <see cref='SizeF' /> .
         /// </summary>
         /// <param name="point">The point.</param>
         /// <param name="size">The size.</param>
         /// <returns>
         ///     The result of the operator.
         /// </returns>
-        public static Point2 Subtract(Point2 point, Size2 size)
+        public static Point2 Subtract(Point2 point, SizeF size)
         {
             return new Point2(point.X - size.Width, point.Y - size.Height);
         }

--- a/source/MonoGame.Extended/Math/RectangleF.cs
+++ b/source/MonoGame.Extended/Math/RectangleF.cs
@@ -100,11 +100,11 @@ namespace MonoGame.Extended
         public RectangleF BoundingRectangle => this;
 
         /// <summary>
-        ///     Gets the <see cref="Size2" /> representing the extents of this <see cref="RectangleF" />.
+        ///     Gets the <see cref="SizeF" /> representing the extents of this <see cref="RectangleF" />.
         /// </summary>
-        public Size2 Size
+        public SizeF Size
         {
-            get { return new Size2(Width, Height); }
+            get { return new SizeF(Width, Height); }
             set
             {
                 Width = value.Width;
@@ -155,11 +155,11 @@ namespace MonoGame.Extended
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="RectangleF" /> structure from the specified top-left
-        ///     <see cref="Point2" /> and the extents <see cref="Size2" />.
+        ///     <see cref="Point2" /> and the extents <see cref="SizeF" />.
         /// </summary>
         /// <param name="position">The top-left point.</param>
         /// <param name="size">The extents.</param>
-        public RectangleF(Point2 position, Size2 size)
+        public RectangleF(Point2 position, SizeF size)
         {
             X = position.X;
             Y = position.Y;

--- a/source/MonoGame.Extended/Math/ShapeExtensions.cs
+++ b/source/MonoGame.Extended/Math/ShapeExtensions.cs
@@ -101,7 +101,7 @@ namespace MonoGame.Extended
         /// <param name="size">The size of the rectangle</param>
         /// <param name="color">The color to draw the rectangle in</param>
         /// <param name="layerDepth">The depth of the layer of this shape</param>
-        public static void FillRectangle(this SpriteBatch spriteBatch, Vector2 location, Size2 size, Color color, float layerDepth = 0)
+        public static void FillRectangle(this SpriteBatch spriteBatch, Vector2 location, SizeF size, Color color, float layerDepth = 0)
         {
             spriteBatch.Draw(GetTexture(spriteBatch), location, null, color, 0, Vector2.Zero, size, SpriteEffects.None, layerDepth);
         }
@@ -118,7 +118,7 @@ namespace MonoGame.Extended
         /// <param name="layerDepth">The depth of the layer of this shape</param>
         public static void FillRectangle(this SpriteBatch spriteBatch, float x, float y, float width, float height, Color color, float layerDepth = 0)
         {
-            FillRectangle(spriteBatch, new Vector2(x, y), new Size2(width, height), color, layerDepth);
+            FillRectangle(spriteBatch, new Vector2(x, y), new SizeF(width, height), color, layerDepth);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace MonoGame.Extended
         /// <param name="color">The color to draw the rectangle in</param>
         /// <param name="thickness">The thickness of the line</param>
         /// <param name="layerDepth">The depth of the layer of this shape</param>
-        public static void DrawRectangle(this SpriteBatch spriteBatch, Vector2 location, Size2 size, Color color, float thickness = 1f, float layerDepth = 0)
+        public static void DrawRectangle(this SpriteBatch spriteBatch, Vector2 location, SizeF size, Color color, float thickness = 1f, float layerDepth = 0)
         {
             DrawRectangle(spriteBatch, new RectangleF(location.X, location.Y, size.Width, size.Height), color, thickness, layerDepth);
         }

--- a/source/MonoGame.Extended/Math/Size.cs
+++ b/source/MonoGame.Extended/Math/Size.cs
@@ -231,7 +231,7 @@ namespace MonoGame.Extended
             return new Point(size.Width, size.Height);
         }
 
-        public static explicit operator Size(Size2 size)
+        public static explicit operator Size(SizeF size)
         {
             return new Size((int) size.Width, (int) size.Height);
         }

--- a/source/MonoGame.Extended/Math/SizeF.cs
+++ b/source/MonoGame.Extended/Math/SizeF.cs
@@ -13,26 +13,26 @@ namespace MonoGame.Extended
     ///     </para>
     /// </remarks>
     /// <seealso cref="IEquatable{T}" />
-    /// <seealso cref="IEquatableByRef{Size2}" />
-    public struct Size2 : IEquatable<Size2>, IEquatableByRef<Size2>
+    /// <seealso cref="IEquatableByRef{SizeF}" />
+    public struct SizeF : IEquatable<SizeF>, IEquatableByRef<SizeF>
     {
         /// <summary>
-        ///     Returns a <see cref="Size2" /> with <see cref="Width" /> and <see cref="Height" /> equal to <c>0.0f</c>.
+        ///     Returns a <see cref="SizeF" /> with <see cref="Width" /> and <see cref="Height" /> equal to <c>0.0f</c>.
         /// </summary>
-        public static readonly Size2 Empty = new Size2();
+        public static readonly SizeF Empty = new SizeF();
 
         /// <summary>
-        ///     The horizontal component of this <see cref="Size2" />.
+        ///     The horizontal component of this <see cref="SizeF" />.
         /// </summary>
         public float Width;
 
         /// <summary>
-        ///     The vertical component of this <see cref="Size2" />.
+        ///     The vertical component of this <see cref="SizeF" />.
         /// </summary>
         public float Height;
 
         /// <summary>
-        ///     Gets a value that indicates whether this <see cref="Size2" /> is empty.
+        ///     Gets a value that indicates whether this <see cref="SizeF" /> is empty.
         /// </summary>
         // ReSharper disable CompareOfFloatsByEqualityOperator
         public bool IsEmpty => (Width == 0) && (Height == 0);
@@ -40,18 +40,18 @@ namespace MonoGame.Extended
         // ReSharper restore CompareOfFloatsByEqualityOperator
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="Size2" /> structure from the specified dimensions.
+        ///     Initializes a new instance of the <see cref="SizeF" /> structure from the specified dimensions.
         /// </summary>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        public Size2(float width, float height)
+        public SizeF(float width, float height)
         {
             Width = width;
             Height = height;
         }
 
         /// <summary>
-        ///     Compares two <see cref="Size2" /> structures. The result specifies
+        ///     Compares two <see cref="SizeF" /> structures. The result specifies
         ///     whether the values of the <see cref="Width" /> and <see cref="Height" />
         ///     fields of the two <see cref="Point2" /> structures are equal.
         /// </summary>
@@ -61,33 +61,33 @@ namespace MonoGame.Extended
         ///     <c>true</c> if the <see cref="Width" /> and <see cref="Height" />
         ///     fields of the two <see cref="Point2" /> structures are equal; otherwise, <c>false</c>.
         /// </returns>
-        public static bool operator ==(Size2 first, Size2 second)
+        public static bool operator ==(SizeF first, SizeF second)
         {
             return first.Equals(ref second);
         }
 
         /// <summary>
-        ///     Indicates whether this <see cref="Size2" /> is equal to another <see cref="Size2" />.
+        ///     Indicates whether this <see cref="SizeF" /> is equal to another <see cref="SizeF" />.
         /// </summary>
         /// <param name="size">The size.</param>
         /// <returns>
         ///     <c>true</c> if this <see cref="Point2" /> is equal to the <paramref name="size" /> parameter; otherwise,
         ///     <c>false</c>.
         /// </returns>
-        public bool Equals(Size2 size)
+        public bool Equals(SizeF size)
         {
             return Equals(ref size);
         }
 
         /// <summary>
-        ///     Indicates whether this <see cref="Size2" /> is equal to another <see cref="Size2" />.
+        ///     Indicates whether this <see cref="SizeF" /> is equal to another <see cref="SizeF" />.
         /// </summary>
         /// <param name="size">The size.</param>
         /// <returns>
         ///     <c>true</c> if this <see cref="Point2" /> is equal to the <paramref name="size" />; otherwise,
         ///     <c>false</c>.
         /// </returns>
-        public bool Equals(ref Size2 size)
+        public bool Equals(ref SizeF size)
         {
             // ReSharper disable CompareOfFloatsByEqualityOperator
             return (Width == size.Width) && (Height == size.Height);
@@ -95,108 +95,108 @@ namespace MonoGame.Extended
         }
 
         /// <summary>
-        ///     Returns a value indicating whether this <see cref="Size2" /> is equal to a specified object.
+        ///     Returns a value indicating whether this <see cref="SizeF" /> is equal to a specified object.
         /// </summary>
         /// <param name="obj">The object to make the comparison with.</param>
         /// <returns>
-        ///     <c>true</c> if this  <see cref="Size2" /> is equal to <paramref name="obj" />; otherwise, <c>false</c>.
+        ///     <c>true</c> if this  <see cref="SizeF" /> is equal to <paramref name="obj" />; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (obj is Size2)
-                return Equals((Size2) obj);
+            if (obj is SizeF)
+                return Equals((SizeF) obj);
             return false;
         }
 
         /// <summary>
-        ///     Compares two <see cref="Size2" /> structures. The result specifies
+        ///     Compares two <see cref="SizeF" /> structures. The result specifies
         ///     whether the values of the <see cref="Width" /> or <see cref="Height" />
-        ///     fields of the two <see cref="Size2" /> structures are unequal.
+        ///     fields of the two <see cref="SizeF" /> structures are unequal.
         /// </summary>
         /// <param name="first">The first size.</param>
         /// <param name="second">The second size.</param>
         /// <returns>
         ///     <c>true</c> if the <see cref="Width" /> or <see cref="Height" />
-        ///     fields of the two <see cref="Size2" /> structures are unequal; otherwise, <c>false</c>.
+        ///     fields of the two <see cref="SizeF" /> structures are unequal; otherwise, <c>false</c>.
         /// </returns>
-        public static bool operator !=(Size2 first, Size2 second)
+        public static bool operator !=(SizeF first, SizeF second)
         {
             return !(first == second);
         }
 
         /// <summary>
-        ///     Calculates the <see cref="Size2" /> representing the vector addition of two <see cref="Size2" /> structures as if
+        ///     Calculates the <see cref="SizeF" /> representing the vector addition of two <see cref="SizeF" /> structures as if
         ///     they
         ///     were <see cref="Vector2" /> structures.
         /// </summary>
         /// <param name="first">The first size.</param>
         /// <param name="second">The second size.</param>
         /// <returns>
-        ///     The <see cref="Size2" /> representing the vector addition of two <see cref="Size2" /> structures as if they
+        ///     The <see cref="SizeF" /> representing the vector addition of two <see cref="SizeF" /> structures as if they
         ///     were <see cref="Vector2" /> structures.
         /// </returns>
-        public static Size2 operator +(Size2 first, Size2 second)
+        public static SizeF operator +(SizeF first, SizeF second)
         {
             return Add(first, second);
         }
 
         /// <summary>
-        ///     Calculates the <see cref="Size2" /> representing the vector addition of two <see cref="Size2" /> structures.
+        ///     Calculates the <see cref="SizeF" /> representing the vector addition of two <see cref="SizeF" /> structures.
         /// </summary>
         /// <param name="first">The first size.</param>
         /// <param name="second">The second size.</param>
         /// <returns>
-        ///     The <see cref="Size2" /> representing the vector addition of two <see cref="Size2" /> structures.
+        ///     The <see cref="SizeF" /> representing the vector addition of two <see cref="SizeF" /> structures.
         /// </returns>
-        public static Size2 Add(Size2 first, Size2 second)
+        public static SizeF Add(SizeF first, SizeF second)
         {
-            Size2 size;
+            SizeF size;
             size.Width = first.Width + second.Width;
             size.Height = first.Height + second.Height;
             return size;
         }
 
         /// <summary>
-        /// Calculates the <see cref="Size2" /> representing the vector subtraction of two <see cref="Size2" /> structures.
+        /// Calculates the <see cref="SizeF" /> representing the vector subtraction of two <see cref="SizeF" /> structures.
         /// </summary>
         /// <param name="first">The first size.</param>
         /// <param name="second">The second size.</param>
         /// <returns>
-        ///     The <see cref="Size2" /> representing the vector subtraction of two <see cref="Size2" /> structures.
+        ///     The <see cref="SizeF" /> representing the vector subtraction of two <see cref="SizeF" /> structures.
         /// </returns>
-        public static Size2 operator -(Size2 first, Size2 second)
+        public static SizeF operator -(SizeF first, SizeF second)
         {
             return Subtract(first, second);
         }
 
-        public static Size2 operator /(Size2 size, float value)
+        public static SizeF operator /(SizeF size, float value)
         {
-            return new Size2(size.Width / value, size.Height / value);
+            return new SizeF(size.Width / value, size.Height / value);
         }
 
-        public static Size2 operator *(Size2 size, float value)
+        public static SizeF operator *(SizeF size, float value)
         {
-            return new Size2(size.Width * value, size.Height * value);
+            return new SizeF(size.Width * value, size.Height * value);
         }
 
         /// <summary>
-        ///     Calculates the <see cref="Size2" /> representing the vector subtraction of two <see cref="Size2" /> structures.
+        ///     Calculates the <see cref="SizeF" /> representing the vector subtraction of two <see cref="SizeF" /> structures.
         /// </summary>
         /// <param name="first">The first size.</param>
         /// <param name="second">The second size.</param>
         /// <returns>
-        ///     The <see cref="Size2" /> representing the vector subtraction of two <see cref="Size2" /> structures.
+        ///     The <see cref="SizeF" /> representing the vector subtraction of two <see cref="SizeF" /> structures.
         /// </returns>
-        public static Size2 Subtract(Size2 first, Size2 second)
+        public static SizeF Subtract(SizeF first, SizeF second)
         {
-            Size2 size;
+            SizeF size;
             size.Width = first.Width - second.Width;
             size.Height = first.Height - second.Height;
             return size;
         }
 
         /// <summary>
-        ///     Returns a hash code of this <see cref="Size2" /> suitable for use in hashing algorithms and data
+        ///     Returns a hash code of this <see cref="SizeF" /> suitable for use in hashing algorithms and data
         ///     structures like a hash table.
         /// </summary>
         /// <returns>
@@ -211,64 +211,64 @@ namespace MonoGame.Extended
         }
 
         /// <summary>
-        ///     Performs an implicit conversion from a <see cref="Point2" /> to a <see cref="Size2" />.
+        ///     Performs an implicit conversion from a <see cref="Point2" /> to a <see cref="SizeF" />.
         /// </summary>
         /// <param name="point">The point.</param>
         /// <returns>
-        ///     The resulting <see cref="Size2" />.
+        ///     The resulting <see cref="SizeF" />.
         /// </returns>
-        public static implicit operator Size2(Point2 point)
+        public static implicit operator SizeF(Point2 point)
         {
-            return new Size2(point.X, point.Y);
+            return new SizeF(point.X, point.Y);
         }
 
 
         /// <summary>
-        ///     Performs an implicit conversion from a <see cref="Point" /> to a <see cref="Size2" />.
+        ///     Performs an implicit conversion from a <see cref="Point" /> to a <see cref="SizeF" />.
         /// </summary>
         /// <param name="point">The point.</param>
         /// <returns>
-        ///     The resulting <see cref="Size2" />.
+        ///     The resulting <see cref="SizeF" />.
         /// </returns>
-        public static implicit operator Size2(Point point)
+        public static implicit operator SizeF(Point point)
         {
-            return new Size2(point.X, point.Y);
+            return new SizeF(point.X, point.Y);
         }
 
         /// <summary>
-        ///     Performs an implicit conversion from a <see cref="Point2" /> to a <see cref="Size2" />.
+        ///     Performs an implicit conversion from a <see cref="Point2" /> to a <see cref="SizeF" />.
         /// </summary>
         /// <param name="size">The size.</param>
         /// <returns>
         ///     The resulting <see cref="Point2" />.
         /// </returns>
-        public static implicit operator Point2(Size2 size)
+        public static implicit operator Point2(SizeF size)
         {
             return new Point2(size.Width, size.Height);
         }
 
         /// <summary>
-        ///     Performs an implicit conversion from a <see cref="Size2" /> to a <see cref="Vector2" />.
+        ///     Performs an implicit conversion from a <see cref="SizeF" /> to a <see cref="Vector2" />.
         /// </summary>
         /// <param name="size">The size.</param>
         /// <returns>
         ///     The resulting <see cref="Vector2" />.
         /// </returns>
-        public static implicit operator Vector2(Size2 size)
+        public static implicit operator Vector2(SizeF size)
         {
             return new Vector2(size.Width, size.Height);
         }
 
         /// <summary>
-        ///     Performs an implicit conversion from a <see cref="Vector2" /> to a <see cref="Size2" />.
+        ///     Performs an implicit conversion from a <see cref="Vector2" /> to a <see cref="SizeF" />.
         /// </summary>
         /// <param name="vector">The vector.</param>
         /// <returns>
-        ///     The resulting <see cref="Size2" />.
+        ///     The resulting <see cref="SizeF" />.
         /// </returns>
-        public static implicit operator Size2(Vector2 vector)
+        public static implicit operator SizeF(Vector2 vector)
         {
-            return new Size2(vector.X, vector.Y);
+            return new SizeF(vector.X, vector.Y);
         }
 
         ///// <summary>
@@ -290,16 +290,16 @@ namespace MonoGame.Extended
         /// <returns>
         ///     The resulting <see cref="Size2" />.
         /// </returns>
-        public static explicit operator Point(Size2 size)
+        public static explicit operator Point(SizeF size)
         {
             return new Point((int)size.Width, (int)size.Height);
         }
 
         /// <summary>
-        ///     Returns a <see cref="string" /> that represents this <see cref="Size2" />.
+        ///     Returns a <see cref="string" /> that represents this <see cref="SizeF" />.
         /// </summary>
         /// <returns>
-        ///     A <see cref="string" /> that represents this <see cref="Size2" />.
+        ///     A <see cref="string" /> that represents this <see cref="SizeF" />.
         /// </returns>
         public override string ToString()
         {

--- a/source/MonoGame.Extended/Math/Vector2Extensions.cs
+++ b/source/MonoGame.Extended/Math/Vector2Extensions.cs
@@ -14,16 +14,16 @@ namespace MonoGame.Extended
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 Translate(this Vector2 vector2, float x, float y) => new Vector2(vector2.X + x, vector2.Y + y);
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Size2 ToSize(this Vector2 value) => new Size2(value.X, value.Y);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Size2 ToAbsoluteSize(this Vector2 value)
+        public static SizeF ToSize(this Vector2 value) => new SizeF(value.X, value.Y);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SizeF ToAbsoluteSize(this Vector2 value)
         {
             var x = Math.Abs(value.X);
             var y = Math.Abs(value.Y);
-            return new Size2(x, y);
+            return new SizeF(x, y);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/MonoGame.Extended/Serialization/Size2JsonConverter.cs
+++ b/source/MonoGame.Extended/Serialization/Size2JsonConverter.cs
@@ -5,29 +5,29 @@ using System.Text.Json.Serialization;
 namespace MonoGame.Extended.Serialization;
 
 /// <summary>
-/// Converts a <see cref="Size2"/> value to or from JSON.
+/// Converts a <see cref="SizeF"/> value to or from JSON.
 /// </summary>
-public class Size2JsonConverter : JsonConverter<Size2>
+public class Size2JsonConverter : JsonConverter<SizeF>
 {
     /// <inheritdoc />
-    public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(Size2);
+    public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(SizeF);
 
     /// <inheritdoc />
     /// <exception cref="JsonException">
-    /// Thrown if the JSON property does not contain a properly formatted <see cref="Size2"/> value
+    /// Thrown if the JSON property does not contain a properly formatted <see cref="SizeF"/> value
     /// </exception>
-    public override Size2 Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override SizeF Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var values = reader.ReadAsMultiDimensional<float>();
 
         if (values.Length == 2)
         {
-            return new Size2(values[0], values[1]);
+            return new SizeF(values[0], values[1]);
         }
 
         if (values.Length == 1)
         {
-            return new Size2(values[0], values[0]);
+            return new SizeF(values[0], values[0]);
         }
 
         throw new JsonException("Invalid Size2 property value");
@@ -37,7 +37,7 @@ public class Size2JsonConverter : JsonConverter<Size2>
     /// <exception cref="ArgumentNullException">
     /// Throw if <paramref name="writer"/> is <see langword="null"/>.
     /// </exception>
-    public override void Write(Utf8JsonWriter writer, Size2 value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, SizeF value, JsonSerializerOptions options)
     {
         ArgumentNullException.ThrowIfNull(writer);
         writer.WriteStringValue($"{value.Width} {value.Height}");

--- a/source/MonoGame.Extended/TextureAtlases/TextureRegion2D.cs
+++ b/source/MonoGame.Extended/TextureAtlases/TextureRegion2D.cs
@@ -15,7 +15,7 @@ namespace MonoGame.Extended.TextureAtlases
             : this(null, texture, region.X, region.Y, region.Width, region.Height)
         {
         }
-        
+
         public TextureRegion2D(string name, Texture2D texture, Rectangle region)
             : this(name, texture, region.X, region.Y, region.Width, region.Height)
         {
@@ -42,7 +42,7 @@ namespace MonoGame.Extended.TextureAtlases
         public int Y { get; }
         public int Width { get; }
         public int Height { get; }
-        public Size2 Size => new Size2(Width, Height);
+        public SizeF Size => new SizeF(Width, Height);
         public object Tag { get; set; }
         public Rectangle Bounds => new Rectangle(X, Y, Width, Height);
 

--- a/tests/MonoGame.Extended.Collisions.Tests/CollisionComponentTests.cs
+++ b/tests/MonoGame.Extended.Collisions.Tests/CollisionComponentTests.cs
@@ -154,7 +154,7 @@ namespace MonoGame.Extended.Collisions.Tests
             Point2 pos2 = new Point2(-2, -1);
 
             IShapeF shape1 = new CircleF(pos1, 2.0f);
-            IShapeF shape2 = new RectangleF(pos2, new Size2(4, 2));
+            IShapeF shape2 = new RectangleF(pos2, new SizeF(4, 2));
 
 
             var actor1 = new BasicActor()
@@ -183,7 +183,7 @@ namespace MonoGame.Extended.Collisions.Tests
             Point2 pos2 = new Point2(-2, -1);
 
             IShapeF shape1 = new CircleF(pos1, 1.0f);
-            IShapeF shape2 = new RectangleF(pos2, new Size2(4, 2));
+            IShapeF shape2 = new RectangleF(pos2, new SizeF(4, 2));
 
 
             var actor1 = new BasicActor()
@@ -212,7 +212,7 @@ namespace MonoGame.Extended.Collisions.Tests
             Point2 pos2 = new Point2(-2, -1);
 
             IShapeF shape1 = new CircleF(pos1, 2.0f);
-            IShapeF shape2 = new RectangleF(pos2, new Size2(4, 2));
+            IShapeF shape2 = new RectangleF(pos2, new SizeF(4, 2));
 
 
             var actor1 = new BasicActor()
@@ -244,8 +244,8 @@ namespace MonoGame.Extended.Collisions.Tests
             Point2 pos1 = new Point2(0, 0);
             Point2 pos2 = new Point2(-2, -1);
 
-            IShapeF shape1 = new RectangleF(pos1, new Size2(4, 2));
-            IShapeF shape2 = new RectangleF(pos2, new Size2(4, 2));
+            IShapeF shape1 = new RectangleF(pos1, new SizeF(4, 2));
+            IShapeF shape2 = new RectangleF(pos2, new SizeF(4, 2));
 
 
             var actor1 = new BasicActor()
@@ -273,8 +273,8 @@ namespace MonoGame.Extended.Collisions.Tests
             Point2 pos1 = new Point2(4, 2);
             Point2 pos2 = new Point2(3, 1);
 
-            IShapeF shape1 = new RectangleF(pos1, new Size2(4, 2));
-            IShapeF shape2 = new RectangleF(pos2, new Size2(4, 2));
+            IShapeF shape1 = new RectangleF(pos1, new SizeF(4, 2));
+            IShapeF shape2 = new RectangleF(pos2, new SizeF(4, 2));
 
 
             var actor1 = new BasicActor()
@@ -303,8 +303,8 @@ namespace MonoGame.Extended.Collisions.Tests
             [Fact]
             public void Actors_is_colliding()
             {
-                var staticBounds = new RectangleF(new Point2(0, 0), new Size2(1, 1));
-                var anotherStaticBounds = new RectangleF(new Point2(0, 0), new Size2(1, 1));
+                var staticBounds = new RectangleF(new Point2(0, 0), new SizeF(1, 1));
+                var anotherStaticBounds = new RectangleF(new Point2(0, 0), new SizeF(1, 1));
                 var staticActor = new CollisionIndicatingActor(staticBounds);
                 var anotherStaticActor = new CollisionIndicatingActor(anotherStaticBounds);
                 _collisionComponent.Insert(staticActor);
@@ -319,8 +319,8 @@ namespace MonoGame.Extended.Collisions.Tests
             [Fact]
             public void Actors_is_not_colliding_when_dynamic_actor_is_moved_out_of_collision_bounds()
             {
-                var staticBounds = new RectangleF(new Point2(0, 0), new Size2(1, 1));
-                var dynamicBounds = new RectangleF(new Point2(0, 0), new Size2(1, 1));
+                var staticBounds = new RectangleF(new Point2(0, 0), new SizeF(1, 1));
+                var dynamicBounds = new RectangleF(new Point2(0, 0), new SizeF(1, 1));
                 var staticActor = new CollisionIndicatingActor(staticBounds);
                 var dynamicActor = new CollisionIndicatingActor(dynamicBounds);
                 _collisionComponent.Insert(staticActor);
@@ -336,17 +336,17 @@ namespace MonoGame.Extended.Collisions.Tests
             [Fact]
             public void Actors_is_colliding_when_dynamic_actor_is_moved_after_update()
             {
-                var staticBounds = new RectangleF(new Point2(0, 0), new Size2(1, 1));
+                var staticBounds = new RectangleF(new Point2(0, 0), new SizeF(1, 1));
                 var staticActor = new CollisionIndicatingActor(staticBounds);
                 _collisionComponent.Insert(staticActor);
                 for (int i = 0; i < QuadTree.QuadTree.DefaultMaxObjectsPerNode; i++)
                 {
-                    var fillerBounds = new RectangleF(new Point2(0, 2), new Size2(.1f, .1f));
+                    var fillerBounds = new RectangleF(new Point2(0, 2), new SizeF(.1f, .1f));
                     var fillerActor = new CollisionIndicatingActor(fillerBounds);
                     _collisionComponent.Insert(fillerActor);
                 }
 
-                var dynamicBounds = new RectangleF(new Point2(2, 2), new Size2(1, 1));
+                var dynamicBounds = new RectangleF(new Point2(2, 2), new SizeF(1, 1));
                 var dynamicActor = new CollisionIndicatingActor(dynamicBounds);
                 _collisionComponent.Insert(dynamicActor);
 
@@ -364,8 +364,8 @@ namespace MonoGame.Extended.Collisions.Tests
             [Fact]
             public void Actors_is_colliding_when_dynamic_actor_is_moved_into_collision_bounds()
             {
-                var staticBounds = new RectangleF(new Point2(0, 0), new Size2(1, 1));
-                var dynamicBounds = new RectangleF(new Point2(2, 2), new Size2(1, 1));
+                var staticBounds = new RectangleF(new Point2(0, 0), new SizeF(1, 1));
+                var dynamicBounds = new RectangleF(new Point2(2, 2), new SizeF(1, 1));
                 var staticActor = new CollisionIndicatingActor(staticBounds);
                 var dynamicActor = new CollisionIndicatingActor(dynamicBounds);
                 _collisionComponent.Insert(staticActor);

--- a/tests/MonoGame.Extended.Collisions.Tests/SpatialHashTests.cs
+++ b/tests/MonoGame.Extended.Collisions.Tests/SpatialHashTests.cs
@@ -6,7 +6,7 @@ namespace MonoGame.Extended.Collisions.Tests;
 
 public class SpatialHashTests
 {
-    private SpatialHash generateSpatialHash() => new SpatialHash(new Size2(64, 64));
+    private SpatialHash generateSpatialHash() => new SpatialHash(new SizeF(64, 64));
     private readonly RectangleF RECT = new RectangleF(10, 10, 20, 20);
 
     [Fact]

--- a/tests/MonoGame.Extended.Tests/Primitives/OrientedRectangleTests.cs
+++ b/tests/MonoGame.Extended.Tests/Primitives/OrientedRectangleTests.cs
@@ -10,7 +10,7 @@ public class OrientedRectangleTests
     [Fact]
     public void Initializes_oriented_rectangle()
     {
-        var rectangle = new OrientedRectangle(new Point2(1, 2), new Size2(3, 4), new Matrix3x2(5, 6, 7, 8, 9, 10));
+        var rectangle = new OrientedRectangle(new Point2(1, 2), new SizeF(3, 4), new Matrix3x2(5, 6, 7, 8, 9, 10));
 
         Assert.Equal(new Point2(1, 2), rectangle.Center);
         Assert.Equal(new Vector2(3, 4), rectangle.Radii);
@@ -31,14 +31,14 @@ public class OrientedRectangleTests
             new object[]
                 {
                     "empty compared with empty is true",
-                    new OrientedRectangle(Point2.Zero, Size2.Empty, Matrix3x2.Identity),
-                    new OrientedRectangle(Point2.Zero, Size2.Empty, Matrix3x2.Identity)
+                    new OrientedRectangle(Point2.Zero, SizeF.Empty, Matrix3x2.Identity),
+                    new OrientedRectangle(Point2.Zero, SizeF.Empty, Matrix3x2.Identity)
                 },
             new object[]
                 {
                     "initialized compared with initialized true",
-                    new OrientedRectangle(new Point2(1, 2), new Size2(3, 4), new Matrix3x2(5, 6, 7, 8, 9, 10)),
-                    new OrientedRectangle(new Point2(1, 2), new Size2(3, 4), new Matrix3x2(5, 6, 7, 8, 9, 10))
+                    new OrientedRectangle(new Point2(1, 2), new SizeF(3, 4), new Matrix3x2(5, 6, 7, 8, 9, 10)),
+                    new OrientedRectangle(new Point2(1, 2), new SizeF(3, 4), new Matrix3x2(5, 6, 7, 8, 9, 10))
                 }
         };
 
@@ -57,7 +57,7 @@ public class OrientedRectangleTests
         [Fact]
         public void Center_point_is_not_translated()
         {
-            var rectangle = new OrientedRectangle(new Point2(1, 2), new Size2(), Matrix3x2.Identity);
+            var rectangle = new OrientedRectangle(new Point2(1, 2), new SizeF(), Matrix3x2.Identity);
             var transform = Matrix3x2.Identity;
 
             var result = OrientedRectangle.Transform(rectangle, ref transform);
@@ -68,7 +68,7 @@ public class OrientedRectangleTests
         [Fact]
         public void Center_point_is_translated()
         {
-            var rectangle = new OrientedRectangle(new Point2(0, 0), new Size2(), new Matrix3x2());
+            var rectangle = new OrientedRectangle(new Point2(0, 0), new SizeF(), new Matrix3x2());
             var transform = Matrix3x2.CreateTranslation(1, 2);
 
             var result = OrientedRectangle.Transform(rectangle, ref transform);
@@ -79,7 +79,7 @@ public class OrientedRectangleTests
         [Fact]
         public void Radii_is_not_changed_by_identity_transform()
         {
-            var rectangle = new OrientedRectangle(new Point2(), new Size2(10, 20), new Matrix3x2());
+            var rectangle = new OrientedRectangle(new Point2(), new SizeF(10, 20), new Matrix3x2());
             var transform = Matrix3x2.Identity;
 
             var result = OrientedRectangle.Transform(rectangle, ref transform);
@@ -90,7 +90,7 @@ public class OrientedRectangleTests
         [Fact]
         public void Radii_is_not_changed_by_translation()
         {
-            var rectangle = new OrientedRectangle(new Point2(1, 2), new Size2(10, 20), new Matrix3x2());
+            var rectangle = new OrientedRectangle(new Point2(1, 2), new SizeF(10, 20), new Matrix3x2());
             var transform = Matrix3x2.CreateTranslation(1, 2);
 
             var result = OrientedRectangle.Transform(rectangle, ref transform);
@@ -101,7 +101,7 @@ public class OrientedRectangleTests
         [Fact]
         public void Orientation_is_rotated_45_degrees_left()
         {
-            var rectangle = new OrientedRectangle(new Point2(), new Size2(), Matrix3x2.Identity);
+            var rectangle = new OrientedRectangle(new Point2(), new SizeF(), Matrix3x2.Identity);
             var transform = Matrix3x2.CreateRotationZ(MathHelper.PiOver4);
 
             var result = OrientedRectangle.Transform(rectangle, ref transform);
@@ -114,7 +114,7 @@ public class OrientedRectangleTests
         [Fact]
         public void Orientation_is_rotated_to_45_degrees_from_180()
         {
-            var rectangle = new OrientedRectangle(new Point2(), new Size2(), Matrix3x2.CreateRotationZ(MathHelper.Pi));
+            var rectangle = new OrientedRectangle(new Point2(), new SizeF(), Matrix3x2.CreateRotationZ(MathHelper.Pi));
             var transform = Matrix3x2.CreateRotationZ(-3 * MathHelper.PiOver4);
             var expectedOrientation = Matrix3x2.CreateRotationZ(MathHelper.PiOver4);
 
@@ -133,7 +133,7 @@ public class OrientedRectangleTests
         [Fact]
         public void Points_are_same_as_center()
         {
-            var rectangle = new OrientedRectangle(new Point2(1, 2), new Size2(), Matrix3x2.Identity);
+            var rectangle = new OrientedRectangle(new Point2(1, 2), new SizeF(), Matrix3x2.Identity);
             var transform = Matrix3x2.Identity;
 
             var result = OrientedRectangle.Transform(rectangle, ref transform);
@@ -152,7 +152,7 @@ public class OrientedRectangleTests
         [Fact]
         public void Points_are_translated()
         {
-            var rectangle = new OrientedRectangle(new Point2(0, 0), new Size2(2, 4), Matrix3x2.Identity);
+            var rectangle = new OrientedRectangle(new Point2(0, 0), new SizeF(2, 4), Matrix3x2.Identity);
             var transform = Matrix3x2.CreateTranslation(10, 20);
 
             var result = OrientedRectangle.Transform(rectangle, ref transform);
@@ -207,7 +207,7 @@ public class OrientedRectangleTests
              *                    :
              *                    :
              */
-            var rectangle = new OrientedRectangle(new Point2(1, 2), new Size2(2, 4), Matrix3x2.Identity);
+            var rectangle = new OrientedRectangle(new Point2(1, 2), new SizeF(2, 4), Matrix3x2.Identity);
             var transform =
                 Matrix3x2.CreateRotationZ(MathHelper.PiOver2)
                 *

--- a/tests/MonoGame.Extended.Tests/Primitives/RectangleFTests.cs
+++ b/tests/MonoGame.Extended.Tests/Primitives/RectangleFTests.cs
@@ -17,7 +17,7 @@ namespace MonoGame.Extended.Tests.Primitives
         [Fact]
         public void PassVector2AsConstructorParameter_Test()
         {
-            var rect1 = new RectangleF(new Vector2(0, 0), new Size2(12.34f, 56.78f));
+            var rect1 = new RectangleF(new Vector2(0, 0), new SizeF(12.34f, 56.78f));
             var rect2 = new RectangleF(new Vector2(0, 0), new Vector2(12.34f, 56.78f));
 
             Assert.Equal(rect1, rect2);
@@ -26,8 +26,8 @@ namespace MonoGame.Extended.Tests.Primitives
         [Fact]
         public void PassPointAsConstructorParameter_Test()
         {
-            var rect1 = new RectangleF(new Vector2(0, 0), new Size2(12, 56));
-            var rect2 = new RectangleF(new Vector2(0, 0), new Size2(12, 56));
+            var rect1 = new RectangleF(new Vector2(0, 0), new SizeF(12, 56));
+            var rect2 = new RectangleF(new Vector2(0, 0), new SizeF(12, 56));
 
             Assert.Equal(rect1, rect2);
         }
@@ -37,7 +37,7 @@ namespace MonoGame.Extended.Tests.Primitives
             [Fact]
             public void Center_point_is_not_translated()
             {
-                var rectangle = new RectangleF(new Point2(0, 0), new Size2(20, 30));
+                var rectangle = new RectangleF(new Point2(0, 0), new SizeF(20, 30));
                 var transform = Matrix3x2.Identity;
 
                 var result = RectangleF.Transform(rectangle, ref transform);
@@ -48,7 +48,7 @@ namespace MonoGame.Extended.Tests.Primitives
             [Fact]
             public void Center_point_is_translated()
             {
-                var rectangleF = new RectangleF(new Point2(0, 0), new Size2(20, 30));
+                var rectangleF = new RectangleF(new Point2(0, 0), new SizeF(20, 30));
                 var transform = Matrix3x2.CreateTranslation(1, 2);
 
                 var result = RectangleF.Transform(rectangleF, ref transform);
@@ -59,23 +59,23 @@ namespace MonoGame.Extended.Tests.Primitives
             [Fact]
             public void Size_is_not_changed_by_identity_transform()
             {
-                var rectangle = new RectangleF(new Point2(0, 0), new Size2(20, 30));
+                var rectangle = new RectangleF(new Point2(0, 0), new SizeF(20, 30));
                 var transform = Matrix3x2.Identity;
 
                 var result = RectangleF.Transform(rectangle, ref transform);
 
-                Assert.Equal(new Size2(20, 30), result.Size);
+                Assert.Equal(new SizeF(20, 30), result.Size);
             }
 
             [Fact]
             public void Size_is_not_changed_by_translation()
             {
-                var rectangle = new RectangleF(new Point2(0, 0), new Size2(20, 30));
+                var rectangle = new RectangleF(new Point2(0, 0), new SizeF(20, 30));
                 var transform = Matrix3x2.CreateTranslation(1, 2);
 
                 var result = RectangleF.Transform(rectangle, ref transform);
 
-                Assert.Equal(new Size2(20, 30), result.Size);
+                Assert.Equal(new SizeF(20, 30), result.Size);
             }
 
             [Fact]
@@ -117,7 +117,7 @@ namespace MonoGame.Extended.Tests.Primitives
                  *                    :
                  *                    :
                  */
-                var rectangle = new RectangleF(new Point2(0, 0), new Size2(2, 4));
+                var rectangle = new RectangleF(new Point2(0, 0), new SizeF(2, 4));
                 var transform =
                     Matrix3x2.CreateRotationZ(MathHelper.PiOver2)
                     *

--- a/tests/MonoGame.Extended.Tests/Primitives/ShapeTests.cs
+++ b/tests/MonoGame.Extended.Tests/Primitives/ShapeTests.cs
@@ -40,8 +40,8 @@ public class ShapeTests
         [Fact]
         public void RectRectSameRectTest()
         {
-            IShapeF shape1 = new RectangleF(Point2.Zero, new Size2(5, 5));
-            IShapeF shape2 = new RectangleF(Point2.Zero, new Size2(5, 5));
+            IShapeF shape1 = new RectangleF(Point2.Zero, new SizeF(5, 5));
+            IShapeF shape2 = new RectangleF(Point2.Zero, new SizeF(5, 5));
 
             Assert.True(shape1.Intersects(shape2));
         }
@@ -49,8 +49,8 @@ public class ShapeTests
         [Fact]
         public void RectRectIntersectingTest()
         {
-            IShapeF shape1 = new RectangleF(Point2.Zero, new Size2(5, 5));
-            IShapeF shape2 = new RectangleF(new Point2(3, 3), new Size2(5, 5));
+            IShapeF shape1 = new RectangleF(Point2.Zero, new SizeF(5, 5));
+            IShapeF shape2 = new RectangleF(new Point2(3, 3), new SizeF(5, 5));
 
             Assert.True(shape1.Intersects(shape2));
         }
@@ -58,8 +58,8 @@ public class ShapeTests
         [Fact]
         public void RectRectNotIntersectingTest()
         {
-            IShapeF shape1 = new RectangleF(Point2.Zero, new Size2(5, 5));
-            IShapeF shape2 = new RectangleF(new Point2(10, 10), new Size2(5, 5));
+            IShapeF shape1 = new RectangleF(Point2.Zero, new SizeF(5, 5));
+            IShapeF shape2 = new RectangleF(new Point2(10, 10), new SizeF(5, 5));
 
             Assert.False(shape1.Intersects(shape2));
         }
@@ -67,7 +67,7 @@ public class ShapeTests
         [Fact]
         public void RectCircContainedTest()
         {
-            IShapeF shape1 = new RectangleF(Point2.Zero, new Size2(5, 5));
+            IShapeF shape1 = new RectangleF(Point2.Zero, new SizeF(5, 5));
             IShapeF shape2 = new CircleF(Point2.Zero, 4);
 
             Assert.True(shape1.Intersects(shape2));
@@ -77,7 +77,7 @@ public class ShapeTests
         [Fact]
         public void RectCircOnEdgeTest()
         {
-            IShapeF shape1 = new RectangleF(Point2.Zero, new Size2(5, 5));
+            IShapeF shape1 = new RectangleF(Point2.Zero, new SizeF(5, 5));
             IShapeF shape2 = new CircleF(new Point2(5, 0), 4);
 
             Assert.True(shape1.Intersects(shape2));
@@ -99,7 +99,7 @@ public class ShapeTests
              *                    :
              *                    :
              */
-            IShapeF rectangle = new OrientedRectangle(Point2.Zero, new Size2(1, 1), Matrix3x2.Identity);
+            IShapeF rectangle = new OrientedRectangle(Point2.Zero, new SizeF(1, 1), Matrix3x2.Identity);
             var circle = new CircleF(Point2.Zero, 1);
 
             Assert.True(rectangle.Intersects(circle));
@@ -117,7 +117,7 @@ public class ShapeTests
              *                    :
              *                    :
              */
-            IShapeF rectangle = new OrientedRectangle(Point2.Zero, new Size2(1, 1), Matrix3x2.Identity);
+            IShapeF rectangle = new OrientedRectangle(Point2.Zero, new SizeF(1, 1), Matrix3x2.Identity);
             var circle = new CircleF(new Point2(-2, 1), .99f);
 
             Assert.False(rectangle.Intersects(circle));
@@ -135,7 +135,7 @@ public class ShapeTests
              *                    *   *
              *                    :* *
              */
-            IShapeF rectangle = new OrientedRectangle(new Point2(-1, 1), new Size2(1.42f, 1.42f), Matrix3x2.CreateRotationZ(-MathHelper.PiOver4));
+            IShapeF rectangle = new OrientedRectangle(new Point2(-1, 1), new SizeF(1.42f, 1.42f), Matrix3x2.CreateRotationZ(-MathHelper.PiOver4));
             var circle = new CircleF(new Point2(1, -1), 1.4f);
 
             Assert.False(rectangle.Intersects(circle));
@@ -153,8 +153,8 @@ public class ShapeTests
              *                    :**
              *                    :
              */
-            IShapeF rectangle = new OrientedRectangle(new Point2(-1, 0), new Size2(1, 1), Matrix3x2.Identity);
-            var rect = new RectangleF(new Point2(0.001f, 0), new Size2(2, 2));
+            IShapeF rectangle = new OrientedRectangle(new Point2(-1, 0), new SizeF(1, 1), Matrix3x2.Identity);
+            var rect = new RectangleF(new Point2(0.001f, 0), new SizeF(2, 2));
 
             Assert.False(rectangle.Intersects(rect));
         }
@@ -171,8 +171,8 @@ public class ShapeTests
              *                    :**
              *                    :
              */
-            IShapeF rectangle = new OrientedRectangle(new Point2(-1, 0), new Size2(1, 1), Matrix3x2.Identity);
-            var rect = new RectangleF(new Point2(0, 0), new Size2(2, 2));
+            IShapeF rectangle = new OrientedRectangle(new Point2(-1, 0), new SizeF(1, 1), Matrix3x2.Identity);
+            var rect = new RectangleF(new Point2(0, 0), new SizeF(2, 2));
 
             Assert.True(rectangle.Intersects(rect));
         }


### PR DESCRIPTION
## Description
Renamed`Size2` to `SizeF` to better define what it's behavior is and to align the naming convention with other types like `RectangleF`

## Reference
- https://github.com/craftworkgames/MonoGame.Extended/issues/538