### PR TITLE
Resolves `ArgmentNulLException` When Loading `BitmapFont` From Disk.

### DIFF
--- a/source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -38,7 +38,7 @@ public sealed class BitmapFont
         }
     }
 
-    public BitmapFontCharacter GetCharacter(int character) => _characters[character];
+    public BitmapFontCharacter GetCharacter(int character) => _characters.TryGetValue(character, out BitmapFontCharacter fontCharacter) ? fontCharacter : null;/*  _characters[character];*/
     public bool TryGetCharacter(int character, out BitmapFontCharacter value) => _characters.TryGetValue(character, out value);
 
     public SizeF MeasureString(string text)

--- a/source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -378,7 +378,7 @@ public sealed class BitmapFont
         {
             if (!pages.ContainsKey(bmfFile.Pages[i]))
             {
-                string texturePath = Path.Combine(bmfFile.Path, bmfFile.Pages[i]);
+                string texturePath = Path.Combine(Path.GetDirectoryName(bmfFile.Path), bmfFile.Pages[i]);
                 using (Stream textureStream = File.OpenRead(texturePath))
                 {
                     Texture2D texture = Texture2D.FromStream(graphicsDevice, textureStream);

--- a/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileReader.cs
+++ b/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileReader.cs
@@ -60,6 +60,8 @@ public static class BitmapFontFileReader
             _ => throw new InvalidOperationException("This does not appear to be a valid BMFont file!")
         };
 
+        bmfFile.Path = stream.Name;
+
         return bmfFile;
     }
 

--- a/source/MonoGame.Extended/Math/PrimitivesHelper.cs
+++ b/source/MonoGame.Extended/Math/PrimitivesHelper.cs
@@ -23,7 +23,7 @@ namespace MonoGame.Extended
             if (rayNearDistance > rayFarDistance)
             {
                 // Swap near and far distance
-                var temp = rayFarDistance;
+                var temp = rayNearDistance;
                 rayNearDistance = rayFarDistance;
                 rayFarDistance = temp;
             }


### PR DESCRIPTION
## Description
The `bmfFile.Path` value was never set causing a `ArgumentNullException` to occur when building the path to the texure files for the bitmap font.

## References
- Closes #923 