### PR TITLE
fix color extension bug

### DIFF
--- a/source/MonoGame.Extended/ColorExtensions.cs
+++ b/source/MonoGame.Extended/ColorExtensions.cs
@@ -100,8 +100,15 @@ namespace MonoGame.Extended
                         (abgr & 0x00FF0000) >> 8  | // Green
                         (abgr & 0xFF000000) >> 24;  // Red
 
-            Color result = default;
+            Color result;
+
+#if FNA
+            result = default;
             result.PackedValue = rgba;
+#else
+            result = new Color(rgba);
+#endif
+
             return result;
         }
 	}

--- a/source/MonoGame.Extended/ColorExtensions.cs
+++ b/source/MonoGame.Extended/ColorExtensions.cs
@@ -100,7 +100,9 @@ namespace MonoGame.Extended
                         (abgr & 0x00FF0000) >> 8  | // Green
                         (abgr & 0xFF000000) >> 24;  // Red
 
-            return new Color(rgba);
+            Color result = default;
+            result.PackedValue = rgba;
+            return result;
         }
 	}
 }


### PR DESCRIPTION
Thanks @nkast 

from nkast
> Color in fna doesnt have a constructor that takes a packed uint value, actually it's private
> https://github.com/FNA-XNA/FNA/blob/31dab885817ddaece9758f480027373f0ad74bea/src/Color.cs#L1668
> There is a property PackedValue, (that implements the  IPackedVector<uint> interface.)