### PR TITLE
Removed boxing in TweenMemberss getters and setters

### DIFF
--- a/source/MonoGame.Extended/Tweening/TweenFieldMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenFieldMember.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.VisualBasic;
 
 namespace MonoGame.Extended.Tweening
 {

--- a/source/MonoGame.Extended/Tweening/TweenFieldMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenFieldMember.cs
@@ -2,40 +2,43 @@ using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.VisualBasic;
 
 namespace MonoGame.Extended.Tweening
 {
     public sealed class TweenFieldMember<T> : TweenMember<T>
-        where T : struct 
+        where T : struct
     {
         private readonly FieldInfo _fieldInfo;
 
-        public TweenFieldMember(object target, FieldInfo fieldInfo) 
+        public TweenFieldMember(object target, FieldInfo fieldInfo)
             : base(target, CompileGetMethod(fieldInfo), CompileSetMethod(fieldInfo))
         {
             _fieldInfo = fieldInfo;
         }
 
-        private static Func<object, object> CompileGetMethod(FieldInfo fieldInfo)
+        private static Func<object, T> CompileGetMethod(FieldInfo fieldInfo)
         {
-            var self = Expression.Parameter(typeof(object));
-            var instance = Expression.Convert(self, fieldInfo.DeclaringType);
-            var field = Expression.Field(instance, fieldInfo);
-            var convert = Expression.TypeAs(field, typeof(object));
-
-            return Expression.Lambda<Func<object, object>>(convert, self).Compile();
+            var entityType = fieldInfo.DeclaringType!;
+            var parameter = Expression.Parameter(typeof(object), "entity");
+            var property = Expression.Field(Expression.Convert(parameter, entityType), fieldInfo);
+            var funcType = typeof(Func<,>).MakeGenericType(typeof(object), fieldInfo.FieldType);
+            return (Func<object, T>)Expression.Lambda(funcType, property, parameter).Compile();
         }
 
-        private static Action<object, object> CompileSetMethod(FieldInfo fieldInfo)
+        private static Action<object, T> CompileSetMethod(FieldInfo fieldInfo)
         {
             Debug.Assert(fieldInfo.DeclaringType != null);
 
-            var self = Expression.Parameter(typeof(object));
-            var value = Expression.Parameter(typeof(object));
-            var fieldExp = Expression.Field(Expression.Convert(self, fieldInfo.DeclaringType), fieldInfo);
-            var assignExp = Expression.Assign(fieldExp, Expression.Convert(value, fieldInfo.FieldType));
+            var entityType = fieldInfo.DeclaringType!;
+            var targetParam = Expression.Parameter(typeof(object), "target");
+            var valueParam = Expression.Parameter(typeof(T), "value");
+            var conversion = Expression.Convert(targetParam, entityType);
 
-            return Expression.Lambda<Action<object, object>>(assignExp, self, value).Compile();
+            var field = Expression.Field(conversion, fieldInfo);
+            var assignation = Expression.Assign(field, valueParam);
+
+            return Expression.Lambda<Action<object, T>>(assignation, targetParam, valueParam).Compile();
         }
 
         public override Type Type => _fieldInfo.FieldType;

--- a/source/MonoGame.Extended/Tweening/TweenFieldMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenFieldMember.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.VisualBasic;
 
 namespace MonoGame.Extended.Tweening
 {
@@ -21,8 +22,7 @@ namespace MonoGame.Extended.Tweening
             var entityType = fieldInfo.DeclaringType!;
             var parameter = Expression.Parameter(typeof(object), "entity");
             var property = Expression.Field(Expression.Convert(parameter, entityType), fieldInfo);
-            var funcType = typeof(Func<,>).MakeGenericType(typeof(object), fieldInfo.FieldType);
-            return (Func<object, T>)Expression.Lambda(funcType, property, parameter).Compile();
+            return Expression.Lambda<Func<object, T>>(property, parameter).Compile();
         }
 
         private static Action<object, T> CompileSetMethod(FieldInfo fieldInfo)

--- a/source/MonoGame.Extended/Tweening/TweenMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenMember.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq.Expressions;
 
+// TODO: THIS BITCH RIGHT HERE DOES A LOT OF BOXING. FIX IT!
+
 namespace MonoGame.Extended.Tweening
 {
     public abstract class TweenMember
@@ -18,19 +20,19 @@ namespace MonoGame.Extended.Tweening
     public abstract class TweenMember<T> : TweenMember
         where T : struct
     {
-        protected TweenMember(object target, Func<object, object> getMethod, Action<object, object> setMethod)
+        protected TweenMember(object target, Func<object, T> getMethod, Action<object, T> setMethod)
             : base(target)
         {
             _getMethod = getMethod;
             _setMethod = setMethod;
         }
 
-        private readonly Func<object, object> _getMethod;
-        private readonly Action<object, object> _setMethod;
+        private readonly Func<object, T> _getMethod;
+        private readonly Action<object, T> _setMethod;
 
         public T Value
         {
-            get { return (T) _getMethod(Target); }
+            get { return _getMethod(Target); }
             set { _setMethod(Target, value); }
         }
     }

--- a/source/MonoGame.Extended/Tweening/TweenMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenMember.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq.Expressions;
 
-// TODO: THIS BITCH RIGHT HERE DOES A LOT OF BOXING. FIX IT!
-
 namespace MonoGame.Extended.Tweening
 {
     public abstract class TweenMember

--- a/source/MonoGame.Extended/Tweening/TweenPropertyMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenPropertyMember.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 namespace MonoGame.Extended.Tweening
 {
     public sealed class TweenPropertyMember<T> : TweenMember<T>
-        where T : struct 
+        where T : struct
     {
         private readonly PropertyInfo _propertyInfo;
 
@@ -19,25 +19,30 @@ namespace MonoGame.Extended.Tweening
         public override Type Type => _propertyInfo.PropertyType;
         public override string Name => _propertyInfo.Name;
 
-        private static Func<object, object> CompileGetMethod(PropertyInfo propertyInfo)
+        //TODO: Try to further optimize this. For example, it needs to do all this reflection compilation shenanigan every time.
+        //Could we cache these instead?
+
+        private static Func<object, T> CompileGetMethod(PropertyInfo propertyInfo)
         {
-            var param = Expression.Parameter(typeof(object));
-            var instance = Expression.Convert(param, propertyInfo.DeclaringType);
-            var convert = Expression.TypeAs(Expression.Property(instance, propertyInfo), typeof(object));
-            return Expression.Lambda<Func<object, object>>(convert, param).Compile();
+            var entityType = propertyInfo.DeclaringType!;
+            var parameter = Expression.Parameter(typeof(object), "entity");
+            var property = Expression.Property(Expression.Convert(parameter, entityType), propertyInfo);
+            var funcType = typeof(Func<,>).MakeGenericType(typeof(object), propertyInfo.PropertyType);
+            return (Func<object, T>)Expression.Lambda(funcType, property, parameter).Compile();
         }
 
-        private static Action<object, object> CompileSetMethod(PropertyInfo propertyInfo)
+        private static Action<object, T> CompileSetMethod(PropertyInfo propertyInfo)
         {
             Debug.Assert(propertyInfo.DeclaringType != null);
 
-            var param = Expression.Parameter(typeof(object));
-            var argument = Expression.Parameter(typeof(object));
-            var expression = Expression.Convert(param, propertyInfo.DeclaringType);
-            var methodInfo = propertyInfo.SetMethod;
-            var arguments = Expression.Convert(argument, propertyInfo.PropertyType);
-            var setterCall = Expression.Call(expression, methodInfo, arguments);
-            return Expression.Lambda<Action<object, object>>(setterCall, param, argument).Compile();
+            var entityType = propertyInfo.DeclaringType!;
+            var targetParam = Expression.Parameter(typeof(object), "target");
+            var valueParam = Expression.Parameter(typeof(T), "value");
+            var conversion = Expression.Convert(targetParam, entityType);
+            var methodInfo = propertyInfo.SetMethod!;
+            var set = Expression.Call(conversion, methodInfo, valueParam);
+
+            return Expression.Lambda<Action<object, T>>(set, targetParam, valueParam).Compile();
         }
     }
 }

--- a/source/MonoGame.Extended/Tweening/TweenPropertyMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenPropertyMember.cs
@@ -27,8 +27,7 @@ namespace MonoGame.Extended.Tweening
             var entityType = propertyInfo.DeclaringType!;
             var parameter = Expression.Parameter(typeof(object), "entity");
             var property = Expression.Property(Expression.Convert(parameter, entityType), propertyInfo);
-            var funcType = typeof(Func<,>).MakeGenericType(typeof(object), propertyInfo.PropertyType);
-            return (Func<object, T>)Expression.Lambda(funcType, property, parameter).Compile();
+            return Expression.Lambda<Func<object, T>>(property, parameter).Compile();
         }
 
         private static Action<object, T> CompileSetMethod(PropertyInfo propertyInfo)


### PR DESCRIPTION
## Description

* Usually, in both tween member classes, both the runtime compiled setter and the getter box their values, despite being constrained to structs
* This PR fixes this by adjusting the typing of the delegates used, as well as modifying the expressions that are compiled so they are assignable to the delegates.
* Finally, it does so in a way that requires no boxing.

Testing of this should be no different from the tests that currently exists, and I tested this for a couple hours with a couple different tweens and it seems to both work and show up far less allocations on my end

I hope it's useful!

## Related Issues/Tickets

* I couldn't find any issues pertaining this, I probably should have opened one before delving into this, my bad.

## Changes Made

* Changed the typing of the TweenMember's delegates to be `Func<object, T>`
* Changed the compiled expressions to instead expect a value (known to be a struct) of the property/field's type, and to convert the instance into the property/field's declaring type before accessing.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
