### PR TITLE
Add pitch support to Camera & OrthographicCamera

### DIFF
--- a/source/MonoGame.Extended/Camera.cs
+++ b/source/MonoGame.Extended/Camera.cs
@@ -9,6 +9,9 @@ namespace MonoGame.Extended
         public abstract float Zoom { get; set; }
         public abstract float MinimumZoom { get; set; }
         public abstract float MaximumZoom { get; set; }
+        public abstract float Pitch { get; set; }
+        public abstract float MinimumPitch { get; set; }
+        public abstract float MaximumPitch { get; set; }
         public abstract RectangleF BoundingRectangle { get; }
         public abstract T Origin { get; set; }
         public abstract T Center { get; }
@@ -17,6 +20,8 @@ namespace MonoGame.Extended
         public abstract void Rotate(float deltaRadians);
         public abstract void ZoomIn(float deltaZoom);
         public abstract void ZoomOut(float deltaZoom);
+        public abstract void PitchUp(float deltaZoom);
+        public abstract void PitchDown(float deltaZoom);
         public abstract void LookAt(T position);
 
         public abstract T WorldToScreen(T worldPosition);

--- a/source/MonoGame.Extended/OrthographicCamera.cs
+++ b/source/MonoGame.Extended/OrthographicCamera.cs
@@ -78,7 +78,7 @@ namespace MonoGame.Extended
             }
         }
 
-        public float Pitch
+        public override float Pitch
         {
             get => _pitch;
             set
@@ -90,7 +90,7 @@ namespace MonoGame.Extended
             }
         }
 
-        public float MinimumPitch
+        public override float MinimumPitch
         {
             get => _minimumPitch;
             set
@@ -105,7 +105,7 @@ namespace MonoGame.Extended
             }
         }
 
-        public float MaximumPitch
+        public override float MaximumPitch
         {
             get => _maximumPitch;
             set
@@ -162,12 +162,12 @@ namespace MonoGame.Extended
                 Zoom = value > MaximumZoom ? MaximumZoom : value;
         }
 
-        public void PitchUp(float deltaPitch)
+        public override void PitchUp(float deltaPitch)
         {
             ClampPitch(Pitch + deltaPitch);
         }
 
-        public void PitchDown(float deltaPitch)
+        public override void PitchDown(float deltaPitch)
         {
             ClampPitch(Pitch - deltaPitch);
         }

--- a/source/MonoGame.Extended/OrthographicCamera.cs
+++ b/source/MonoGame.Extended/OrthographicCamera.cs
@@ -11,6 +11,9 @@ namespace MonoGame.Extended
         private float _maximumZoom = float.MaxValue;
         private float _minimumZoom;
         private float _zoom;
+        private float _pitch;
+        private float _maximumPitch = float.MaxValue;
+        private float _minimumPitch;
 
         public OrthographicCamera(GraphicsDevice graphicsDevice)
             : this(new DefaultViewportAdapter(graphicsDevice))
@@ -23,6 +26,7 @@ namespace MonoGame.Extended
 
             Rotation = 0;
             Zoom = 1;
+            Pitch = 1;
             Origin = new Vector2(viewportAdapter.VirtualWidth/2f, viewportAdapter.VirtualHeight/2f);
             Position = Vector2.Zero;
         }
@@ -74,6 +78,48 @@ namespace MonoGame.Extended
             }
         }
 
+        public float Pitch
+        {
+            get => _pitch;
+            set
+            {
+                if ((value < MinimumPitch) || (value > MaximumPitch))
+                    throw new ArgumentException("Pitch must be between MinimumPitch and MaximumPitch");
+
+                _pitch = value;
+            }
+        }
+
+        public float MinimumPitch
+        {
+            get => _minimumPitch;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentException("MinimumPitch must be greater than zero");
+
+                if (Pitch < value)
+                    Pitch = MinimumPitch;
+
+                _minimumPitch = value;
+            }
+        }
+
+        public float MaximumPitch
+        {
+            get => _maximumPitch;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentException("MaximumPitch must be greater than zero");
+
+                if (Pitch > value)
+                    Pitch = value;
+
+                _maximumPitch = value;
+            }
+        }
+
         public override RectangleF BoundingRectangle
         {
             get
@@ -116,6 +162,24 @@ namespace MonoGame.Extended
                 Zoom = value > MaximumZoom ? MaximumZoom : value;
         }
 
+        public void PitchUp(float deltaPitch)
+        {
+            ClampPitch(Pitch + deltaPitch);
+        }
+
+        public void PitchDown(float deltaPitch)
+        {
+            ClampPitch(Pitch - deltaPitch);
+        }
+
+        private void ClampPitch(float value)
+        {
+            if (value < MinimumPitch)
+                Pitch = MinimumPitch;
+            else
+                Pitch = value > MaximumPitch ? MaximumPitch : value;
+        }
+
         public override void LookAt(Vector2 position)
         {
             Position = position - new Vector2(_viewportAdapter.VirtualWidth/2f, _viewportAdapter.VirtualHeight/2f);
@@ -155,7 +219,7 @@ namespace MonoGame.Extended
                 Matrix.CreateTranslation(new Vector3(-Position*parallaxFactor, 0.0f))*
                 Matrix.CreateTranslation(new Vector3(-Origin, 0.0f))*
                 Matrix.CreateRotationZ(Rotation)*
-                Matrix.CreateScale(Zoom, Zoom, 1)*
+                Matrix.CreateScale(Zoom, Zoom * Pitch, 1)*
                 Matrix.CreateTranslation(new Vector3(Origin, 0.0f));
         }
 


### PR DESCRIPTION
This is a simple and unobtrusive addition to the Camera & OrthographicCamera classes that adds a pitch variable and implementation. The reason this is needed is because it allows the camera to better create a faux-3D or 2.5D perspective that can be rotated, zoomed, and pitched, as if it were a true 3D camera, while still maintaining that it is fundamentally 2D. The inclusion of this addition does not alter any existing functionality nor would it affect existing projects already using the OrthographicCamera class.