### PR TITLE
Don't remove subdirectories from atlas image and atlas region names

### DIFF
--- a/source/MonoGame.Extended.Content.Pipeline/TextureAtlases/TexturePackerWriter.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/TextureAtlases/TexturePackerWriter.cs
@@ -15,14 +15,14 @@ public class TexturePackerWriter : ContentTypeWriter<TexturePackerProcessorResul
     protected override void Write(ContentWriter writer, TexturePackerProcessorResult result)
     {
         var tpFile = result.Data;
-        var imageAssetName = Path.GetFileNameWithoutExtension(tpFile.Meta.Image);
+        var imageAssetName = Path.ChangeExtension(tpFile.Meta.Image, null);
 
         writer.Write(imageAssetName);
         writer.Write(tpFile.Regions.Count);
 
         foreach (var region in tpFile.Regions)
         {
-            var regionName = Path.GetFileNameWithoutExtension(region.FileName);
+            var regionName = Path.ChangeExtension(region.FileName, null);
 
             writer.Write(region.Frame.X);
             writer.Write(region.Frame.Y);


### PR DESCRIPTION
Don't remove subdirectories from atlas image, this makes sprite management more flexible;

example: json data can be stored in sheetdata/player.json, texture can be stored in textures/player.png; player.json contains relative path to texture: image=../textures/player.png (requires TexturePacker update which is released soon)

don't remove subdirectories from atlas region names, to be able to load multiple animations from one texture atlas without conflicting region names; example: walk/01.png, walk/02.png, ... turn/01.png, turn/02.png, ...