### PR TITLE
Use MaxSpeed when calculating speedGain

### DIFF
--- a/source/MonoGame.Extended/Particles/Modifiers/VortexModifier.cs
+++ b/source/MonoGame.Extended/Particles/Modifiers/VortexModifier.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended.Particles.Modifiers
@@ -20,7 +21,8 @@ namespace MonoGame.Extended.Particles.Modifiers
 
                 var distance2 = diff.LengthSquared();
 
-                var speedGain = _gravConst*Mass/distance2*elapsedSeconds;
+                var speedGain = _gravConst*Mass/distance2;
+                speedGain = Math.Max(Math.Min(speedGain, MaxSpeed), -MaxSpeed) * elapsedSeconds;
                 // normalize distances and multiply by speedGain
                 diff.Normalize();
                 particle->Velocity += diff*speedGain;


### PR DESCRIPTION
## Description
Implements the calculation from the Mercury Particle Engine that takes into account the `MaxSpeed` property.

## References
- Closes #698 