### PR TITLE
Remove unnecessary dependencies to SharpDX and Content.Pipeline from the core library

### DIFF
--- a/source/MonoGame.Extended/Math/OrientedRectangle.cs
+++ b/source/MonoGame.Extended/Math/OrientedRectangle.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Xna.Framework;
-using SharpDX.Direct3D;
 
 namespace MonoGame.Extended
 {

--- a/source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -6,9 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.Content.Pipeline"
-                      Version="3.8.1.303"
-                      PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- remove unused SharpDX using
introduces in https://github.com/craftworkgames/MonoGame.Extended/pull/840

- remove Content.Pipeline reference from the core library
introduced in https://github.com/craftworkgames/MonoGame.Extended/pull/692