### PR TITLE
fix(RectangleF): Remove extra open curly braces in the 'ToString' method

### DIFF
--- a/source/MonoGame.Extended/Math/RectangleF.cs
+++ b/source/MonoGame.Extended/Math/RectangleF.cs
@@ -686,7 +686,7 @@ namespace MonoGame.Extended
         /// </returns>
         public override string ToString()
         {
-            return $"{{X: {X}, Y: {Y}, Width: {Width}, Height: {Height}";
+            return $"X: {X}, Y: {Y}, Width: {Width}, Height: {Height}";
         }
 
         internal string DebugDisplayString => string.Concat(X, "  ", Y, "  ", Width, "  ", Height);


### PR DESCRIPTION
## Description

The `ToString` method in the `RectangleF` class had extra curly braces at the beginning.

## Related Issues/Tickets

- closes #983 

## Changes Made

- removed extra curly braces

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [X] I have verified that there are no existing pull requests that would overlap with this pull request.
* [X] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [X] I have verified that this pull request adheres to this project's code of conduct.
* [X] I have written a descriptive title for this pull request.
* [X] I have provided appropriate test coverage were applicable.
