### PR TITLE
Fix incorrect first animation frame

### DIFF
--- a/source/MonoGame.Extended/Graphics/AnimatedSprite.cs
+++ b/source/MonoGame.Extended/Graphics/AnimatedSprite.cs
@@ -51,6 +51,7 @@ public class AnimatedSprite : Sprite
     {
         _animation = spriteSheet.GetAnimation(initialAnimation);
         Controller = new AnimationController(_animation);
+        TextureRegion = _spriteSheet.TextureAtlas[Controller.CurrentFrame];
     }
 
     /// <summary>
@@ -65,6 +66,7 @@ public class AnimatedSprite : Sprite
     {
         _animation = _spriteSheet.GetAnimation(name);
         Controller = new AnimationController(_animation);
+        TextureRegion = _spriteSheet.TextureAtlas[Controller.CurrentFrame];
         return Controller;
     }
 


### PR DESCRIPTION
Fix for first animation frame always showing the first sprite sheet texture region rather than the first animation's texture region - issue #929
