### PR TITLE
Add `Interval<T>` struct to replace `Range<T>`

### DIFF
--- a/source/MonoGame.Extended/Math/FastRandom.cs
+++ b/source/MonoGame.Extended/Math/FastRandom.cs
@@ -104,9 +104,25 @@ namespace MonoGame.Extended
         /// A 32-bit signed integer that is greater than or equal to the <see cref="Range{T}.Min"/> and less than or
         /// equal to the <see cref="Range{T}.Max"/> value of <paramref name="range"/>.
         /// </returns>
+        [Obsolete("Use Next(Interval<int>).  Range<T> will be removed in 6.0")]
         public int Next(Range<int> range)
         {
             return _impl.Next(range);
+        }
+
+        /// <summary>
+        /// Returns a random integer that is within a closed interval.
+        /// </summary>
+        /// <param name="interval">
+        /// A closed interval representing the lower and upper bounds of the random number to return.
+        /// </param>
+        /// <returns>
+        /// A 32-bit signed integer that is greater than or equal to the <see cref="Interval{T}.Min"/> value and less
+        /// than or equal to the <see cref="Interval{T}.Max"/> value of <paramref name="interval"/>.
+        /// </returns>
+        public int Next(Interval<int> interval)
+        {
+            return _impl.Next(interval);
         }
 
         /// <summary>
@@ -158,9 +174,25 @@ namespace MonoGame.Extended
         /// A single-precision floating point number that is greater than or equal to the <see cref="Range{T}.Min"/>
         /// and less than the <see cref="Range{T}.Max"/> value of <paramref name="range"/>
         /// </returns>
+        [Obsolete("Use Next(Interval<float>).  Range<T> will be removed in 6.0")]
         public float NextSingle(Range<float> range)
         {
             return _impl.NextSingle(range);
+        }
+
+        /// <summary>
+        /// Returns a random floating-point number that is within a closed interval.
+        /// </summary>
+        /// <param name="interval">
+        /// A closed interval representing the lower and upper bounds of the random number to return.
+        /// </param>
+        /// <returns>
+        /// A single-precision floating point number that is greater than or equal to the <see cref="Interval{T}.Min"/>
+        /// value and less than or equal to the <see cref="Interval{T}.Max"/> value of <paramref name="interval"/>.
+        /// </returns>
+        public float NextSingle(Interval<float> interval)
+        {
+            return _impl.NextSingle(interval);
         }
 
         /// <summary>
@@ -198,11 +230,15 @@ namespace MonoGame.Extended
             int Next();
             int Next(int max);
             int Next(int min, int max);
+            [Obsolete("Use Next(Interval<int>).  Range<T> will be removed in 6.0")]
             int Next(Range<int> range);
+            int Next(Interval<int> interval);
             float NextSingle();
             float NextSingle(float max);
             float NextSingle(float min, float max);
+            [Obsolete("Use Next(Interval<float>).  Range<T> will be removed in 6.0")]
             float NextSingle(Range<float> range);
+            float NextSingle(Interval<float> interval);
             float NextAngle();
             void NextUnitVector(out Vector2 vector);
             unsafe void NextUnitVector(Vector2* vector);
@@ -244,9 +280,15 @@ namespace MonoGame.Extended
                 return (int)((max - min) * NextSingle() + 0.5f) + min;
             }
 
+            [Obsolete("Use Next(Interval<int>).  Range<T> will be removed in 6.0")]
             public int Next(Range<int> range)
             {
                 return Next(range.Min, range.Max);
+            }
+
+            public int Next(Interval<int> interval)
+            {
+                return Next(interval.Min, interval.Max);
             }
 
             public float NextSingle()
@@ -264,9 +306,15 @@ namespace MonoGame.Extended
                 return (max - min) * NextSingle() + min;
             }
 
+            [Obsolete("Use Next(Interval<float>).  Range<T> will be removed in 6.0")]
             public float NextSingle(Range<float> range)
             {
                 return NextSingle(range.Min, range.Max);
+            }
+
+            public float NextSingle(Interval<float> interval)
+            {
+                return NextSingle(interval.Min, interval.Max);
             }
 
             public float NextAngle()
@@ -320,10 +368,17 @@ namespace MonoGame.Extended
                 return LocalRandom.Next(min, max);
             }
 
+            [Obsolete("Use Next(Interval<int>).  Range<T> will be removed in 6.0")]
             public int Next(Range<int> range)
             {
                 return LocalRandom.Next(range.Min, range.Max);
             }
+
+            public int Next(Interval<int> interval)
+            {
+                return LocalRandom.Next(interval.Min, interval.Max);
+            }
+
             public float NextSingle()
             {
                 return LocalRandom.NextSingle();
@@ -339,9 +394,15 @@ namespace MonoGame.Extended
                 return LocalRandom.NextSingle(min, max);
             }
 
+            [Obsolete("Use Next(Interval<float>).  Range<T> will be removed in 6.0")]
             public float NextSingle(Range<float> range)
             {
                 return LocalRandom.NextSingle(range.Min, range.Max);
+            }
+
+            public float NextSingle(Interval<float> interval)
+            {
+                return LocalRandom.NextSingle(interval.Min, interval.Max);
             }
 
             public float NextAngle()

--- a/source/MonoGame.Extended/Math/Interval.cs
+++ b/source/MonoGame.Extended/Math/Interval.cs
@@ -1,0 +1,262 @@
+using System;
+
+namespace MonoGame.Extended;
+
+/// <summary>
+/// Represents a closed mathematical interval [Min, Max] defined by comparable bounds.
+/// </summary>
+/// <typeparam name="T">
+/// The type of values contained in the interval.
+/// </typeparam>
+public readonly struct Interval<T> : IEquatable<Interval<T>> where T : IComparable<T>
+{
+    private readonly T _min;
+    private readonly T _max;
+
+    /// <summary>
+    /// Gets the minimum bound of the interval.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the interval is empty.</exception>
+    public T Min
+    {
+        get
+        {
+            if (IsEmpty)
+            {
+                throw new InvalidOperationException("Cannot access bounds of an empty interval");
+            }
+            return _min;
+        }
+    }
+
+    /// <summary>
+    /// Gets the maximum bound of the interval.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the interval is empty.</exception>
+    public T Max
+    {
+        get
+        {
+            if (IsEmpty)
+            {
+                throw new InvalidOperationException("Cannot access bounds of an empty interval");
+            }
+            return _max;
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the interval contains no values.
+    /// </summary>
+    public bool IsEmpty { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the interval contains exactly one value.
+    /// </summary>
+    public bool IsDegenerate => !IsEmpty && _min.Equals(_max);
+
+    /// <summary>
+    /// Gets a value indicating whether the interval contains more than one value.
+    /// </summary>
+    public bool IsProper => !IsEmpty && !_min.Equals(_max);
+
+    /// <summary>
+    /// Gets an empty interval.
+    /// </summary>
+    public static Interval<T> Empty => new(true);
+
+    /// <summary>
+    /// Initializes an interval with the specified bounds.
+    /// </summary>
+    /// <param name="min">The minimum bound of the interval.</param>
+    /// <param name="max">The maximum bound of the interval.</param>
+    /// <exception cref="ArgumentException">Thrown when min is greater than max.</exception>
+    public Interval(T min, T max)
+    {
+        if (min.CompareTo(max) > 0)
+        {
+            throw new ArgumentException("Minimum bounds cannot be greater than maximum bounds");
+        }
+
+        _min = min;
+        _max = max;
+        IsEmpty = false;
+    }
+
+    /// <summary>
+    /// Initializes a degenerate interval containing only the specified value.
+    /// </summary>
+    /// <param name="value">The single value to be contained in the interval.</param>
+    public Interval(T value) : this(value, value) { }
+
+    private Interval(bool isEmpty)
+    {
+        _min = default;
+        _max = default;
+        IsEmpty = true;
+    }
+
+    /// <summary>
+    /// Determines whether the interval contains the specified value.
+    /// </summary>
+    /// <param name="value">The value to test for containment.</param>
+    /// <returns>true if the value is within the interval bounds; otherwise, false.</returns>
+    public bool Contains(T value)
+    {
+        if (IsEmpty)
+        {
+            return false;
+        }
+
+        return value.CompareTo(_min) >= 0 && value.CompareTo(_max) <= 0;
+    }
+
+    /// <summary>
+    /// Determines whether this interval completely contains another interval.
+    /// </summary>
+    /// <param name="other">The interval to test for containment.</param>
+    /// <returns>true if this interval completely contains the other interval; otherwise, false.</returns>
+    public bool Contains(Interval<T> other)
+    {
+        if (other.IsEmpty)
+        {
+            return true;
+        }
+
+        if (IsEmpty)
+        {
+            return false;
+        }
+
+        return _min.CompareTo(other._min) <= 0 && _max.CompareTo(other._max) >= 0;
+    }
+
+    /// <summary>
+    /// Determines whether this interval shares any values with another interval.
+    /// </summary>
+    /// <param name="other">The interval to test for overlap.</param>
+    /// <returns>true if the intervals have any values in common; otherwise, false.</returns>
+    public bool Overlap(Interval<T> other)
+    {
+        if (IsEmpty || other.IsEmpty)
+        {
+            return false;
+        }
+
+        return _min.CompareTo(other._max) <= 0 && _max.CompareTo(other._min) >= 0;
+    }
+
+    /// <summary>
+    /// Computes the intersection of this interval with another interval.
+    /// </summary>
+    /// <param name="other">The interval to intersect with.</param>
+    /// <returns>An interval containing only values present in both intervals, or empty if no intersection exists.</returns>
+    public Interval<T> Intersect(Interval<T> other)
+    {
+        if (IsEmpty || other.IsEmpty || !Overlap(other))
+        {
+            return Empty;
+        }
+
+        T minBound = _min.CompareTo(other._min) >= 0 ? _min : other._min;
+        T maxBound = _max.CompareTo(other._max) <= 0 ? _max : other._max;
+
+        return new Interval<T>(minBound, maxBound);
+    }
+
+    /// <summary>
+    /// Computes the smallest interval containing both this interval and another interval.
+    /// </summary>
+    /// <param name="other">The interval to compute the hull with.</param>
+    /// <returns>The smallest interval that contains both intervals.</returns>
+    public Interval<T> Hull(Interval<T> other)
+    {
+        if (IsEmpty)
+        {
+            return other;
+        }
+
+        if (other.IsEmpty)
+        {
+            return this;
+        }
+
+        T minBound = _min.CompareTo(other._min) <= 0 ? _min : other._min;
+        T maxBound = _max.CompareTo(other._max) >= 0 ? _max : other._max;
+
+        return new Interval<T>(minBound, maxBound);
+    }
+
+    /// <summary>
+    /// Creates an interval that spans both specified values.
+    /// </summary>
+    /// <param name="a">The first value.</param>
+    /// <param name="b">The second value.</param>
+    /// <returns>An interval from the minimum to maximum of the two values.</returns>
+    public static Interval<T> Hull(T a, T b)
+    {
+        if (a.CompareTo(b) <= 0)
+        {
+            return new Interval<T>(a, b);
+        }
+        else
+        {
+            return new Interval<T>(b, a);
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object obj) => obj is Interval<T> other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(Interval<T> other)
+    {
+        if (IsEmpty && other.IsEmpty)
+        {
+            return true;
+        }
+
+        if (IsEmpty && !other.IsEmpty)
+        {
+            return false;
+        }
+
+        return _min.Equals(other._min) && _max.Equals(other._max);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        if (IsEmpty)
+        {
+            return 0;
+        }
+
+        return HashCode.Combine(_min, _max);
+    }
+
+    /// <inheritdoc />
+    public static bool operator ==(Interval<T> left, Interval<T> right) => left.Equals(right);
+
+    /// <inheritdoc />
+    public static bool operator !=(Interval<T> left, Interval<T> right) => !left.Equals(right);
+
+    /// <inheritdoc />
+    public static implicit operator Interval<T>(T value) => new(value);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        if (IsEmpty)
+        {
+            return "∅";
+        }
+
+        if (IsDegenerate)
+        {
+            return $"[{_min}]";
+        }
+
+        return $"[{_min}, {_max}]";
+    }
+}

--- a/source/MonoGame.Extended/Math/RandomExtensions.cs
+++ b/source/MonoGame.Extended/Math/RandomExtensions.cs
@@ -5,29 +5,41 @@ namespace MonoGame.Extended
 {
     public static class RandomExtensions
     {
+        [Obsolete("Use Next(Random, Interval<int>).  Range<T> will be removed in 6.0")]
         public static int Next(this Random random, Range<int> range)
         {
             return random.Next(range.Min, range.Max);
         }
 
+        public static int Next(this Random random, Interval<int> interval)
+        {
+            return random.Next(interval.Min, interval.Max);
+        }
+
         public static float NextSingle(this Random random, float min, float max)
         {
-            return (max - min)*NextSingle(random) + min;
+            return (max - min) * NextSingle(random) + min;
         }
 
         public static float NextSingle(this Random random, float max)
         {
-            return max*NextSingle(random);
+            return max * NextSingle(random);
         }
 
         public static float NextSingle(this Random random)
         {
-            return (float) random.NextDouble();
+            return (float)random.NextDouble();
         }
 
+        [Obsolete("Use Next(Random, Interval<float>).  Range<T> will be removed in 6.0")]
         public static float NextSingle(this Random random, Range<float> range)
         {
             return NextSingle(random, range.Min, range.Max);
+        }
+
+        public static float NextSingle(this Random random, Interval<float> interval)
+        {
+            return NextSingle(random, interval.Min, interval.Max);
         }
 
         public static float NextAngle(this Random random)
@@ -38,7 +50,7 @@ namespace MonoGame.Extended
         public static void NextUnitVector(this Random random, out Vector2 vector)
         {
             var angle = NextAngle(random);
-            vector = new Vector2((float) Math.Cos(angle), (float) Math.Sin(angle));
+            vector = new Vector2((float)Math.Cos(angle), (float)Math.Sin(angle));
         }
     }
 }

--- a/source/MonoGame.Extended/Math/Range.cs
+++ b/source/MonoGame.Extended/Math/Range.cs
@@ -5,6 +5,7 @@ namespace MonoGame.Extended
     /// <summary>
     ///     Represents a closed interval defined by a minimum and a maximum value of a give type.
     /// </summary>
+    [Obsolete("Use new Interval<T> struct.  Range<T> will be removed in 6.0")]
     public struct Range<T> : IEquatable<Range<T>> where T : IComparable<T>
     {
         public Range(T min, T max)

--- a/source/MonoGame.Extended/Serialization/Json/IntervalJsonConverter.cs
+++ b/source/MonoGame.Extended/Serialization/Json/IntervalJsonConverter.cs
@@ -5,16 +5,15 @@ using System.Text.Json.Serialization;
 namespace MonoGame.Extended.Serialization.Json;
 
 /// <summary>
-/// Converts a <see cref="Range{T}"/> value to or from JSON.
+/// Converts a <see cref="Interval{T}"/> value to or from JSON.
 /// </summary>
-[Obsolete("Use IntervalJsonConverter<T>.  Range<T> will be removed in 6.0")]
-public class RangeJsonConverter<T> : JsonConverter<Range<T>> where T : IComparable<T>
+public class IntervalJsonConverter<T> : JsonConverter<Interval<T>> where T : IComparable<T>
 {
     /// <inheritdoc />
-    public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(Range<T>);
+    public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(Interval<T>);
 
     /// <inheritdoc />
-    public override Range<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override Interval<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         Span<T> values = reader.ReadAsMultiDimensional<T>(options);
 
@@ -22,25 +21,25 @@ public class RangeJsonConverter<T> : JsonConverter<Range<T>> where T : IComparab
         {
             if (values[0].CompareTo(values[1]) < 0)
             {
-                return new Range<T>(values[0], values[1]);
+                return new Interval<T>(values[0], values[1]);
             }
 
-            return new Range<T>(values[1], values[0]);
+            return new Interval<T>(values[1], values[0]);
         }
 
         if (values.Length == 1)
         {
-            return new Range<T>(values[0], values[0]);
+            return new Interval<T>(values[0], values[0]);
         }
 
-        throw new InvalidOperationException("Invalid range");
+        throw new InvalidOperationException("Invalid interval");
     }
 
     /// <inheritdoc />
     /// <exception cref="ArgumentNullException">
     /// Throw if <paramref name="writer"/> is <see langword="null"/>.
     /// </exception>
-    public override void Write(Utf8JsonWriter writer, Range<T> value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, Interval<T> value, JsonSerializerOptions options)
     {
         ArgumentNullException.ThrowIfNull(writer);
         writer.WriteStartArray();

--- a/source/MonoGame.Extended/Serialization/Json/MonoGameJsonSerializerOptionsProvider.cs
+++ b/source/MonoGame.Extended/Serialization/Json/MonoGameJsonSerializerOptionsProvider.cs
@@ -15,9 +15,15 @@ public static class MonoGameJsonSerializerOptionsProvider
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
 
+        // TODO: 6.0
+        // Remove RangeJsonConverter usage
+
         options.Converters.Add(new RangeJsonConverter<int>());
         options.Converters.Add(new RangeJsonConverter<float>());
         options.Converters.Add(new RangeJsonConverter<HslColor>());
+        options.Converters.Add(new IntervalJsonConverter<int>());
+        options.Converters.Add(new IntervalJsonConverter<float>());
+        options.Converters.Add(new IntervalJsonConverter<HslColor>());
         options.Converters.Add(new ThicknessJsonConverter());
         options.Converters.Add(new RectangleFJsonConverter());
         options.Converters.Add(new TextureAtlasJsonConverter(contentManager, contentPath));

--- a/tests/MonoGame.Extended.Tests/Math/IntervalTests.cs
+++ b/tests/MonoGame.Extended.Tests/Math/IntervalTests.cs
@@ -1,0 +1,342 @@
+using System;
+using Xunit;
+
+namespace MonoGame.Extended.Tests;
+
+public class IntervalTests
+{
+    [Fact]
+    public void Constructor_WithMinLessThanMax_CreatesProperInterval()
+    {
+        Interval<int> interval = new(10, 20);
+
+        Assert.Equal(10, interval.Min);
+        Assert.Equal(20, interval.Max);
+        Assert.True(interval.IsProper);
+        Assert.False(interval.IsDegenerate);
+        Assert.False(interval.IsEmpty);
+    }
+
+    [Fact]
+    public void Constructor_WithEqualBounds_CreatesDegenerateInterval()
+    {
+        Interval<int> interval = new(10, 10);
+
+        Assert.Equal(10, interval.Min);
+        Assert.Equal(10, interval.Max);
+        Assert.False(interval.IsProper);
+        Assert.True(interval.IsDegenerate);
+        Assert.False(interval.IsEmpty);
+    }
+
+    [Fact]
+    public void Constructor_WithInvalidBounds_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new Interval<int>(20, 10));
+    }
+
+    [Fact]
+    public void Constructor_SingleValue_CreatesDegenerate()
+    {
+        Interval<int> interval = new(10);
+        Assert.Equal(10, interval.Min);
+        Assert.Equal(10, interval.Max);
+        Assert.True(interval.IsDegenerate);
+        Assert.False(interval.IsProper);
+        Assert.False(interval.IsEmpty);
+    }
+
+    [Fact]
+    public void Empty_CreatesEmptyInterval()
+    {
+        Interval<int> empty = Interval<int>.Empty;
+        Assert.True(empty.IsEmpty);
+        Assert.False(empty.IsDegenerate);
+        Assert.False(empty.IsProper);
+    }
+
+    [Fact]
+    public void Empty_AccessingBounds_ThrowsInvalidOperationException()
+    {
+        Interval<int> empty = Interval<int>.Empty;
+
+        Assert.Throws<InvalidOperationException>(() => empty.Min);
+        Assert.Throws<InvalidOperationException>(() => empty.Max);
+    }
+
+    [Fact]
+    public void Contains_Value_ReturnsTrueForBoundaryAndInteriorValues()
+    {
+        Interval<int> interval = new(10, 15);
+
+        for (int i = 10; i <= 15; i++)
+        {
+            Assert.True(interval.Contains(i));
+        }
+    }
+
+    [Fact]
+    public void Contains_Value_ReturnsFalseForValuesOutsideBounds()
+    {
+        Interval<int> interval = new(10, 20);
+
+        Assert.False(interval.Contains(9));
+        Assert.False(interval.Contains(21));
+    }
+
+    [Fact]
+    public void Contains_Value_EmptyInterval_ReturnsFalse()
+    {
+        Interval<int> empty = Interval<int>.Empty;
+        Assert.False(empty.Contains(10));
+    }
+
+    [Fact]
+    public void Contains_Interval_ReturnsTrueForCompletelyContainedInterval()
+    {
+        Interval<int> outer = new(10, 30);
+        Interval<int> inner = new(15, 25);
+
+        Assert.True(outer.Contains(inner));
+    }
+
+    [Fact]
+    public void Contains_Interval_ReturnsFalseForPartiallyOverlappingInterval()
+    {
+        Interval<int> interval = new(10, 20);
+        Interval<int> overlapping = new(15, 25);
+
+        Assert.False(interval.Contains(overlapping));
+    }
+
+    [Fact]
+    public void Contains_Interval_ReturnsFalseForSeparateInterval()
+    {
+        Interval<int> interval = new(10, 20);
+        Interval<int> separate = new(30, 40);
+
+        Assert.False(interval.Contains(separate));
+    }
+
+    [Fact]
+    public void Contains_EmptyInterval_ReturnsTrue()
+    {
+        Interval<int> interval = new(10, 20);
+        Interval<int> empty = Interval<int>.Empty;
+
+        Assert.True(interval.Contains(empty));
+        Assert.True(empty.Contains(empty));
+    }
+
+    [Fact]
+    public void Contains_Self_ReturnsTrue()
+    {
+        Interval<int> interval = new(10, 20);
+
+        Assert.True(interval.Contains(interval));
+    }
+
+    [Fact]
+    public void Overlap_ReturnsTrueForOverlappingIntervals()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> b = new(15, 25);
+
+        Assert.True(a.Overlap(b));
+        Assert.True(b.Overlap(a));
+    }
+
+    [Fact]
+    public void Overlap_ReturnsFalseForSeparateIntervals()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> c = new(30, 40);
+
+        Assert.False(a.Overlap(c));
+        Assert.False(c.Overlap(a));
+    }
+
+    [Fact]
+    public void Overlap_ReturnsTrueForIntervalsTouchingAtBoundary()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> d = new(20, 30);
+
+        Assert.True(a.Overlap(d));
+    }
+
+    [Fact]
+    public void Overlap_WithEmptyInterval_ReturnsFalse()
+    {
+        Interval<int> interval = new(10, 20);
+        Interval<int> empty = Interval<int>.Empty;
+
+        Assert.False(interval.Overlap(empty));
+        Assert.False(empty.Overlap(empty));
+    }
+
+    [Fact]
+    public void Overlap_Self_ReturnsTrue()
+    {
+        Interval<int> interval = new(10, 20);
+
+        Assert.True(interval.Overlap(interval));
+    }
+
+    [Fact]
+    public void Intersect_OverlappingIntervals_ReturnsCorrectBounds()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> b = new(15, 25);
+        Interval<int> intersection = a.Intersect(b);
+
+        Assert.Equal(15, intersection.Min);
+        Assert.Equal(20, intersection.Max);
+    }
+
+    [Fact]
+    public void Intersect_NoOverlap_ReturnsEmpty()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> b = new(30, 40);
+
+        Assert.True(a.Intersect(b).IsEmpty);
+    }
+
+    [Fact]
+    public void Intersect_WithEmptyInterval_ReturnsEmpty()
+    {
+        Interval<int> interval = new(10, 20);
+        Interval<int> empty = Interval<int>.Empty;
+
+        Assert.True(interval.Intersect(empty).IsEmpty);
+        Assert.True(empty.Intersect(empty).IsEmpty);
+    }
+
+    [Fact]
+    public void Intersect_Self_ReturnsOriginalInterval()
+    {
+        Interval<int> interval = new(10, 20);
+
+        Assert.Equal(interval, interval.Intersect(interval));
+    }
+
+    [Fact]
+    public void Hull_SeparateIntervals_ReturnsSpanningInterval()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> b = new(30, 40);
+        Interval<int> hull = a.Hull(b);
+
+        Assert.Equal(10, hull.Min);
+        Assert.Equal(40, hull.Max);
+    }
+
+    [Fact]
+    public void Hull_WithEmptyInterval_ReturnsNonEmptyInterval()
+    {
+        Interval<int> interval = new(10, 20);
+        Interval<int> empty = Interval<int>.Empty;
+
+        Assert.Equal(interval, interval.Hull(empty));
+        Assert.Equal(interval, empty.Hull(interval));
+        Assert.True(empty.Hull(empty).IsEmpty);
+    }
+
+    [Fact]
+    public void Hull_Self_ReturnsOriginalInterval()
+    {
+        Interval<int> interval = new(10, 20);
+
+        Assert.Equal(interval, interval.Hull(interval));
+    }
+
+    [Fact]
+    public void Hull_StaticMethod_HandlesParameterOrderCorrectly()
+    {
+        Interval<int> hull1 = Interval<int>.Hull(20, 10);
+        Interval<int> hull2 = Interval<int>.Hull(10, 20);
+
+        Assert.Equal(10, hull1.Min);
+        Assert.Equal(20, hull1.Max);
+        Assert.Equal(hull1, hull2);
+    }
+
+    [Fact]
+    public void Equality_SameIntervals_ReturnsTrue()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> b = new(10, 20);
+
+        Assert.True(a == b);
+        Assert.True(a.Equals(b));
+        Assert.False(a != b);
+    }
+
+    [Fact]
+    public void Equality_DifferentIntervals_ReturnsFalse()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> c = new(20, 30);
+
+        Assert.False(a == c);
+        Assert.False(a.Equals(c));
+        Assert.True(a != c);
+    }
+
+    [Fact]
+    public void Equality_EmptyIntervals_ReturnsTrue()
+    {
+        Interval<int> empty1 = Interval<int>.Empty;
+        Interval<int> empty2 = Interval<int>.Empty;
+
+        Assert.True(empty1 == empty2);
+        Assert.True(empty1.Equals(empty2));
+    }
+
+    [Fact]
+    public void Equality_EmptyVsNonEmpty_ReturnsFalse()
+    {
+        Interval<int> interval = new(10, 20);
+        Interval<int> empty = Interval<int>.Empty;
+
+        Assert.False(interval == empty);
+        Assert.True(interval != empty);
+    }
+
+    [Fact]
+    public void GetHashCode_EqualIntervals_ReturnsSameHashCode()
+    {
+        Interval<int> a = new(10, 20);
+        Interval<int> b = new(10, 20);
+
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromValue_CreatesDegenerate()
+    {
+        Interval<int> interval = 10;
+
+        Assert.Equal(10, interval.Min);
+        Assert.Equal(10, interval.Max);
+        Assert.True(interval.IsDegenerate);
+    }
+
+    [Fact]
+    public void ToString_ShowsCorrectFormat()
+    {
+        Assert.Equal("[10, 20]", new Interval<int>(10, 20).ToString());
+        Assert.Equal("[10]", new Interval<int>(10).ToString());
+        Assert.Equal("∅", Interval<int>.Empty.ToString());
+    }
+
+    [Fact]
+    public void StringInterval_WorksWithComparable()
+    {
+        Interval<string> interval = new("apple", "zebra");
+
+        Assert.True(interval.Contains("banana"));
+        Assert.False(interval.Contains("aardvark"));
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces a new `Interval<T>` struct that replaces the existing `Range<T>` struct with a mathematically complete interval implementation based on mathematical interval theory.  

## Related Issues/Tickets

* None

## Changes Made

* Add `Interval<T>` struct
* Marked `Range<T>` as obsolete
* Updated existing code that uses `Range<T>` to have their methods marked obsolete with `Interval<T>` implementations to use
* Add unit tests for `Interval<T>`

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
