### PR TITLE
Vortex modifier is now an actual vortex and not a gravity well

### DIFF
--- a/source/MonoGame.Extended/Particles/Modifiers/VortexModifier.cs
+++ b/source/MonoGame.Extended/Particles/Modifiers/VortexModifier.cs
@@ -38,7 +38,7 @@ public unsafe class VortexModifier : Modifier
     /// Particles closer to the center experience proportionally stronger forces. The scaling
     /// follows the formula: <c>actualForce = Strength × (OuterRadius / particleDistance)</c>.
     /// </remarks>
-    public float Strength { get; set; } = 100.0f;
+    public float Strength { get; set; }
 
     /// <summary>
     /// Gets or sets the maximum distance from the vortex center where forces are applied.
@@ -48,7 +48,7 @@ public unsafe class VortexModifier : Modifier
     /// as the reference point for force strength calculations, where particles at this exact
     /// distance experience the base <see cref="Strength"/> value.
     /// </remarks>
-    public float OuterRadius { get; set; } = 300.0f;
+    public float OuterRadius { get; set; }
 
     /// <summary>
     /// Gets or sets the minimum distance from the vortex center where forces are applied.
@@ -58,7 +58,7 @@ public unsafe class VortexModifier : Modifier
     /// Prevents extreme force magnitudes and simulation instability when particles
     /// get very close to the center point.
     /// </remarks>
-    public float InnerRadius { get; set; } = 10.0f;
+    public float InnerRadius { get; set; }
 
     /// <summary>
     /// Gets or sets the maximum velocity magnitude that particles can reach under vortex influence.
@@ -69,7 +69,7 @@ public unsafe class VortexModifier : Modifier
     /// Prevents runaway acceleration and maintains visual stability when particles
     /// accumulate high velocities through repeated vortex acceleration.
     /// </remarks>
-    public float MaxVelocity = 300.0f;
+    public float MaxVelocity { get; set; }
 
     /// <summary>
     /// Gets or sets the rotation angle, in radians, applied to gravitational force vectors.
@@ -109,7 +109,7 @@ public unsafe class VortexModifier : Modifier
     /// </summary>
     public VortexModifier()
     {
-        RotationAngle = 45.0f;
+        RotationAngle = 0.0f;
     }
 
     /// <inheritdoc />

--- a/source/MonoGame.Extended/Particles/Modifiers/VortexModifier.cs
+++ b/source/MonoGame.Extended/Particles/Modifiers/VortexModifier.cs
@@ -1,7 +1,3 @@
-// Copyright (c) Craftwork Games. All rights reserved.
-// Licensed under the MIT license.
-// See LICENSE file in the project root for full license information.
-
 using System;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended.Particles.Data;
@@ -9,71 +5,158 @@ using MonoGame.Extended.Particles.Data;
 namespace MonoGame.Extended.Particles.Modifiers;
 
 /// <summary>
-/// A modifier that creates a gravitational vortex effect, pulling particles toward a central point.
+/// A modifier that creates vortex effects by applying rotated gravitational forces to particles.
 /// </summary>
 /// <remarks>
-/// The <see cref="VortexModifier"/> simulates a gravitational attraction between a central point and
-/// each particle. The strength of the attraction is based on gravitational principles, where the force
-/// is proportional to the masses and inversely proportional to the square of the distance.
-///
-/// The actual acceleration applied to each particle is clamped to prevent particles from moving
-/// too quickly when they get close to the center of the vortex.
+///     <para>
+///         The <see cref="VortexModifier"/> generates spiral motion by rotating gravitational attraction vectors
+///         around a central point. Unlike pure gravitational attraction, this creates swirling, orbital, and
+///         spiral-out effects depending on the rotation angle applied to the force vectors.
+///     </para>
+///     <para>
+///         Forces are strongest at the <see cref="InnerRadius"/> and weakest at the <see cref="OuterRadius"/>,
+///         following a linear inverse relationship with distance.
+///     </para>
 /// </remarks>
 public unsafe class VortexModifier : Modifier
 {
-    private const float GRAVITY = 100000f;
+    private float _rotationAngle;
+    private float _cosAngle;
+    private float _sinAngle;
 
     /// <summary>
-    /// Gets or sets the center position of the vortex in 2D space.
+    /// Gets or sets the position of the vortex center relative to particle emission points.
+    /// </summary>
+    public Vector2 Position { get; set; } = Vector2.Zero;
+
+    /// <summary>
+    /// Gets or sets the force strength applied to particles at the outer radius.
+    /// </summary>
+    /// <value>The acceleration in units per second squared applied at the <see cref="OuterRadius"/>.</value>
+    /// <remarks>
+    /// This value represents the acceleration magnitude applied to particles at the vortex edge.
+    /// Particles closer to the center experience proportionally stronger forces. The scaling
+    /// follows the formula: <c>actualForce = Strength × (OuterRadius / particleDistance)</c>.
+    /// </remarks>
+    public float Strength { get; set; } = 100.0f;
+
+    /// <summary>
+    /// Gets or sets the maximum distance from the vortex center where forces are applied.
     /// </summary>
     /// <remarks>
-    /// Particles will be attracted toward this point.
+    /// Particles beyond this radius are unaffected by the vortex. This distance also serves
+    /// as the reference point for force strength calculations, where particles at this exact
+    /// distance experience the base <see cref="Strength"/> value.
     /// </remarks>
-    public Vector2 Position;
+    public float OuterRadius { get; set; } = 300.0f;
 
     /// <summary>
-    /// Gets or sets the mass of the vortex center.
+    /// Gets or sets the minimum distance from the vortex center where forces are applied.
     /// </summary>
     /// <remarks>
-    /// Higher mass values create stronger attraction forces.
+    /// Creates a dead zone around the vortex center where particles are unaffected.
+    /// Prevents extreme force magnitudes and simulation instability when particles
+    /// get very close to the center point.
     /// </remarks>
-    public float Mass;
+    public float InnerRadius { get; set; } = 10.0f;
 
     /// <summary>
-    /// Gets or sets the maximum speed that the vortex can impart on particles.
+    /// Gets or sets the maximum velocity magnitude that particles can reach under vortex influence.
+    /// </summary>
+    /// <value>The speed limit in units per second.</value>
+    /// <remarks>
+    /// Particle velocities are clamped to this magnitude after vortex forces are applied.
+    /// Prevents runaway acceleration and maintains visual stability when particles
+    /// accumulate high velocities through repeated vortex acceleration.
+    /// </remarks>
+    public float MaxVelocity = 300.0f;
+
+    /// <summary>
+    /// Gets or sets the rotation angle, in radians, applied to gravitational force vectors.
     /// </summary>
     /// <remarks>
-    /// This value limits how quickly particles can be accelerated by the vortex,
-    /// preventing extreme velocities when particles get very close to the center.
+    /// This angle determines the motion pattern created by the vortex
+    /// <list type="table">
+    /// <listheader><term>Angle</term><description>description</description></listheader>
+    /// <item><term>0°</term><description>Pure gravitational attraction (particles pulled straight inward)</description></item>
+    /// <item><term>Small angles (5-20°)</term><description>Inward spirals and temporary orbital motion</description></item>
+    /// <item><term>Medium angles (30-60°)</term><description>Wide deflection arcs around the vortex</description></item>
+    /// <item><term>Large angles (90°+)</term><description>Particles to deflect around the vortex perimeter without entering</description></item>
+    /// </list>
+    /// Positive values create counterclockwise rotation, where as negative values create clockwise rotation.
     /// </remarks>
-    public float MaxSpeed;
+    public float RotationAngle
+    {
+        get => _rotationAngle;
+        set
+        {
+            if (_rotationAngle == value)
+            {
+                return;
+            }
+
+            _rotationAngle = value;
+
+            // Precalculate cos and sin angle so we're not doing it each
+            // modifier loop.
+            _cosAngle = MathF.Cos(_rotationAngle);
+            _sinAngle = MathF.Sin(_rotationAngle);
+        }
+    }
 
     /// <summary>
-    /// Updates all particles by applying a gravitational force towards the vortex center.
+    /// Initializes a new instance of the <see cref="VortexModifier"/> class.
     /// </summary>
-    /// <inheritdoc/>
+    public VortexModifier()
+    {
+        RotationAngle = 45.0f;
+    }
+
+    /// <inheritdoc />
     protected internal override unsafe void Update(float elapsedSeconds, ParticleIterator iterator, int particleCount)
     {
-        if (!Enabled) { return; }
+        if (!Enabled) return;
 
         for (int i = 0; i < particleCount && iterator.HasNext; i++)
         {
             Particle* particle = iterator.Next();
 
-            float distx = Position.X - particle->Position[0];
-            float disty = Position.Y - particle->Position[1];
+            float vortexX = particle->TriggeredPos[0] + Position.X;
+            float vortexY = particle->TriggeredPos[1] + Position.Y;
 
-            float distance2 = (distx * distx) + (disty * disty);
-            float distance = (float)Math.Sqrt(distance2);
+            float dx = particle->Position[0] - vortexX;
+            float dy = particle->Position[1] - vortexY;
+            float distance = MathF.Sqrt(dx * dx + dy * dy);
 
-            float m = (GRAVITY * Mass * particle->Mass) / distance2;
-            m = Math.Max(Math.Min(m, MaxSpeed), -MaxSpeed) * elapsedSeconds;
+            if (distance < InnerRadius || distance > OuterRadius)
+            {
+                continue;
+            }
 
-            distx = (distx / distance) * m;
-            disty = (disty / distance) * m;
+            float gravityX = -dx / distance;
+            float gravityY = -dy / distance;
 
-            particle->Velocity[0] += distx;
-            particle->Velocity[1] += disty;
+            float rotatedX = gravityX * _cosAngle - gravityY * _sinAngle;
+            float rotatedY = gravityX * _sinAngle + gravityY * _cosAngle;
+
+            // Strength is the force applied at the outer edge
+            // Closer particles get proportionally stronger force
+            float distanceRatio = OuterRadius / distance;
+            float forceStrength = Strength * distanceRatio;
+
+            particle->Velocity[0] += rotatedX * forceStrength * elapsedSeconds;
+            particle->Velocity[1] += rotatedY * forceStrength * elapsedSeconds;
+
+            // Clamp total velocity to max speed
+            float velocityMagnitude = MathF.Sqrt(particle->Velocity[0] * particle->Velocity[0] +
+                                               particle->Velocity[1] * particle->Velocity[1]);
+
+            if (velocityMagnitude > MaxVelocity)
+            {
+                float scale = MaxVelocity / velocityMagnitude;
+                particle->Velocity[0] *= scale;
+                particle->Velocity[1] *= scale;
+            }
         }
     }
 }

--- a/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
@@ -559,8 +559,12 @@ public sealed class ParticleEffectReader : IDisposable
     private Modifier ReadVortexModifier(XmlReader reader)
     {
         VortexModifier modifier = new VortexModifier();
-        modifier.Mass = reader.GetAttributeFloat(nameof(VortexModifier.Mass));
-        modifier.MaxSpeed = reader.GetAttributeFloat(nameof(VortexModifier.MaxSpeed));
+        modifier.Position = reader.GetAttributeVector2(nameof(VortexModifier.Position));
+        modifier.Strength = reader.GetAttributeFloat(nameof(VortexModifier.Strength));
+        modifier.OuterRadius = reader.GetAttributeFloat(nameof(VortexModifier.OuterRadius));
+        modifier.InnerRadius = reader.GetAttributeFloat(nameof(VortexModifier.InnerRadius));
+        modifier.MaxVelocity = reader.GetAttributeFloat(nameof(VortexModifier.MaxVelocity));
+        modifier.RotationAngle = reader.GetAttributeFloat(nameof(VortexModifier.RotationAngle));
         return modifier;
     }
 

--- a/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
@@ -372,8 +372,11 @@ public class ParticleEffectWriter : IDisposable
             case VortexModifier vortexModifier:
                 _writer.WriteAttributeString(nameof(Type), nameof(VortexModifier));
                 _writer.WriteAttributeVector2(nameof(VortexModifier.Position), vortexModifier.Position);
-                _writer.WriteAttributeFloat(nameof(VortexModifier.Mass), vortexModifier.Mass);
-                _writer.WriteAttributeFloat(nameof(VortexModifier.MaxSpeed), vortexModifier.MaxSpeed);
+                _writer.WriteAttributeFloat(nameof(VortexModifier.Strength), vortexModifier.Strength);
+                _writer.WriteAttributeFloat(nameof(VortexModifier.OuterRadius), vortexModifier.OuterRadius);
+                _writer.WriteAttributeFloat(nameof(VortexModifier.InnerRadius), vortexModifier.InnerRadius);
+                _writer.WriteAttributeFloat(nameof(VortexModifier.MaxVelocity), vortexModifier.MaxVelocity);
+                _writer.WriteAttributeFloat(nameof(VortexModifier.RotationAngle), vortexModifier.RotationAngle);
                 break;
 
             default:

--- a/tests/MonoGame.Extended.Tests/Particles/ParticleEffectReaderTests.cs
+++ b/tests/MonoGame.Extended.Tests/Particles/ParticleEffectReaderTests.cs
@@ -840,7 +840,7 @@ public class ParticleEffectReaderTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="VortexModifier" Frequency="60" Type="VortexModifier" Position="0,0" Mass="0" MaxSpeed="0" />
+                    <Modifier Name="VortexModifier" Frequency="60" Type="VortexModifier" Position="0,0" Strength="1" OuterRadius="2" InnerRadius="3" MaxVelocity="4" RotationAngle="5" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -858,8 +858,11 @@ public class ParticleEffectReaderTests
         Assert.Equal(60.0f, modifier.Frequency);
         Assert.Equal("VortexModifier", modifier.Name);
         Assert.Equal(Vector2.Zero, modifier.Position);
-        Assert.Equal(0.0f, modifier.Mass);
-        Assert.Equal(0.0f, modifier.MaxSpeed);
+        Assert.Equal(1.0f, modifier.Strength);
+        Assert.Equal(2.0f, modifier.OuterRadius);
+        Assert.Equal(3.0f, modifier.InnerRadius);
+        Assert.Equal(4.0f, modifier.MaxVelocity);
+        Assert.Equal(5.0f, modifier.RotationAngle);
     }
 
     [Fact]

--- a/tests/MonoGame.Extended.Tests/Particles/ParticleEffectWriterTests.cs
+++ b/tests/MonoGame.Extended.Tests/Particles/ParticleEffectWriterTests.cs
@@ -797,7 +797,7 @@ public class ParticleEffectWriterTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="VortexModifier" Frequency="60" Type="VortexModifier" Position="0,0" Mass="0" MaxSpeed="0" />
+                    <Modifier Name="VortexModifier" Frequency="60" Type="VortexModifier" Position="0,0" Strength="0" OuterRadius="0" InnerRadius="0" MaxVelocity="0" RotationAngle="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>


### PR DESCRIPTION
## Description

The original vortex modifier implementation did not actually create vortexes, instead it acted as a gravity well, or attractor.  This updates it to simulate vortex physics.

## Related Issues/Tickets

- None

## Changes Made

Modified the vortex modifier to simulate vortex physics

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
