### PR TITLE
Added FromAbgr method

### DIFF
--- a/source/MonoGame.Extended/ColorExtensions.cs
+++ b/source/MonoGame.Extended/ColorExtensions.cs
@@ -81,5 +81,26 @@ namespace MonoGame.Extended
 
             return new HslColor(h, s, l);
         }
+
+        /// <summary>
+        /// Returns a new <see cref="Color"/> value based on a packed value in the ABGR format.
+        /// </summary>
+        /// <remarks>
+        /// This is useful for when you have HTML hex style values such as #123456 and want to use it in hex format for
+        /// the parameter.  Since Color's standard format is RGBA, you would have to do new Color(0xFF563212) since R
+        /// is the LSB.  With this method, you can write it the same way it is written in HTML hex by doing
+        /// <c>>ColorExtensions.FromAbgr(0x123456FF);</c>
+        /// </remarks>
+        /// <param name="abgr">The packed color value in ABGR format</param>
+        /// <returns>The <see cref="Color"/> value created</returns>
+        public static Color FromAbgr(uint abgr)
+        {
+            uint rgba = (abgr & 0x000000FF) << 24 | // Alpha
+                        (abgr & 0x0000FF00) << 8  | // Blue
+                        (abgr & 0x00FF0000) >> 8  | // Green
+                        (abgr & 0xFF000000) >> 24;  // Red
+
+            return new Color(rgba);
+        }
 	}
 }


### PR DESCRIPTION
## Description
By default, you can create a `Color` value using a packed `uint` value that is in the RGBA format where R is the least significant byte (LSB).  This can be awkward when you have a HTML styled hex color value such as `#112233` and you want to use that as the packed `uint` value, you have to reverse it for MonoGame by doing `new Color(0xFF332211);` so that R is the LSB

This PR adds a new method to `ColorExtension` that takes a packed `uint` value that is in ABGR format where A is the LSB and creates a `Color` value from it.  So you can use HTMl styled hex color values such as `#112233` and write it naturally by doing `ColorExtensions.FromAbgr(0x112233FF);`

## Motivation
This was added after a conversation in the MonoGame discord with Ritchie where they expressed the annoyance with not being able to do this in MonoGame.  ColorExtensions already has the `.FromHex(string)` method, but this requires int parsing of substrings and is less performant than doing bit operations from the new method.