### PR TITLE
Set initial frame when animation is changed

### DIFF
--- a/source/MonoGame.Extended/Graphics/AnimatedSprite.cs
+++ b/source/MonoGame.Extended/Graphics/AnimatedSprite.cs
@@ -65,6 +65,8 @@ public class AnimatedSprite : Sprite
     {
         _animation = _spriteSheet.GetAnimation(name);
         Controller = new AnimationController(_animation);
+        TextureRegion = _spriteSheet.TextureAtlas[Controller.CurrentFrame];
+
         return Controller;
     }
 


### PR DESCRIPTION
I wanted to have single-frame animations (just to keep the logic simple in my game). E.g. while a move state might have multiple frames, an idle state just shows a single frame.

However, I noticed in such cases the animation would not be updated. Initially, I thought I did something wrong but couldn't figure it out. Then I looked into the codebase and noticed a small issue. When an animation is set, the initial frame is not yet configured. It will only change after an update, which would only happen for multi-frame animations.

This small change ensures the initial frame is configured as soon as the animation is set. This way, the correct sprite is also immediately shown for the new animation.

Perhaps these issues are related:
 
- https://github.com/craftworkgames/MonoGame.Extended/issues/933
- https://github.com/craftworkgames/MonoGame.Extended/issues/929