### PR TITLE
Fix/textureatlas import error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-       <Version>5.0.1</Version>
+       <Version>5.0.2</Version>
    </PropertyGroup>
 
     <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MonoGame.Extended is a set of utilities (in the form of libraries/tools) to [Mon
 Code is distributed as NuGet packages in the form of libraries (`.dll` files). You can easily install the NuGet packages into your existing MonoGame project using the NuGet Package Manager UI in Visual Studio or by using the command line interface (CLI) in a terminal.
 
 ```sh
-dotnet add package MonoGame.Extended --version 5.0.1
+dotnet add package MonoGame.Extended --version 5.0.2
 ```
 
 ### Using the Content Pipeline Extensions

--- a/source/MonoGame.Extended.Content.Pipeline/TextureAtlases/TexturePackerJsonImporter.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/TextureAtlases/TexturePackerJsonImporter.cs
@@ -8,9 +8,9 @@ using MonoGame.Extended.Content.TexturePacker;
 namespace MonoGame.Extended.Content.Pipeline.TextureAtlases
 {
     [ContentImporter(".json", DefaultProcessor = "TexturePackerProcessor", DisplayName = "TexturePacker JSON Importer - MonoGame.Extended")]
-    public class TexturePackerJsonImporter : ContentImporter<TexturePackerFileContent>
+    public class TexturePackerJsonImporter : ContentImporter<ContentImporterResult<TexturePackerFileContent>>
     {
-        public override TexturePackerFileContent Import(string filename, ContentImporterContext context)
+        public override ContentImporterResult<TexturePackerFileContent> Import(string filename, ContentImporterContext context)
         {
             var tpFile = TexturePackerFileReader.Read(filename);
 
@@ -27,7 +27,7 @@ namespace MonoGame.Extended.Content.Pipeline.TextureAtlases
                 }
             }
 
-            return tpFile;
+            return new ContentImporterResult<TexturePackerFileContent>(filename, tpFile);
         }
     }
 }

--- a/source/MonoGame.Extended.Content.Pipeline/TextureAtlases/TexturePackerProcessor.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/TextureAtlases/TexturePackerProcessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Content.Pipeline.Processors;
@@ -10,25 +11,26 @@ using MonoGame.Extended.Content.TexturePacker;
 namespace MonoGame.Extended.Content.Pipeline.TextureAtlases;
 
 [ContentProcessor(DisplayName = "TexturePacker Processor - MonoGame.Extended")]
-public class TexturePackerProcessor : ContentProcessor<TexturePackerFileContent, TexturePackerProcessorResult>
+public class TexturePackerProcessor : ContentProcessor<ContentImporterResult<TexturePackerFileContent>, TexturePackerProcessorResult>
 {
-    public override TexturePackerProcessorResult Process(TexturePackerFileContent input, ContentProcessorContext context)
+    public override TexturePackerProcessorResult Process(ContentImporterResult<TexturePackerFileContent> input, ContentProcessorContext context)
     {
-        if (input.Meta.Image != null)
+        if (input.Data.Meta.Image != null)
         {
             // Validates the texture exists and can be processed (fails build if missing)
-            var externalRef = new ExternalReference<Texture2DContent>(input.Meta.Image);
+            var externalRef = new ExternalReference<Texture2DContent>(input.Data.Meta.Image);
             context.BuildAndLoadAsset<Texture2DContent, Texture2DContent>(externalRef, nameof(TextureProcessor));
 
         }
-        else if (input.Meta.DataFormat == "monogame-extended")
+        else if (input.Data.Meta.DataFormat == "monogame-extended")
         {
-            foreach (var texture in input.Textures)
+            foreach (var texture in input.Data.Textures)
             {
-                var externalRef = new ExternalReference<Texture2DContent>(texture.FileName);
+                string texturePath = Path.Combine(Path.GetDirectoryName(input.FilePath), texture.FileName);
+                var externalRef = new ExternalReference<Texture2DContent>(texturePath);
                 context.BuildAndLoadAsset<Texture2DContent, Texture2DContent>(externalRef, nameof(TextureProcessor));
             }
         }
-        return new TexturePackerProcessorResult(input);
+        return new TexturePackerProcessorResult(input.Data);
     }
 }

--- a/tests/MonoGame.Extended.Content.Pipeline.Tests/TexturePackerJsonImporterProcessorTests.cs
+++ b/tests/MonoGame.Extended.Content.Pipeline.Tests/TexturePackerJsonImporterProcessorTests.cs
@@ -12,19 +12,19 @@ namespace MonoGame.Extended.Content.Pipeline.Tests
         {
             var filePath = PathExtensions.GetApplicationFullPath(@"TestData/test-tileset.json");
             var importer = new TexturePackerJsonImporter();
-            var data = importer.Import(filePath, Substitute.For<ContentImporterContext>());
+            var importResult = importer.Import(filePath, Substitute.For<ContentImporterContext>());
 
-            Assert.NotNull(data);
+            Assert.NotNull(importResult);
 
             // Check meta.image contains image name
-            Assert.Equal("test-tileset.png", data.Meta.Image);
+            Assert.Equal("test-tileset.png", importResult.Data.Meta.Image);
 
             // Check regions count and textures
-            Assert.Equal(9, data.Regions.Count);
-            Assert.Null(data.Textures);  // only used by new MonoGame.Extended JSON format
+            Assert.Equal(9, importResult.Data.Regions.Count);
+            Assert.Null(importResult.Data.Textures);  // only used by new MonoGame.Extended JSON format
 
             // Check first region
-            var firstRegion = data.Regions[0];
+            var firstRegion = importResult.Data.Regions[0];
             Assert.Equal("1.png", firstRegion.FileName);
             Assert.Equal(2, firstRegion.Frame.X);
             Assert.Equal(2, firstRegion.Frame.Y);
@@ -54,16 +54,16 @@ namespace MonoGame.Extended.Content.Pipeline.Tests
         {
             var filePath = PathExtensions.GetApplicationFullPath(@"TestData/test-atlas.json");
             var importer = new TexturePackerJsonImporter();
-            var data = importer.Import(filePath, Substitute.For<ContentImporterContext>());
+            var importResult = importer.Import(filePath, Substitute.For<ContentImporterContext>());
 
             // Regions must be null (only used by old generic json format)
-            Assert.Null(data.Regions);
+            Assert.Null(importResult.Data.Regions);
 
             // Textures contains 1 texture
-            Assert.NotNull(data.Textures);
-            Assert.Single(data.Textures);
+            Assert.NotNull(importResult.Data.Textures);
+            Assert.Single(importResult.Data.Textures);
 
-            var texture = data.Textures[0];
+            var texture = importResult.Data.Textures[0];
             Assert.Equal("test-atlas-texture.png", texture.FileName);
 
             // The first texture contains frames


### PR DESCRIPTION
## Description

This pull request resolved #1016 by ensuring the PNG file path for TexturePacker imports are resolved from the directory relative to the JSON file.

## Related Issues/Tickets

* Closes #1016 

## Changes Made

* Use `ContentImporterResult<T>` for import result of `TexturePackerImporter` so we can pass the path to the JSON file to the processor.
* Updated the `TexturePackerProcessor` to resolve the PNG file relative to the directory the JSON file is in

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
