### PR TITLE
Add Thread-Safe Shared Instance to FastRandom

### DIFF
--- a/source/MonoGame.Extended/Math/FastRandom.cs
+++ b/source/MonoGame.Extended/Math/FastRandom.cs
@@ -1,127 +1,342 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended
 {
+
     /// <summary>
-    ///     A random number generator that uses a fast algorithm to generate random values.
-    ///     The speed comes at the price of true 'randomness' though, there are noticeable
-    ///     patterns & it compares quite unfavourably to other algorithms in that respect.
-    ///     It's a good choice in situations where speed is more desirable than a
-    ///     good random distribution, and a poor choice when random distribution is important.
+    /// Represents a pseudo-random number generator using a linear congruential generator algorithm.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    ///     This implementation uses the same constants as Microsoft Visual C++ rand() function:
+    /// 
+    ///     a=214013
+    ///     c=2531011
+    ///     m=2^31
+    /// </para>
+    /// <para>
+    ///     It provides high performance and speed, but comes at the price of having lower statistical quality, or true
+    ///     'randomness' compared to modern algorithms.  The algorithm is deterministic based on the initial seed
+    ///     value, making it suitable for reproducible sequences.
+    ///</para>
+    ///<para>
+    ///     Note: This pseudo-random number generator exhibits noticeable patterns and should not be used for
+    ///     cryptographic purposes or when a high-quality random distribution is critical.  Consider using
+    ///     <see cref="System.Random"/> for better statistical properties.
+    /// </para>
+    /// </remarks>
     public class FastRandom
     {
-        private int _state;
+        private readonly IFastRandomImpl _impl;
 
-        public FastRandom()
-            : this(1)
+        /// <summary>
+        /// Provides a thread-safe <see cref="FastRandom"/> instance that may be used concurrently from any thread.
+        /// </summary>
+        public static FastRandom Shared { get; } = new FastRandom(new ThreadSafeFastRandomImpl());
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FastRandom"/> class using the default seed value.
+        /// </summary>
+        public FastRandom() : this(1)
         {
+
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FastRandom"/> class using the specified seed value.
+        /// </summary>
+        /// <param name="seed">A number used to calculate a starting value for the pseudo-random number sequence.</param>
         public FastRandom(int seed)
         {
-            if (seed < 1)
-                throw new ArgumentOutOfRangeException(nameof(seed), "seed must be greater than zero");
+            _impl = new LinearCongruentialGeneratorImpl(seed);
+        }
 
-            _state = seed;
+        private FastRandom(IFastRandomImpl impl)
+        {
+            ArgumentNullException.ThrowIfNull(impl);
+            _impl = impl;
         }
 
         /// <summary>
-        ///     Gets the next random integer value.
+        /// Returns a non-negative random integer.
         /// </summary>
-        /// <returns>A random positive integer.</returns>
+        /// <returns>A 32-bit signed integer that is greater than or equal to 0 and less than 32768.</returns>
         public int Next()
         {
-            _state = 214013*_state + 2531011;
-            return (_state >> 16) & 0x7FFF;
+            return _impl.Next();
         }
 
         /// <summary>
-        ///     Gets the next random integer value which is greater than zero and less than or equal to
-        ///     the specified maxmimum value.
+        /// Returns a non-negative random integer that is less than or equal to the specified maximum.
         /// </summary>
-        /// <param name="max">The maximum random integer value to return.</param>
-        /// <returns>A random integer value between zero and the specified maximum value.</returns>
+        /// <param name="max">The inclusive upper bound of the random number to be generated.</param>
+        /// <returns>
+        /// A 32-bit signed integer that is greater than or equal to 0 and less than or equal to <paramref name="max"/>.
+        /// </returns>
         public int Next(int max)
         {
-            return (int) (max*NextSingle() + 0.5f);
+            return _impl.Next(max);
         }
 
         /// <summary>
-        ///     Gets the next random integer between the specified minimum and maximum values.
+        /// Returns a random integer that is within a specified range.
         /// </summary>
-        /// <param name="min">The inclusive minimum value.</param>
-        /// <param name="max">The inclusive maximum value.</param>
+        /// <param name="min">The inclusive lower bound of the random number returned.</param>
+        /// <param name="max">The inclusive upper bound of the random number returned.</param>
+        /// <returns>
+        /// A 32-bit signed integer that is greater than or equal to <paramref name="min"/> and less than or equal to
+        /// <paramref name="max"/>.
+        /// </returns>
         public int Next(int min, int max)
         {
-            return (int) ((max - min)*NextSingle() + 0.5f) + min;
+            return _impl.Next(min, max);
         }
 
         /// <summary>
-        ///     Gets the next random integer between the specified range of values.
+        /// Returns a random integer that is within a specified range.
         /// </summary>
-        /// <param name="range">A range representing the inclusive minimum and maximum values.</param>
-        /// <returns>A random integer between the specified minumum and maximum values.</returns>
+        /// <param name="range">
+        /// A range representing the inclusive lower and upper bound of the random number to return.
+        /// </param>
+        /// <returns>
+        /// A 32-bit signed integer that is greater than or equal to the <see cref="Range{T}.Min"/> and less than or
+        /// equal to the <see cref="Range{T}.Max"/> value of <paramref name="range"/>.
+        /// </returns>
         public int Next(Range<int> range)
         {
-            return Next(range.Min, range.Max);
+            return _impl.Next(range);
         }
 
         /// <summary>
-        ///     Gets the next random single value.
+        /// Returns a random floating-point number that is greater than or equal to 0.0 and less than 1.0.
         /// </summary>
-        /// <returns>A random single value between 0 and 1.</returns>
+        /// <returns>
+        /// A single-precision floating point number that is greater than or equal to 0.0 and less than 1.0.
+        /// </returns>
         public float NextSingle()
         {
-            return Next()/(float) short.MaxValue;
+            return _impl.NextSingle();
         }
 
         /// <summary>
-        ///     Gets the next random single value which is greater than zero and less than or equal to
-        ///     the specified maxmimum value.
+        /// Returns a random floating-point number that is greater than or equal to 0.0 and less than the
+        /// specified maximum.
         /// </summary>
-        /// <param name="max">The maximum random single value to return.</param>
-        /// <returns>A random single value between zero and the specified maximum value.</returns>
+        /// <param name="max">The exclusive upper bond of the random number generated.</param>
+        /// <returns>
+        /// A single precision floating-point number that is greater than or equal to 0.0 and less than
+        /// <paramref name="max"/>.
+        /// </returns>
         public float NextSingle(float max)
         {
-            return max*NextSingle();
+            return _impl.NextSingle(max);
         }
 
         /// <summary>
-        ///     Gets the next random single value between the specified minimum and maximum values.
+        /// Returns a random floating-point number that is within a specified range.
         /// </summary>
-        /// <param name="min">The inclusive minimum value.</param>
-        /// <param name="max">The inclusive maximum value.</param>
-        /// <returns>A random single value between the specified minimum and maximum values.</returns>
+        /// <param name="min">The inclusive lower bound of the random number returned.</param>
+        /// <param name="max">The exclusive upper bound of the random number returned.</param>
+        /// <returns>
+        /// A single-precision floating point number that is greater than or equal to <paramref name="min"/> and
+        /// less than <paramref name="max"/>.
+        /// </returns>
         public float NextSingle(float min, float max)
         {
-            return (max - min)*NextSingle() + min;
+            return _impl.NextSingle(min, max);
         }
 
         /// <summary>
-        ///     Gets the next random single value between the specified range of values.
+        /// Returns a random floating-point number that is within a specified range.
         /// </summary>
-        /// <param name="range">A range representing the inclusive minimum and maximum values.</param>
-        /// <returns>A random single value between the specified minimum and maximum values.</returns>
+        /// <param name="range">
+        /// A range representing the inclusive lower and exclusive upper bound of the random number returned.
+        /// </param>
+        /// <returns>
+        /// A single-precision floating point number that is greater than or equal to the <see cref="Range{T}.Min"/>
+        /// and less than the <see cref="Range{T}.Max"/> value of <paramref name="range"/>
+        /// </returns>
         public float NextSingle(Range<float> range)
         {
-            return NextSingle(range.Min, range.Max);
+            return _impl.NextSingle(range);
         }
 
         /// <summary>
-        ///     Gets the next random angle value.
+        /// Returns a random angle between -π and π.
         /// </summary>
-        /// <returns>A random angle value.</returns>
+        /// <returns>
+        /// A random angle value in radians.
+        /// </returns>
         public float NextAngle()
         {
-            return NextSingle(-MathHelper.Pi, MathHelper.Pi);
+            return _impl.NextAngle();
         }
 
+        /// <summary>
+        /// Gets a random unit vector.
+        /// </summary>
+        /// <param name="vector">When this method returns, contains a unit vector with a random direction.</param>
         public void NextUnitVector(out Vector2 vector)
         {
-            var angle = NextAngle();
-            vector = new Vector2((float) Math.Cos(angle), (float) Math.Sin(angle));
+            _impl.NextUnitVector(out vector);
         }
+
+        #region IFastRandomImplementation
+        private interface IFastRandomImpl
+        {
+            int Next();
+            int Next(int max);
+            int Next(int min, int max);
+            int Next(Range<int> range);
+            float NextSingle();
+            float NextSingle(float max);
+            float NextSingle(float min, float max);
+            float NextSingle(Range<float> range);
+            float NextAngle();
+            void NextUnitVector(out Vector2 vector);
+        }
+        #endregion
+
+        #region Linear Congruential Generator
+        private sealed class LinearCongruentialGeneratorImpl : IFastRandomImpl
+        {
+            private const int MULTIPLIER = 214013;
+            private const int INCREMENT = 2531011;
+
+            private int _state;
+
+            public LinearCongruentialGeneratorImpl() : this(1)
+            {
+
+            }
+
+            public LinearCongruentialGeneratorImpl(int seed)
+            {
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(seed);
+                _state = seed;
+            }
+
+            public int Next()
+            {
+                _state = MULTIPLIER * _state + INCREMENT;
+                return (_state >> 16) & 0x7FFF;
+            }
+
+            public int Next(int max)
+            {
+                return (int)(max * NextSingle() + 0.5f);
+            }
+
+            public int Next(int min, int max)
+            {
+                return (int)((max - min) * NextSingle() + 0.5f) + min;
+            }
+
+            public int Next(Range<int> range)
+            {
+                return Next(range.Min, range.Max);
+            }
+
+            public float NextSingle()
+            {
+                return Next() / (float)short.MaxValue;
+            }
+
+            public float NextSingle(float max)
+            {
+                return max * NextSingle();
+            }
+
+            public float NextSingle(float min, float max)
+            {
+                return (max - min) * NextSingle() + min;
+            }
+
+            public float NextSingle(Range<float> range)
+            {
+                return NextSingle(range.Min, range.Max);
+            }
+
+            public float NextAngle()
+            {
+                return NextSingle(-MathHelper.Pi, MathHelper.Pi);
+            }
+
+            public void NextUnitVector(out Vector2 vector)
+            {
+                float angle = NextAngle();
+                vector.X = MathF.Cos(angle);
+                vector.Y = MathF.Sin(angle);
+            }
+        }
+        #endregion
+
+        #region ThreadSafeImpl
+        private sealed class ThreadSafeFastRandomImpl : IFastRandomImpl
+        {
+            [ThreadStatic]
+            private static LinearCongruentialGeneratorImpl t_random;
+
+            private static LinearCongruentialGeneratorImpl LocalRandom => t_random ?? Create();
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static LinearCongruentialGeneratorImpl Create()
+            {
+                t_random = new LinearCongruentialGeneratorImpl();
+                return t_random;
+            }
+
+            public int Next()
+            {
+                return LocalRandom.Next();
+            }
+
+            public int Next(int max)
+            {
+                return LocalRandom.Next(max);
+            }
+
+            public int Next(int min, int max)
+            {
+                return LocalRandom.Next(min, max);
+            }
+
+            public int Next(Range<int> range)
+            {
+                return LocalRandom.Next(range.Min, range.Max);
+            }
+            public float NextSingle()
+            {
+                return LocalRandom.NextSingle();
+            }
+
+            public float NextSingle(float max)
+            {
+                return LocalRandom.NextSingle(max);
+            }
+
+            public float NextSingle(float min, float max)
+            {
+                return LocalRandom.NextSingle(min, max);
+            }
+
+            public float NextSingle(Range<float> range)
+            {
+                return LocalRandom.NextSingle(range.Min, range.Max);
+            }
+
+            public float NextAngle()
+            {
+                return LocalRandom.NextAngle();
+            }
+
+            public void NextUnitVector(out Vector2 vector)
+            {
+                LocalRandom.NextUnitVector(out vector);
+            }
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
This PR updates the `FastRandom` class with a thread-safe shared instance, similar to `System.Random.Shared`, while maintaining the speed advantage of the original implementation. 

> [!NOTE]
> This is in preparation for upcoming changes for the particle system that will benefit from a thread-safe shared instance during parallel execution.

## Key Improvements

- Added `FastRandom.Shared` property that can be access from multiple threads.
- Restructured implementation to use an interface pattern.
- Updated `NextUnitVector` to use `MathF` instead of `Math` for better performance.
- Updated argument validations to use modern patterns such as `ArgumentOutOfRangeException.ThrowIfNegativeOrZero()`
- Updated documentation for all public API methods

## Performance Benchmarks

I've conducted benchmarks comparing the original and new implementations, as well as comparing against `System.Random`.  The following are the results:

- The new implementation maintains the same performance as the original with a \~1\~2% variance.
- Both the original and new implementations are 6-7x faster than `System.Random` for basic operations
- The thread-save `FastRandom.Shared` is ~2x faster than `System.Random.Shared`.
- In a threaded parallel test, `FastRandom.Shared` outperforms `System.Random.Shared` by ~25%

The benchmark used is attached as a .zip to this PR for others to verify.

[fastrandom-benchmark.zip](https://github.com/user-attachments/files/20212352/fastrandom-benchmark.zip)

### Benchmark Results

| Method                            |        Mean |     Error |    StdDev | Ratio | RatioSD |
| --------------------------------- | ----------: | --------: | --------: | ----: | ------: |
| Old_Next                          |    81.92 us |  0.666 us |  0.623 us |  1.00 |    0.01 |
| New_Next                          |    81.31 us |  0.295 us |  0.262 us |  0.99 |    0.01 |
| SystemRandom_Next                 |   553.30 us |  1.277 us |  1.195 us |  6.75 |    0.05 |
|                                   |             |           |           |       |         |
| New_Shared_Next                   |    82.87 us |  0.271 us |  0.253 us |  1.01 |    0.01 |
| SystemRandom_Shared_Next          |   157.77 us |  0.497 us |  0.415 us |  1.93 |    0.01 |
|                                   |             |           |           |       |         |
| Old_Next_Min_Max                  |    85.92 us |  0.678 us |  0.601 us |  1.05 |    0.01 |
| New_Next_Min_Max                  |    81.80 us |  0.952 us |  0.890 us |  1.00 |    0.01 |
| SystemRandom_Min_Max              |   535.14 us |  0.746 us |  0.698 us |  6.53 |    0.05 |
|                                   |             |           |           |       |         |
| New_Shared_Next_Min_Max           |    80.85 us |  0.142 us |  0.132 us |  0.99 |    0.01 |
| SystemRandom_Shared_Min_Max       |   148.25 us |  0.307 us |  0.272 us |  1.81 |    0.01 |
|                                   |             |           |           |       |         |
| Old_NextSingle                    |    86.11 us |  0.582 us |  0.545 us |  1.05 |    0.01 |
| New_NextSingle                    |    80.70 us |  0.081 us |  0.072 us |  0.99 |    0.01 |
| SystemRandom_NextSingle           |   556.79 us |  1.512 us |  1.414 us |  6.80 |    0.05 |
|                                   |             |           |           |       |         |
| New_Shared_NextSingle             |    82.01 us |  1.053 us |  0.985 us |  1.00 |    0.01 |
| SystemRandom_Shared_NextSingle    |   145.87 us |  0.280 us |  0.248 us |  1.78 |    0.01 |
|                                   |             |           |           |       |         |
| Old_NextSingle_Min_Max            |    83.20 us |  0.312 us |  0.292 us |  1.02 |    0.01 |
| New_NextSingle_Min_Max            |    80.72 us |  0.186 us |  0.174 us |  0.99 |    0.01 |
| New_Shared_Single_Min_Max         |    81.12 us |  0.382 us |  0.319 us |  0.99 |    0.01 |
|                                   |             |           |           |       |         |
| Old_NextAngle                     |    81.26 us |  0.392 us |  0.367 us |  0.99 |    0.01 |
| New_NextAngle                     |    82.41 us |  0.286 us |  0.267 us |  1.01 |    0.01 |
| New_Shared_NextAngle              |    83.94 us |  0.301 us |  0.266 us |  1.02 |    0.01 |
|                                   |             |           |           |       |         |
| Old_NextUnitVector                | 1,580.26 us |  2.935 us |  2.745 us | 19.29 |    0.15 |
| New_NextUnitVector                | 1,651.68 us |  4.398 us |  3.672 us | 20.16 |    0.15 |
| New_Shared_NextUnitVector         | 1,837.55 us | 24.801 us | 23.199 us | 22.43 |    0.32 |
|                                   |             |           |           |       |         |
| New_Shared_Parallel_Next          |    41.15 us |  0.415 us |  0.368 us |  0.50 |    0.01 |
| SystemRandom_Shared_Parallel_Next |    54.86 us |  0.648 us |  0.606 us |  0.67 |    0.01 |

## Implementation Notes

1. The original LCG algorithm has been maintained for compatibility
2. The `ThreadSafeFastRandomImpl` uses `[ThreadStatic]`to maintain one generator per thread, so there is no need for a `lock` object.
3. The `IFastRandomImpl` interface allows for potential future alternative implementations.
4. All public APIs maintain he same behavior, so there is no breaking changes.
