### PR TITLE
Ensure zero origin for sprite

### DIFF
--- a/source/MonoGame.Extended/Graphics/Sprite.cs
+++ b/source/MonoGame.Extended/Graphics/Sprite.cs
@@ -145,7 +145,7 @@ public class Sprite : IColorable
         Color = Color.White;
         IsVisible = true;
         Effect = SpriteEffects.None;
-        OriginNormalized = new Vector2(0.5f, 0.5f);
+        OriginNormalized = Vector2.Zero;
         Depth = 0.0f;
     }
 


### PR DESCRIPTION
Resolves issue for `Sprite` origin not being correctly set to `Vector2.Zero` by default.  Resolves issue #968 

## Reference
- #968 