### PR TITLE
`BitmapFont` now always loads from `TitleContainer`.

### DIFF
--- a/source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
+++ b/source/MonoGame.Extended/BitmapFonts/BitmapFont.cs
@@ -364,13 +364,19 @@ public sealed class BitmapFont
 
     public static BitmapFont FromFile(GraphicsDevice graphicsDevice, string path)
     {
-        using FileStream stream = File.OpenRead(path);
-        return FromStream(graphicsDevice, stream);
+        using Stream stream = TitleContainer.OpenStream(path);
+        return FromStream(graphicsDevice, stream, path);
     }
 
+    [Obsolete("Use the FromStream() overload that takes an explicit name.")]
     public static BitmapFont FromStream(GraphicsDevice graphicsDevice, FileStream stream)
     {
-        var bmfFile = BitmapFontFileReader.Read(stream);
+        return FromStream(graphicsDevice, stream, stream.Name);
+    }
+
+    public static BitmapFont FromStream(GraphicsDevice graphicsDevice, Stream stream, string name)
+    {
+        var bmfFile = BitmapFontFileReader.Read(stream, name);
 
         //  Load page textures
         Dictionary<string, Texture2D> pages = new Dictionary<string, Texture2D>();
@@ -379,7 +385,7 @@ public sealed class BitmapFont
             if (!pages.ContainsKey(bmfFile.Pages[i]))
             {
                 string texturePath = Path.Combine(Path.GetDirectoryName(bmfFile.Path), bmfFile.Pages[i]);
-                using (Stream textureStream = File.OpenRead(texturePath))
+                using (Stream textureStream = TitleContainer.OpenStream(texturePath))
                 {
                     Texture2D texture = Texture2D.FromStream(graphicsDevice, textureStream);
                     pages.Add(bmfFile.Pages[i], texture);

--- a/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileReader.cs
+++ b/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileReader.cs
@@ -28,18 +28,33 @@ public static class BitmapFontFileReader
     public static BitmapFontFileContent Read(string path)
     {
         using var stream = File.OpenRead(path);
-        return Read(stream);
+        return Read(stream, path);
     }
 
     /// <summary>
     /// Reads the content of the font file at the path specified.
     /// </summary>
-    /// <param name="stream">A <see cref="FileStream"/> containing the font file contents to read.</param>
+    /// <param name="stream">A <see cref="Stream"/> containing the font file contents to read.</param>
     /// <returns>A <see cref="BitmapFontFileContent"/> instance containing the results of the read operation.</returns>
     /// <exception cref="InvalidOperationException">
     /// Thrown if the header for the file contents does not match a known header format.
     /// </exception>
+    [Obsolete("Use the overload that takes an explicit name parameter.")]
     public static BitmapFontFileContent Read(FileStream stream)
+    {
+        return Read(stream, stream.Name);
+    }
+
+    /// <summary>
+    /// Reads the content of the font file at the path specified.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> containing the font file contents to read.</param>
+    /// <param name="name">The name or path that uniquely identifies this <see cref="BitmapFontFileContent"/>.</param>
+    /// <returns>A <see cref="BitmapFontFileContent"/> instance containing the results of the read operation.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the header for the file contents does not match a known header format.
+    /// </exception>
+    public static BitmapFontFileContent Read(Stream stream, string name)
     {
         long position = stream.Position;
         var sig = stream.ReadByte();
@@ -60,7 +75,7 @@ public static class BitmapFontFileReader
             _ => throw new InvalidOperationException("This does not appear to be a valid BMFont file!")
         };
 
-        bmfFile.Path = stream.Name;
+        bmfFile.Path = name;
 
         return bmfFile;
     }

--- a/tests/MonoGame.Extended.Tests/BitmapFonts/BitmapFontFileReaderTests.cs
+++ b/tests/MonoGame.Extended.Tests/BitmapFonts/BitmapFontFileReaderTests.cs
@@ -102,8 +102,9 @@ public class BitmapFontFileReaderTests
     [Fact]
     public void Read_BinaryFile_Test()
     {
-        using FileStream stream = File.OpenRead("BitmapFonts/files/bmfont/test-font-binary.fnt");
-        var actual = BitmapFontFileReader.Read(stream);
+        string path = "BitmapFonts/files/bmfont/test-font-binary.fnt";
+        using FileStream stream = File.OpenRead(path);
+        var actual = BitmapFontFileReader.Read(stream, path);
         Assert.Equal(_expected.Header, actual.Header);
         Assert.Equal(_expected.Info, actual.Info);
         Assert.Equal(_expected.Common, actual.Common);
@@ -116,8 +117,9 @@ public class BitmapFontFileReaderTests
     [Fact]
     public void Read_XmlFile_Test()
     {
-        using FileStream stream = File.OpenRead("BitmapFonts/files/bmfont/test-font-xml.fnt");
-        var actual = BitmapFontFileReader.Read(stream);
+        string path = "BitmapFonts/files/bmfont/test-font-xml.fnt";
+        using FileStream stream = File.OpenRead(path);
+        var actual = BitmapFontFileReader.Read(stream, path);
         Assert.Equal(_expected.Header, actual.Header);
         Assert.Equal(_expected.Info, actual.Info);
         Assert.Equal(_expected.Common, actual.Common);
@@ -130,8 +132,9 @@ public class BitmapFontFileReaderTests
     [Fact]
     public void Read_Text_Test()
     {
-        using FileStream stream = File.OpenRead("BitmapFonts/files/bmfont/test-font-text.fnt");
-        var actual = BitmapFontFileReader.Read(stream);
+        string path = "BitmapFonts/files/bmfont/test-font-text.fnt";
+        using FileStream stream = File.OpenRead(path);
+        var actual = BitmapFontFileReader.Read(stream, path);
         Assert.Equal(_expected.Header, actual.Header);
         Assert.Equal(_expected.Info, actual.Info);
         Assert.Equal(_expected.Common, actual.Common);


### PR DESCRIPTION
Fixes KNI web builds when using `BitmapFont`.

Resolves #944