### PR TITLE
Copy Reference DLLs from NuGet Automatically

### DIFF
--- a/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
+++ b/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Content Include="$(ArtifactsPath)/bin/MonoGame.Extended.Content.Pipeline/release/*.dll" Pack="True" PackagePath="tools" />
+    <Content Include="$(ArtifactsPath)/bin/MonoGame.Extended.Content.Pipeline/release/*.dll" Pack="true" PackagePath="tools" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
+++ b/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <Content Include="$(ArtifactsPath)/bin/MonoGame.Extended.Content.Pipeline/release/*.dll" Pack="true" PackagePath="tools" />
+    <Content Include="MonoGame.Extended.Content.Pipeline.targets" Pack="true" PackagePath="build" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.targets
+++ b/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="CopyMonoGameExtendedDlls" BeforeTargets="RunContentBuilder;BeforeBuild">
+    <ItemGroup>
+      <DLLsToCopy Include="$(MSBuildThisFileDirectory)\..\tools\*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(DLLsToCopy)"
+          DestinationFolder="$(MSBuildProjectDirectory)Content/references"
+          OverwriteReadOnlyFiles="true"
+          SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.targets
+++ b/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.targets
@@ -5,7 +5,7 @@
       <DLLsToCopy Include="$(MSBuildThisFileDirectory)\..\tools\*.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(DLLsToCopy)"
-          DestinationFolder="$(MSBuildProjectDirectory)Content/references"
+          DestinationFolder="$(MSBuildProjectDirectory)/Content/references"
           OverwriteReadOnlyFiles="true"
           SkipUnchangedFiles="true" />
   </Target>


### PR DESCRIPTION
## Description
This PR updates the `MonoGame.Extended.Content.Pipeline` NuGet to now include a `.targets` file. The target is set to run before the `RunContentBuilder` task from MonoGame and also before the generic `BeforeBuild` task as a fallback.  The task will copy the dlls that users need to reference from the NuGet package installation directory to the `/Content/refrences` directory in the project root.

This is implemented as a QoL update to make it easier to add the dll references needed without having to (1) create a nuget.config or (2) go hunting the dll down in global nuget cache directory.

