### PR TITLE
ShapeExtensions: Add defensive check for IsDiposed when getting texture

### DIFF
--- a/source/MonoGame.Extended/Math/ShapeExtensions.cs
+++ b/source/MonoGame.Extended/Math/ShapeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -15,7 +15,7 @@ namespace MonoGame.Extended
 
         private static Texture2D GetTexture(SpriteBatch spriteBatch)
         {
-            if (_whitePixelTexture == null)
+            if (_whitePixelTexture == null || _whitePixelTexture.IsDisposed)
             {
                 _whitePixelTexture = new Texture2D(spriteBatch.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
                 _whitePixelTexture.SetData(new[] { Color.White });


### PR DESCRIPTION
## Description

Added additional condition to check if the `_whitePixelTexture` has been disposed of before reusing.  This prevents `ObjectDisposedExceptions` from occurring when using the texture.  An `ObjectDisposedException` can occur in the rare event of a `GraphicsDeviceReset` event trigger.  Additionally on Android, if the application is placed in the background for too long, the android activity may stop but the application will still be running.  If this occurs, when switching back to the application, the texture may be disposed of.

## Related Issues/Tickets

* Closes #769 

## Changes Made

* Added check for `_whitePixelTexture.IsDisposed` along with the `null` check in `GetTexture`

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
