### PR TITLE
Resolves NullReferenceException When Getting Invalid Key From TiledMapProperties

### DIFF
--- a/source/MonoGame.Extended.Tiled/TiledMapProperties.cs
+++ b/source/MonoGame.Extended.Tiled/TiledMapProperties.cs
@@ -7,7 +7,7 @@ namespace MonoGame.Extended.Tiled
         public bool TryGetValue(string key, out string value)
         {
             bool result = TryGetValue(key, out TiledMapPropertyValue tmpVal);
-            value = result ? null : tmpVal.Value;
+            value = result ? tmpVal.Value : null;
             return result;
         }
     }

--- a/tests/MonoGame.Extended.Tiled.Tests/TileMapPropertiesTest.cs
+++ b/tests/MonoGame.Extended.Tiled.Tests/TileMapPropertiesTest.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Craftwork Games. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+namespace MonoGame.Extended.Tiled.Tests;
+
+public class TileMapPropertiesTest
+{
+    // NullReferenceException in TiledMapProperties
+    // https://github.com/craftworkgames/MonoGame.Extended/issues/901
+    [Fact]
+    public void TryGetValue_InvalidKey_ReturnsFalse()
+    {
+        TiledMapProperties properties = new TiledMapProperties();
+        var result = properties.TryGetValue("invalid", out string value);
+        Assert.False(result);
+        Assert.True(string.IsNullOrEmpty(value));
+    }
+
+    [Fact]
+    public void TryGetValue_ValidKey_ReturnsFalse()
+    {
+        var expected = "value";
+        TiledMapProperties properties = new TiledMapProperties();
+        properties.Add("test", new TiledMapPropertyValue(expected));
+
+        var result = properties.TryGetValue("test", out string actual);
+
+        Assert.True(result);
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
## Description
This resolves an issue when, given a key that doesn't exist, the `TledMapProperties.TryGetValue` method would throw a `NullReferenceException`.

## Related Issues
- https://github.com/craftworkgames/MonoGame.Extended/issues/901