### PR TITLE
Add compile time exclusion

### DIFF
--- a/source/MonoGame.Extended/Content/ContentReaderExtensions.cs
+++ b/source/MonoGame.Extended/Content/ContentReaderExtensions.cs
@@ -9,12 +9,14 @@ namespace MonoGame.Extended.Content
 {
     public static class ContentReaderExtensions
     {
+#if FNA || KNI
         private static readonly FieldInfo _contentReaderGraphicsDeviceFieldInfo = typeof(ContentReader).GetTypeInfo().GetDeclaredField("graphicsDevice");
 
         public static GraphicsDevice GetGraphicsDevice(this ContentReader contentReader)
         {
             return (GraphicsDevice)_contentReaderGraphicsDeviceFieldInfo.GetValue(contentReader);
         }
+#endif
 
         public static string RemoveExtension(string path)
         {

--- a/source/MonoGame.Extended/Content/ContentReaderExtensions.cs
+++ b/source/MonoGame.Extended/Content/ContentReaderExtensions.cs
@@ -9,13 +9,20 @@ namespace MonoGame.Extended.Content
 {
     public static class ContentReaderExtensions
     {
-#if FNA || KNI
-        private static readonly FieldInfo _contentReaderGraphicsDeviceFieldInfo = typeof(ContentReader).GetTypeInfo().GetDeclaredField("graphicsDevice");
+		
+#if FNA
+		public static GraphicsDevice GetGraphicsDevice(this ContentReader contentReader)
+		{
+			var serviceProvider = contentReader.ContentManager.ServiceProvider;
+			var graphicsDeviceService = serviceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
+				   
+			if (graphicsDeviceService == null)
+			{
+				throw new InvalidOperationException("No Graphics Device Service");
+			}
 
-        public static GraphicsDevice GetGraphicsDevice(this ContentReader contentReader)
-        {
-            return (GraphicsDevice)_contentReaderGraphicsDeviceFieldInfo.GetValue(contentReader);
-        }
+			return graphicsDeviceService.GraphicsDevice;
+		}
 #endif
 
         public static string RemoveExtension(string path)


### PR DESCRIPTION
This fixes an issue where because Monogame now comes with this extension method, it fails if someone has Monogame and Extended functionality mixed on in their ContentTypeReader class.

https://github.com/MonoGame/MonoGame/blob/8df1e3edb3076b010822d2c9cf019f2f7f5f70a0/MonoGame.Framework/Content/ContentReaderExtensions.cs#L24

Example code that will break, can't have both of these using statements.  To fix I've simply made it so Monogame.Extended doesn't add these methods during compile time.

```csharp
using Microsoft.Xna.Framework.Content;
using MonoGame.Extended.Content;

namespace ContentManager_Extensions
{
    public class ReaderExample : ContentTypeReader<ReaderExampleClass>
    {
        protected override ReaderExampleClass Read(ContentReader reader, ReaderExampleClass existingInstance)
        {
            var graphicsDevice = reader.GetGraphicsDevice();

            return new ReaderExampleClass("exampletexture.png");
        }
    }

    public class ReaderExampleClass
    {
        public string TextureName { get; set; }

        public ReaderExampleClass(string textureName)
        {
            this.TextureName = textureName;
        }
    }
}
```

![image](https://github.com/user-attachments/assets/817ff8a5-06d7-4b4c-91b8-51f066162f67)



