### PR TITLE
Unit Test `BitmapFont.MeasureString` With Trailing Space

### DIFF
--- a/tests/MonoGame.Extended.Tests/BitmapFonts/BitmapFontTests.cs
+++ b/tests/MonoGame.Extended.Tests/BitmapFonts/BitmapFontTests.cs
@@ -59,6 +59,22 @@ namespace MonoGame.Extended.Tests.BitmapFonts
             Assert.Equal(0, size.Height);
         }
 
+        //  Test added for issue #695
+        //  https://github.com/craftworkgames/MonoGame.Extended/issues/695
+        //
+        //  Issue claims measure string does not account for space at the end of string.
+        [Fact]
+        public void BitmapFont_MeasureString_SpaceAtEnd_Test()
+        {
+            var font = CreateTestFont();
+
+            var noSpaceAtEnd = font.MeasureString("Hello World");
+            var spaceAtEnd = font.MeasureString("Hello World ");
+
+            Assert.NotEqual(noSpaceAtEnd, spaceAtEnd);
+
+        }
+
         private static BitmapFont CreateTestFont()
         {
             var textureRegion = new TextureRegion2D(null, x: 219, y: 61, width: 16, height: 18);


### PR DESCRIPTION
## Description
This PR adds a unit test for `BitmapFont.MeasureString` to ensure that it accounts for the trailing space at the end of a string.  

Reference:
- https://github.com/craftworkgames/MonoGame.Extended/issues/695