### PR TITLE
Correctly swap rayNear and rayFar distance

### DIFF
--- a/source/MonoGame.Extended/Math/PrimitivesHelper.cs
+++ b/source/MonoGame.Extended/Math/PrimitivesHelper.cs
@@ -23,7 +23,7 @@ namespace MonoGame.Extended
             if (rayNearDistance > rayFarDistance)
             {
                 // Swap near and far distance
-                var temp = rayFarDistance;
+                var temp = rayNearDistance;
                 rayNearDistance = rayFarDistance;
                 rayFarDistance = temp;
             }


### PR DESCRIPTION
## Description
This resolves an issue where the `rayNearDistance` and `rayFarDistance` were not being swapped properly.

## References
- Closes #726 