### PR TITLE
Fix `NullReferenceException` in `ObjectPool` when reusing all returned items

### DIFF
--- a/source/MonoGame.Extended/Collections/IPoolable.cs
+++ b/source/MonoGame.Extended/Collections/IPoolable.cs
@@ -1,12 +1,12 @@
-﻿namespace MonoGame.Extended.Collections
-{
-    public delegate void ReturnToPoolDelegate(IPoolable poolable);
+﻿using System;
 
+namespace MonoGame.Extended.Collections
+{
     public interface IPoolable
     {
         IPoolable NextNode { get; set; }
         IPoolable PreviousNode { get; set; }
-        void Initialize(ReturnToPoolDelegate returnDelegate);
+        void Initialize(Action<IPoolable> returnDelegate);
         void Return();
     }
 }

--- a/source/MonoGame.Extended/Collections/ObjectPool.cs
+++ b/source/MonoGame.Extended/Collections/ObjectPool.cs
@@ -15,7 +15,7 @@ namespace MonoGame.Extended.Collections
     public class ObjectPool<T> : IEnumerable<T>
         where T : class, IPoolable
     {
-        private readonly ReturnToPoolDelegate _returnToPoolDelegate;
+        private readonly Action<IPoolable> _returnToPoolDelegate;
 
         private readonly Deque<T> _freeItems; // circular buffer for O(1) operations
         private T _headNode; // linked list for iteration

--- a/source/MonoGame.Extended/Collections/ObjectPool.cs
+++ b/source/MonoGame.Extended/Collections/ObjectPool.cs
@@ -144,7 +144,13 @@ namespace MonoGame.Extended.Collections
         {
             item.Initialize(_returnToPoolDelegate);
             item.NextNode = null;
-            if (item != _tailNode)
+            if(_tailNode is null)
+            {
+                _headNode = item;
+                _tailNode = item;
+                item.PreviousNode = null;
+            }
+            else
             {
                 item.PreviousNode = _tailNode;
                 _tailNode.NextNode = item;

--- a/tests/MonoGame.Extended.Tests/Collections/ObjectPoolTests.cs
+++ b/tests/MonoGame.Extended.Tests/Collections/ObjectPoolTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Craftwork Games. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MonoGame.Extended.Collections;
+
+namespace MonoGame.Extended.Tests.Collections;
+
+public class ObjectPoolTests
+{
+    private class TestPoolable : IPoolable
+    {
+        public Action<IPoolable> ReturnAction { get; private set; }
+        public IPoolable NextNode { get; set; }
+        public IPoolable PreviousNode { get; set; }
+
+        public void Initialize(Action<IPoolable> returnAction)
+        {
+            ReturnAction = returnAction;
+        }
+
+        public void Return()
+        {
+            ReturnAction(this);
+        }
+    }
+
+    [Fact]
+    public void ObjectPool_ThrowsNullReferenceException_WhenAllItemsReturnedAndNewCalled()
+    {
+        // Arrange
+        var pool = new ObjectPool<TestPoolable>(() => new TestPoolable(), 2);
+
+        // Act & Assert
+        var item1 = pool.New();
+        var item2 = pool.New();
+
+        // Return all items to the pool
+        item1.Return();
+        item2.Return();
+
+
+        var exception = Record.Exception(() => pool.New());
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Description
Fix `NullReferenceException` in `ObjectPool` when reusing all returned items

The `ObjectPool`'s `Use()` method was throwing a `NullReferenceException` when all items had been returned to the pool and `New()` was called again. This was due to `_tailNode` being null in this scenario.

Added a null check for `_tailNode` in Use() method to properly reinitialize the linked list structure when the pool has been emptied and refilled.

## Related Issues
- https://github.com/craftworkgames/MonoGame.Extended/issues/471