### PR TITLE
Enhance LineProfile with radiation modes and direction control for particle emission

### DIFF
--- a/source/MonoGame.Extended/Particles/Profiles/LineProfile.cs
+++ b/source/MonoGame.Extended/Particles/Profiles/LineProfile.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended.Particles.Profiles;
@@ -11,8 +12,7 @@ namespace MonoGame.Extended.Particles.Profiles;
 /// </summary>
 /// <remarks>
 /// The <see cref="LineProfile"/> positions particles randomly along a line segment centered at the emitter position and
-/// defined by an axis direction and length. Unlike <see cref="LineUniformProfile"/>, this profile gives each particle a
-/// random heading in any direction.
+/// defined by an axis direction and length.
 /// </remarks>
 public sealed class LineProfile : Profile
 {
@@ -27,15 +27,80 @@ public sealed class LineProfile : Profile
     public float Length;
 
     /// <summary>
+    /// The emission direction vector used when <see cref="Radiate"/> is <see cref="LineRadiation.Directional"/>
+    /// or as a scale factor when <see cref="Radiate"/> is <see cref="LineRadiation.NormalUp"/> or <see cref="LineRadiation.NormalDown"/>.
+    /// </summary>
+    /// <remarks>
+    /// For <see cref="LineRadiation.Directional"/>, this vector directly specifies the particle heading direction.
+    /// For <see cref="LineRadiation.NormalUp"/> and <see cref="LineRadiation.NormalDown"/>, this vector's magnitude and sign
+    /// control the normal emission behavior. Positive values emit in the specified normal direction, while negative values
+    /// flip to the opposite direction.
+    /// This property is ignored when <see cref="Radiate"/> is <see cref="LineRadiation.None"/>.
+    /// </remarks>
+    public Vector2 Direction = Vector2.UnitY;
+
+    /// <summary>
+    /// The radiation mode that determines how particle headings are calculated.
+    /// </summary>
+    public LineRadiation Radiate = LineRadiation.None;
+
+    /// <summary>
     /// Computes the offset and heading for a new particle.
     /// </summary>
     /// <param name="offset">A pointer to the Vector2 where the offset from the emitter position will be stored.</param>
     /// <param name="heading">A pointer to the Vector2 where the unit direction vector will be stored.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="Radiate"/> contains an unsupported value.
+    /// </exception>
     public override unsafe void GetOffsetAndHeading(Vector2* offset, Vector2* heading)
     {
         float value = FastRandom.Shared.NextSingle(Length * -0.5f, Length * 0.5f);
         offset->X = Axis.X * value;
         offset->Y = Axis.Y * value;
-        FastRandom.Shared.NextUnitVector(heading);
+
+        // Calculate heading based on radiation mode
+        switch (Radiate)
+        {
+            case LineRadiation.None:
+                FastRandom.Shared.NextUnitVector(heading);
+                break;
+
+            case LineRadiation.Directional:
+                Vector2 normalizedDirection = Vector2.Normalize(Direction);
+                heading->X = normalizedDirection.X;
+                heading->Y = normalizedDirection.Y;
+                break;
+
+            case LineRadiation.NormalUp:
+                Vector2 normalizedAxis = Vector2.Normalize(Axis);
+                Vector2 normalUp = new Vector2(-normalizedAxis.Y, -normalizedAxis.X);
+
+                float scaleUp = Direction.Length();
+                if (Direction.X < 0 || Direction.Y < 0)
+                {
+                    scaleUp = -scaleUp;
+                }
+
+                heading->X = normalUp.X * MathF.Sign(scaleUp);
+                heading->Y = normalUp.Y * MathF.Sign(scaleUp);
+                break;
+
+            case LineRadiation.NormalDown:
+                Vector2 normalizedAxisDown = Vector2.Normalize(Axis);
+                Vector2 normalDown = new Vector2(normalizedAxisDown.Y, normalizedAxisDown.X);
+
+                float scaleDown = Direction.Length();
+                if (Direction.X < 0 || Direction.Y < 0)
+                {
+                    scaleDown = -scaleDown;
+                }
+
+                heading->X = normalDown.X * MathF.Sign(scaleDown);
+                heading->Y = normalDown.Y * MathF.Sign(scaleDown);
+                break;
+
+            default:
+                throw new InvalidOperationException($"Unsupported radiation mode '{Radiate}'");
+        }
     }
 }

--- a/source/MonoGame.Extended/Particles/Profiles/LineRadiation.cs
+++ b/source/MonoGame.Extended/Particles/Profiles/LineRadiation.cs
@@ -1,0 +1,47 @@
+namespace MonoGame.Extended.Particles.Profiles;
+
+/// <summary>
+/// Defines the radiation pattern for particles when using a <see cref="LineProfile"/>.
+/// </summary>
+/// <remarks>
+/// This enumeration determines how a particle's initial heading is calculated relative to the line segment.
+/// Different radiation patterns enable various effects such as rain, fountains, or chaotic dispersion.
+/// </remarks>
+public enum LineRadiation
+{
+    /// <summary>
+    /// Particles move in random directions unrelated to their position.
+    /// </summary>
+    /// <remarks>
+    /// In this mode, the initial heading of particles is completely random and has no relationship to their position
+    /// along the line.
+    /// </remarks>
+    None,
+
+    /// <summary>
+    /// Particles move in the direction specified by the <see cref="LineProfile.Direction"/> property.
+    /// </summary>
+    /// <remarks>
+    /// In this mode, all particles are given the same initial heading as specified by the Direction vector. This allows
+    /// complete control over particle movement direction regardless of the line's orientation.
+    /// </remarks>
+    Directional,
+
+    /// <summary>
+    /// Particles move perpendicular to the line axis in the upward screen direction.
+    /// </summary>
+    /// <remarks>
+    /// In this mode, particles are given initial headings perpendicular to the line's axis, pointing upward in screen
+    /// coordinates (negative Y direction).
+    /// </remarks>
+    NormalUp,
+
+    /// <summary>
+    /// Particles move perpendicular to the line axis in the downward screen direction.
+    /// </summary>
+    /// <remarks>
+    /// In this mode, particles are given initial headings perpendicular to the line's axis, pointing downward in screen
+    /// coordinates (positive Y direction).
+    /// </remarks>
+    NormalDown
+}

--- a/source/MonoGame.Extended/Particles/Profiles/Profile.cs
+++ b/source/MonoGame.Extended/Particles/Profiles/Profile.cs
@@ -44,6 +44,23 @@ public abstract class Profile
     }
 
     /// <summary>
+    /// Creates a <see cref="LineProfile"/> that emits particles along a line segment.
+    /// </summary>
+    /// <param name="axis">The direction vector of the line.</param>
+    /// <param name="length">The length of the line segment.</param>
+    /// <param name="radiate">The radiation mode that determines how particle headings are calculated.</param>
+    /// <param name="direction">
+    /// The emission direction vector used when <paramref name="radiate"/> is <see cref="LineRadiation.Directional"/>
+    /// or as a scale factor when <paramref name="radiate"/> is <see cref="LineRadiation.NormalUp"/> or
+    /// <see cref="LineRadiation.NormalDown"/>.
+    /// </param>
+    /// <returns>A new <see cref="LineProfile"/> instance.</returns>
+    public static Profile Line(Vector2 axis, float length, LineRadiation radiate, Vector2 direction)
+    {
+        return new LineProfile { Axis = axis, Length = length, Radiate = radiate, Direction = direction };
+    }
+
+    /// <summary>
     /// Creates a <see cref="RingProfile"/> that emits particles from the perimeter of a circle.
     /// </summary>
     /// <param name="radius">The radius of the ring.</param>


### PR DESCRIPTION
## Description

Adds lines radiation mode and direction control for particle emissions when using `LineProfile`

## Related Issues/Tickets

* None

## Changes Made

* Added `LineRadiation` enum with `None`, `Directional`, `NormalUp`, `NormalDown` modes
* Added `Direction` and `Radiate` properties to `LineProfile` for emission control
* Updated `LineProfile.GetOffsetAndHeading` to support new radiation modes
* Added `Profile.Line` overload accepting `LineRadiation` and `Direction` parameters

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
