### PR TITLE
Add Independent Axis Scale To Particles

### DIFF
--- a/source/MonoGame.Extended/Particles/Data/Particle.cs
+++ b/source/MonoGame.Extended/Particles/Data/Particle.cs
@@ -44,7 +44,7 @@ public unsafe struct Particle
     /// <summary>
     /// The scale factor applied to this particle's visual representation.
     /// </summary>
-    public float Scale;
+    public fixed float Scale[2];
 
     /// <summary>
     /// The position where this particle was triggered or emitted from [X, Y].

--- a/source/MonoGame.Extended/Particles/Data/ParticleReleaseParameters.cs
+++ b/source/MonoGame.Extended/Particles/Data/ParticleReleaseParameters.cs
@@ -54,7 +54,7 @@ public class ParticleReleaseParameters
     /// <remarks>
     /// Defaults to a random value between 0.0 (half scale) and 1.0 (full scale)
     /// </remarks>
-    public ParticleFloatParameter Scale = new ParticleFloatParameter(0.5f, 1.0f);
+    public ParticleVector2Parameter Scale = new ParticleVector2Parameter(new Vector2(0.5f, 0.5f), new Vector2(1.0f, 1.0f));
 
     /// <summary>
     /// Gets or sets the initial rotation (in radians) of particles when released.

--- a/source/MonoGame.Extended/Particles/Modifiers/Interpolators/ScaleInterpolator.cs
+++ b/source/MonoGame.Extended/Particles/Modifiers/Interpolators/ScaleInterpolator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using Microsoft.Xna.Framework;
 using MonoGame.Extended.Particles.Data;
 
 namespace MonoGame.Extended.Particles.Modifiers.Interpolators;
@@ -14,7 +15,7 @@ namespace MonoGame.Extended.Particles.Modifiers.Interpolators;
 /// <see cref="Interpolator{T}.StartValue"/> to <see cref="Interpolator{T}.EndValue"/> based on the
 /// provided interpolation amount (typically representing the particle's normalized age).
 /// </remarks>
-public class ScaleInterpolator : Interpolator<float>
+public class ScaleInterpolator : Interpolator<Vector2>
 {
     /// <summary>
     /// Updates a particle's scale by interpolating between the start and end values.
@@ -23,6 +24,7 @@ public class ScaleInterpolator : Interpolator<float>
     /// <param name="particle">A pointer to the particle to update.</param>
     public override unsafe void Update(float amount, Particle* particle)
     {
-        particle->Scale = StartValue + (EndValue - StartValue) * amount;
+        particle->Scale[0] = StartValue.X + (EndValue.X - StartValue.X) * amount;
+        particle->Scale[1] = StartValue.Y + (EndValue.Y - StartValue.Y) * amount;
     }
 }

--- a/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Xml;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
@@ -270,7 +271,7 @@ public sealed class ParticleEffectReader : IDisposable
                         break;
 
                     case nameof(ParticleReleaseParameters.Scale):
-                        parameters.Scale = ReadParticleFloatParameter(subtree);
+                        parameters.Scale = ReadParticleVector2Parameter(subtree);
                         break;
 
                     case nameof(ParticleReleaseParameters.Rotation):
@@ -323,6 +324,25 @@ public sealed class ParticleEffectReader : IDisposable
         }
 
         return new ParticleFloatParameter(0);
+    }
+
+    private ParticleVector2Parameter ReadParticleVector2Parameter(XmlReader reader)
+    {
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleVector2Parameter.Kind));
+
+        if(kind == ParticleValueKind.Constant)
+        {
+            Vector2 value = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.Constant));
+            return new ParticleVector2Parameter(value);
+        }
+        else if(kind == ParticleValueKind.Random)
+        {
+            Vector2 min = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMin));
+            Vector2 max = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMax));
+            return new ParticleVector2Parameter(min, max);
+        }
+
+        return new ParticleVector2Parameter(Vector2.Zero);
     }
 
     private ParticleColorParameter ReadParticleColorParameter(XmlReader reader)
@@ -604,8 +624,8 @@ public sealed class ParticleEffectReader : IDisposable
 
             case nameof(ScaleInterpolator):
                 ScaleInterpolator scaleInterpolator = new ScaleInterpolator();
-                scaleInterpolator.StartValue = reader.GetAttributeFloat(nameof(ScaleInterpolator.StartValue));
-                scaleInterpolator.EndValue = reader.GetAttributeFloat(nameof(ScaleInterpolator.EndValue));
+                scaleInterpolator.StartValue = reader.GetAttributeVector2(nameof(ScaleInterpolator.StartValue));
+                scaleInterpolator.EndValue = reader.GetAttributeVector2(nameof(ScaleInterpolator.EndValue));
                 return scaleInterpolator;
 
             case nameof(VelocityInterpolator):

--- a/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
@@ -205,6 +205,8 @@ public class ParticleEffectWriter : IDisposable
             _writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMin), parameter.RandomMin);
             _writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMax), parameter.RandomMax);
         }
+
+        _writer.WriteEndElement();
     }
 
     private void WriteParticleColorParameter(string name, ParticleColorParameter parameter)

--- a/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
@@ -149,7 +149,7 @@ public class ParticleEffectWriter : IDisposable
         WriteParticleFloatParameter(nameof(ParticleReleaseParameters.Speed), parameters.Speed);
         WriteParticleColorParameter(nameof(ParticleReleaseParameters.Color), parameters.Color);
         WriteParticleFloatParameter(nameof(ParticleReleaseParameters.Opacity), parameters.Opacity);
-        WriteParticleFloatParameter(nameof(ParticleReleaseParameters.Scale), parameters.Scale);
+        WriteParticleVector2Parameter(nameof(ParticleReleaseParameters.Scale), parameters.Scale);
         WriteParticleFloatParameter(nameof(ParticleReleaseParameters.Rotation), parameters.Rotation);
         WriteParticleFloatParameter(nameof(ParticleReleaseParameters.Mass), parameters.Mass);
 
@@ -189,6 +189,22 @@ public class ParticleEffectWriter : IDisposable
         }
 
         _writer.WriteEndElement();
+    }
+
+    private void WriteParticleVector2Parameter(string name, ParticleVector2Parameter parameter)
+    {
+        _writer.WriteStartElement(name);
+        _writer.WriteAttributeString(nameof(ParticleVector2Parameter.Kind), parameter.Kind.ToString());
+
+        if(parameter.Kind == ParticleValueKind.Constant)
+        {
+            _writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.Constant), parameter.Constant);
+        }
+        else
+        {
+            _writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMin), parameter.RandomMin);
+            _writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMax), parameter.RandomMax);
+        }
     }
 
     private void WriteParticleColorParameter(string name, ParticleColorParameter parameter)
@@ -403,8 +419,8 @@ public class ParticleEffectWriter : IDisposable
 
             case ScaleInterpolator scaleInterpolator:
                 _writer.WriteAttributeString(nameof(Type), nameof(ScaleInterpolator));
-                _writer.WriteAttributeFloat(nameof(ScaleInterpolator.StartValue), scaleInterpolator.StartValue);
-                _writer.WriteAttributeFloat(nameof(ScaleInterpolator.EndValue), scaleInterpolator.EndValue);
+                _writer.WriteAttributeVector2(nameof(ScaleInterpolator.StartValue), scaleInterpolator.StartValue);
+                _writer.WriteAttributeVector2(nameof(ScaleInterpolator.EndValue), scaleInterpolator.EndValue);
                 break;
 
             case VelocityInterpolator velocityInterpolator:

--- a/source/MonoGame.Extended/Particles/ParticleEmitter.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEmitter.cs
@@ -369,7 +369,11 @@ public sealed unsafe class ParticleEmitter : IDisposable
             particle->Color[2] = color.Z;
 
             particle->Opacity = Parameters.Opacity.Value;
-            particle->Scale = Parameters.Scale.Value;
+
+            Vector2 scale = Parameters.Scale.Value;
+            particle->Scale[0] = scale.X;
+            particle->Scale[1] = scale.Y;
+
             particle->Rotation = Parameters.Rotation.Value;
             particle->Mass = Parameters.Mass.Value;
             particle->LayerDepth = layerDepth;

--- a/source/MonoGame.Extended/Particles/SpriteBatchExtensions.ParticleEfffect.cs
+++ b/source/MonoGame.Extended/Particles/SpriteBatchExtensions.ParticleEfffect.cs
@@ -96,7 +96,7 @@ public static class SpriteBatchExtensions
         }
 
         Vector2 position = new Vector2(particle->Position[0], particle->Position[1]);
-        float scale = particle->Scale;
+        Vector2 scale = new Vector2(particle->Scale[0], particle->Scale[1]);
         float rotation = particle->Rotation;
         float layerDepth = particle->LayerDepth;
 

--- a/tests/MonoGame.Extended.Tests/Particles/ParticleEffectReaderTests.cs
+++ b/tests/MonoGame.Extended.Tests/Particles/ParticleEffectReaderTests.cs
@@ -87,7 +87,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -119,7 +119,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -155,7 +155,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -189,7 +189,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -223,7 +223,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -257,7 +257,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -291,7 +291,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -325,7 +325,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -359,7 +359,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -391,7 +391,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -425,7 +425,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -459,7 +459,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -498,7 +498,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -540,7 +540,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -581,7 +581,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -622,7 +622,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -661,7 +661,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -703,7 +703,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -744,7 +744,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -784,7 +784,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -826,7 +826,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -866,7 +866,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -908,7 +908,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -954,7 +954,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -1000,7 +1000,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -1046,7 +1046,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -1092,7 +1092,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0,0" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -1100,7 +1100,7 @@ public class ParticleEffectReaderTests
                   <Modifiers>
                     <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" StartValue="0" EndValue="0" />
+                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" StartValue="0,0" EndValue="1,1" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -1120,8 +1120,8 @@ public class ParticleEffectReaderTests
         Assert.Single(modifier.Interpolators);
 
         ScaleInterpolator interpolator = Assert.IsType<ScaleInterpolator>(modifier.Interpolators[0]);
-        Assert.Equal(0.0f, interpolator.StartValue);
-        Assert.Equal(0.0f, interpolator.EndValue);
+        Assert.Equal(Vector2.Zero, interpolator.StartValue);
+        Assert.Equal(Vector2.One, interpolator.EndValue);
     }
 
     [Fact]
@@ -1138,7 +1138,7 @@ public class ParticleEffectReaderTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>

--- a/tests/MonoGame.Extended.Tests/Particles/ParticleEffectWriterTests.cs
+++ b/tests/MonoGame.Extended.Tests/Particles/ParticleEffectWriterTests.cs
@@ -56,7 +56,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -90,7 +90,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -127,7 +127,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -161,7 +161,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -195,7 +195,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -229,7 +229,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -263,7 +263,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -297,7 +297,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -331,7 +331,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -365,7 +365,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -399,7 +399,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -435,7 +435,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -474,7 +474,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -513,7 +513,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -552,7 +552,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -591,7 +591,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -630,7 +630,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -669,7 +669,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -708,7 +708,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -747,7 +747,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -786,7 +786,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -825,7 +825,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -866,7 +866,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -911,7 +911,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -956,7 +956,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -1001,7 +1001,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -1046,7 +1046,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>
@@ -1054,7 +1054,7 @@ public class ParticleEffectWriterTests
                   <Modifiers>
                     <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" StartValue="0" EndValue="0" />
+                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" StartValue="0,0" EndValue="0,0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -1091,7 +1091,7 @@ public class ParticleEffectWriterTests
                     <Speed Kind="Random" RandomMin="50" RandomMax="100" />
                     <Color Kind="Constant" Constant="1,1,1" />
                     <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
-                    <Scale Kind="Random" RandomMin="0.5" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
                     <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
                     <Mass Kind="Constant" Constant="1" />
                   </Parameters>


### PR DESCRIPTION
## Summary

This PR updates the particle system to add independent X and Y axis scale values for a particle.  This was originally only available through the ScaleInterpolator and not the Scale particle parameter.  The recent refactor of the particle system in #990 removed it from the ScaleInterpolator.

This PR adds it back and also updates the Scale particle parameter.