### PR TITLE
Update to use MonoGame 3.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Unreleased changes exist in the current `develop` branch but have not been pushed as either a stable or prerelease NuGet package.
 >
 
+## [4.1.0]
+## Changed
+- Updated to reference current MonoGame 3.8.3
+
 ## [4.0.4]
 ## Fixed
 - Resolved issue where the `Sprite.Origin` property was incorrectly being set to the center origin of the sprite in the constructor. [@AristurtleDev](https://github.com/AristurtleDev) [#938](https://github.com/craftworkgames/MonoGame.Extended/pull/969)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>4.0.4</Version>
+        <Version>4.1.0</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/benchmarks/Directory.Build.props
+++ b/benchmarks/Directory.Build.props
@@ -13,7 +13,7 @@
 
     <ItemGroup Condition="!$(DefineConstants.Contains('FNA')) AND !$(DefineConstants.Contains('KNI'))">
         <PackageReference Include="MonoGame.Framework.DesktopGL"
-                          Version="3.8.2.1105"
+                          Version="3.8.3"
                           PrivateAssets="All" />
     </ItemGroup>
 

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -13,7 +13,7 @@
 
    <ItemGroup Condition="!$(DefineConstants.Contains('FNA')) AND !$(DefineConstants.Contains('KNI'))">
        <PackageReference Include="MonoGame.Framework.DesktopGL"
-                          Version="3.8.2.1105"
+                          Version="3.8.3"
                           PrivateAssets="All" />
     </ItemGroup>
 

--- a/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
+++ b/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Autofac" Version="5.2.0" />
 
     <PackageReference Include="MonoGame.Framework.Content.Pipeline"
-                      Version="3.8.2.1105"
+                      Version="3.8.3"
                       PrivateAssets="All" />
   </ItemGroup>
 

--- a/source/MonoGame.Extended/.config/dotnet-tools.json
+++ b/source/MonoGame.Extended/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgfxc": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgfxc"
       ],

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -13,7 +13,7 @@
 
     <ItemGroup Condition="!$(DefineConstants.Contains('FNA')) AND !$(DefineConstants.Contains('KNI'))">
         <PackageReference Include="MonoGame.Framework.DesktopGL"
-                          Version="3.8.2.1105" />
+                          Version="3.8.3" />
     </ItemGroup>
 
     <ItemGroup Condition="$(DefineConstants.Contains('KNI'))">

--- a/tests/MonoGame.Extended.Content.Pipeline.Tests/MonoGame.Extended.Content.Pipeline.Tests.csproj
+++ b/tests/MonoGame.Extended.Content.Pipeline.Tests/MonoGame.Extended.Content.Pipeline.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updates the internal reference to MonoGame 3.8.3
Bumps the minor SemVer since this isn't a patch, so we're now at 4.1.0