### PR TITLE
Texture2DRegion Name Default to Texture Name

### DIFF
--- a/source/MonoGame.Extended/Graphics/Texture2DRegion.cs
+++ b/source/MonoGame.Extended/Graphics/Texture2DRegion.cs
@@ -179,7 +179,7 @@ public class Texture2DRegion
 
         if (string.IsNullOrEmpty(name))
         {
-            name = $"{texture.Name}({x}, {y}, {width}, {height})";
+            name = $"{texture.Name}";
         }
 
         Name = name;


### PR DESCRIPTION
## Summary

The Textur2DRegion.Name value was defaulted to the name of the texture and the bounds of the texture when no name was given in the constructor.  This changes it so that it just defaults to the texture name only.