### PR TITLE
feat(ComponentMapper): Add 'TryGet' methods

### DIFF
--- a/source/MonoGame.Extended/ECS/ComponentMapper.cs
+++ b/source/MonoGame.Extended/ECS/ComponentMapper.cs
@@ -59,17 +59,8 @@ namespace MonoGame.Extended.ECS
 
         public bool TryGet(int entityId, [NotNullWhen(true)] out T result)
         {
-            var component = Get(entityId);
-
-            if (component == null)
-            {
-                result = default(T);
-                return false;
-            }
-
-            result = component;
-
-            return true;
+            result = Get(entityId);
+            return result != null;
         }
 
         public override bool Has(int entityId)

--- a/source/MonoGame.Extended/ECS/ComponentMapper.cs
+++ b/source/MonoGame.Extended/ECS/ComponentMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using MonoGame.Extended.Collections;
 
 namespace MonoGame.Extended.ECS
@@ -49,6 +50,26 @@ namespace MonoGame.Extended.ECS
         public T Get(int entityId)
         {
             return Components[entityId];
+        }
+
+        public bool TryGet(Entity entity, [NotNullWhen(true)] out T result)
+        {
+            return TryGet(entity.Id, out result);
+        }
+
+        public bool TryGet(int entityId, [NotNullWhen(true)] out T result)
+        {
+            var component = Get(entityId);
+
+            if (component == null)
+            {
+                result = default(T);
+                return false;
+            }
+
+            result = component;
+
+            return true;
         }
 
         public override bool Has(int entityId)

--- a/tests/MonoGame.Extended.Tests/ECS/ComponentMapperTests.cs
+++ b/tests/MonoGame.Extended.Tests/ECS/ComponentMapperTests.cs
@@ -46,6 +46,31 @@ namespace MonoGame.Extended.ECS.Tests
         }
 
         [Fact]
+        public void PutAndTryGetComponent()
+        {
+            // Arrange
+            const int entityId = 4;
+            const int entityIdNotAdded = 100;
+
+            var mapper = new ComponentMapper<Transform2>(1, _ => { });
+            var component = new Transform2();
+
+            mapper.Put(entityId, component);
+
+            // Act
+            bool foundAdded = mapper.TryGet(entityId, out Transform2 transformFromAdded);
+            bool foundNotAdded = mapper.TryGet(entityIdNotAdded, out Transform2 transformFromNotAdded);
+
+            // Assert
+            Assert.Equal(typeof(Transform2), mapper.ComponentType);
+            Assert.True(mapper.Components.Count >= 1);
+            Assert.True(foundAdded);
+            Assert.Same(component, transformFromAdded);
+            Assert.False(foundNotAdded);
+            Assert.Equal(default(Transform2), transformFromNotAdded);
+        }
+
+        [Fact]
         public void OnDelete()
         {
             const int entityId = 1;


### PR DESCRIPTION
## Description

I am writing a multiplayer Pong game as an example game for my network library and I have some places where I am not sure if an entity has some component. I could use 'ComponentMapper.Has' and 'ComponentMapper.Get', but these are two lookups and it's not that clean. Or use 'ComponentMapper.Get' with a null check.

I personally like the "Try" pattern for this and it is easier to read, so I made this PR.

Example of a network system which uses the new `TryGet` method:

```c#
    protected override void OnEntityRemoved(int entityId)
    {
        if (!this.networkMapper.TryGet(entityId, out NetworkComponent? networkComponent))
        {
            return;
        }

        var destroyEntityPacket = Packet.FromPool(MessageType.DestroyEntity);
        destroyEntityPacket.WriteInt(networkComponent.Id);

        this.server.BroadcastReliable(destroyEntityPacket);

        base.OnEntityRemoved(entityId);
    }
```

Feel free to reject the PR if these changes are not wanted/needed.

## Related Issues/Tickets

- no related issues/tickets

## Changes Made

- added `bool TryGet(Entity entity, [NotNullWhen(true)] out T result)` method to `ComponentMapper<T>`
- added `bool TryGet(int entityId, [NotNullWhen(true)] out T result)` method to `ComponentMapper<T>`
- added a unit test for it

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [X] I have verified that there are no existing pull requests that would overlap with this pull request.
* [X] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [X] I have verified that this pull request adheres to this project's code of conduct.
* [X] I have written a descriptive title for this pull request.
* [X] I have provided appropriate test coverage were applicable.
