### PR TITLE
Feature/static particle serializer

### DIFF
--- a/source/MonoGame.Extended/Content/ContentReaders/ParticleEffectContentReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/ParticleEffectContentReader.cs
@@ -13,7 +13,6 @@ public sealed class ParticleEffectContentReader : ContentTypeReader<ParticleEffe
 
         byte[] xmlBytes = Encoding.UTF8.GetBytes(xmlContent);
         using Stream stream = new MemoryStream(xmlBytes);
-        using ParticleEffectReader reader = new ParticleEffectReader(stream, input.ContentManager);
-        return reader.ReadParticleEffect();
+        return ParticleEffectSerializer.Deserialize(stream, input.ContentManager);
     }
 }

--- a/source/MonoGame.Extended/Particles/ParticleEffect.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffect.cs
@@ -245,8 +245,7 @@ public class ParticleEffect : IDisposable
     /// <exception cref="ArgumentException"><paramref name="path"/> is <see langword="null"/> or empty.</exception>
     public static ParticleEffect FromFile(string path, ContentManager content)
     {
-        using ParticleEffectReader reader = new(path, content);
-        return reader.ReadParticleEffect();
+        return ParticleEffectSerializer.Deserialize(path, content);
     }
 
     /// <summary>
@@ -259,8 +258,7 @@ public class ParticleEffect : IDisposable
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> or <paramref name="content"/> is <see langword="null"/></exception>
     public static ParticleEffect FromStream(Stream stream, ContentManager content, string baseDirectory)
     {
-        using ParticleEffectReader reader = new(stream, content);
-        return reader.ReadParticleEffect();
+        return ParticleEffectSerializer.Deserialize(stream, content, baseDirectory);
     }
 
     /// <summary>

--- a/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
@@ -23,6 +23,7 @@ namespace MonoGame.Extended.Particles;
 /// <summary>
 /// Represents a reader that deserializes a <see cref="ParticleEffect"/> from an XML configuration.
 /// </summary>
+[Obsolete("Use ParticleEffectSerializer.Deserialize.  ParticleEffectReader will be removed in 6.0.0")]
 public sealed class ParticleEffectReader : IDisposable
 {
     private readonly XmlReader _reader;

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -1,0 +1,646 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.Graphics;
+using MonoGame.Extended.Particles.Data;
+using MonoGame.Extended.Particles.Modifiers;
+using MonoGame.Extended.Particles.Modifiers.Containers;
+using MonoGame.Extended.Particles.Modifiers.Interpolators;
+using MonoGame.Extended.Particles.Profiles;
+using MonoGame.Extended.Serialization.Xml;
+
+namespace MonoGame.Extended.Particles;
+
+/// <summary>
+/// Provides static methods for serializing and deserializing <see cref="ParticleEffect"/> instances to and from XML.
+/// </summary>
+public static class ParticleEffectSerializer
+{
+    /// <summary>
+    /// Deserializes a <see cref="ParticleEffect"/> from an XML file.
+    /// </summary>
+    /// <param name="fileName">The file path to read the XML from</param>
+    /// <param name="content">The <see cref="ContentManager"/> to use for loading texture.</param>
+    /// <returns>The deserialized <see cref="ParticleEffect"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="content"/> or <paramref name="fileName"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="fileName"/> is empty.</exception>
+    /// <exception cref="XmlException">Thrown when the XMl format is invalid.</exception>
+    public static ParticleEffect Deserialize(string fileName, ContentManager content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrEmpty(fileName);
+
+        XmlReaderSettings settings = new XmlReaderSettings();
+        settings.CloseInput = true;
+        settings.IgnoreComments = true;
+        settings.IgnoreWhitespace = true;
+
+        string fullPath = Path.GetFullPath(fileName);
+        string baseDirectory = Path.GetDirectoryName(fullPath);
+
+        using XmlReader reader = XmlReader.Create(fileName, settings);
+        return Deserialize(reader, content, baseDirectory);
+    }
+
+    /// <summary>
+    /// Deserializes a <see cref="ParticleEffect"/> from a stream containing XML data.
+    /// </summary>
+    /// <param name="stream">The stream to read from.</param>
+    /// <param name="content">The <see cref="ContentManager"/> to use for loading textures.</param>
+    /// <param name="baseDirectory">
+    /// The base directory to use for resolving relative texture paths.
+    /// If <see langword="null"/>, uses the <see cref="ContentManager.RootDirectory"/> property of <paramref name="content"/>.
+    /// </param>
+    /// <returns>The deserialized <see cref="ParticleEffect"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="stream"/> or <paramref name="content"/> are <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="XmlException">Thrown when the XMl format is invalid.</exception>
+    public static ParticleEffect Deserialize(Stream stream, ContentManager content, string baseDirectory = null)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(content);
+
+        XmlReaderSettings settings = new XmlReaderSettings();
+        settings.CloseInput = false;
+        settings.IgnoreComments = true;
+        settings.IgnoreWhitespace = true;
+
+        if (string.IsNullOrEmpty(baseDirectory))
+        {
+            baseDirectory = content.RootDirectory;
+        }
+
+        using XmlReader reader = XmlReader.Create(stream, settings);
+        return Deserialize(reader, content, baseDirectory);
+    }
+
+    private static ParticleEffect Deserialize(XmlReader reader, ContentManager content, string baseDirectory)
+    {
+        reader.MoveToContent();
+
+        if (reader.NodeType != XmlNodeType.Element || reader.LocalName != nameof(ParticleEffect))
+        {
+            throw new XmlException($"Expected {nameof(ParticleEffect)} root element");
+        }
+
+        string name = reader.GetAttribute(nameof(ParticleEffect.Name)) ?? nameof(ParticleEffect);
+        ParticleEffect effect = new ParticleEffect(name);
+
+        effect.Position = reader.GetAttributeVector2(nameof(ParticleEffect.Position));
+        effect.Rotation = reader.GetAttributeFloat(nameof(ParticleEffect.Rotation));
+        effect.Scale = reader.GetAttributeVector2(nameof(ParticleEffect.Scale));
+        effect.AutoTrigger = reader.GetAttributeBool(nameof(ParticleEffect.AutoTrigger));
+        effect.AutoTriggerFrequency = reader.GetAttributeFloat(nameof(ParticleEffect.AutoTriggerFrequency));
+
+        if (reader.ReadToDescendant(nameof(ParticleEffect.Emitters)))
+        {
+            if (reader.ReadToDescendant(nameof(ParticleEmitter)))
+            {
+                do
+                {
+                    ParticleEmitter emitter = ReadParticleEmitter(reader, content, baseDirectory);
+                    effect.Emitters.Add(emitter);
+                } while (reader.ReadToNextSibling(nameof(ParticleEmitter)));
+            }
+        }
+
+        return effect;
+    }
+
+    private static ParticleEmitter ReadParticleEmitter(XmlReader reader, ContentManager content, string baseDirectory)
+    {
+        int capacity = reader.GetAttributeInt(nameof(ParticleEmitter.Capacity));
+
+        ParticleEmitter emitter = new ParticleEmitter(capacity);
+        emitter.Name = reader.GetAttribute(nameof(ParticleEmitter.Name)) ?? nameof(ParticleEmitter);
+        emitter.LifeSpan = reader.GetAttributeFloat(nameof(ParticleEmitter.LifeSpan));
+        emitter.Offset = reader.GetAttributeVector2(nameof(ParticleEmitter.Offset));
+        emitter.LayerDepth = reader.GetAttributeFloat(nameof(ParticleEmitter.LayerDepth));
+        emitter.ReclaimFrequency = reader.GetAttributeFloat(nameof(ParticleEmitter.ReclaimFrequency));
+
+        string strategy = reader.GetAttribute(nameof(ParticleEmitter.ModifierExecutionStrategy));
+
+        if (strategy.Equals(nameof(ModifierExecutionStrategy.Serial)))
+        {
+            emitter.ModifierExecutionStrategy = ModifierExecutionStrategy.Serial;
+        }
+        else if (strategy.Equals(nameof(ModifierExecutionStrategy.Parallel)))
+        {
+            emitter.ModifierExecutionStrategy = ModifierExecutionStrategy.Parallel;
+        }
+        else
+        {
+            emitter.ModifierExecutionStrategy = ModifierExecutionStrategy.Serial;
+        }
+
+        emitter.RenderingOrder = reader.GetAttributeEnum<ParticleRenderingOrder>(nameof(ParticleEmitter.RenderingOrder));
+
+        using XmlReader subtree = reader.ReadSubtree();
+        while (subtree.Read())
+        {
+            if (subtree.NodeType == XmlNodeType.Element)
+            {
+                switch (subtree.LocalName)
+                {
+                    case nameof(ParticleEmitter.TextureRegion):
+                        emitter.TextureRegion = ReadTexture2DRegion(subtree, content, baseDirectory);
+                        break;
+
+                    case nameof(ParticleEmitter.Parameters):
+                        emitter.Parameters = ReadParticleReleaseParameters(subtree);
+                        break;
+
+                    case nameof(ParticleEmitter.Profile):
+                        emitter.Profile = ReadProfile(subtree);
+                        break;
+
+                    case nameof(ParticleEmitter.Modifiers):
+                        ReadModifiers(subtree, emitter.Modifiers);
+                        break;
+                }
+            }
+        }
+
+        return emitter;
+    }
+
+    private static Texture2DRegion ReadTexture2DRegion(XmlReader reader, ContentManager content, string baseDirectory)
+    {
+        string name = reader.GetAttribute(nameof(Texture2DRegion.Texture.Name));
+
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        string path = Path.Combine(baseDirectory, name);
+        Texture2D texture = content.Load<Texture2D>(path);
+
+        Rectangle bounds = reader.GetAttributeRectangle(nameof(Texture2DRegion.Bounds));
+
+        if (bounds.IsEmpty)
+        {
+            bounds = texture.Bounds;
+        }
+
+        return new Texture2DRegion(texture, bounds);
+    }
+
+    private static ParticleReleaseParameters ReadParticleReleaseParameters(XmlReader reader)
+    {
+        ParticleReleaseParameters parameters = new ParticleReleaseParameters();
+
+        using XmlReader subtree = reader.ReadSubtree();
+        while (subtree.Read())
+        {
+            if (subtree.NodeType == XmlNodeType.Element)
+            {
+                switch (subtree.LocalName)
+                {
+                    case nameof(ParticleReleaseParameters.Quantity):
+                        parameters.Quantity = ReadParticleInt32Parameter(subtree);
+                        break;
+
+                    case nameof(ParticleReleaseParameters.Speed):
+                        parameters.Speed = ReadParticleFloatParameter(subtree);
+                        break;
+
+                    case nameof(ParticleReleaseParameters.Color):
+                        parameters.Color = ReadParticleColorParameter(subtree);
+                        break;
+
+                    case nameof(ParticleReleaseParameters.Opacity):
+                        parameters.Opacity = ReadParticleFloatParameter(subtree);
+                        break;
+
+                    case nameof(ParticleReleaseParameters.Scale):
+                        parameters.Scale = ReadParticleVector2Parameter(subtree);
+                        break;
+
+                    case nameof(ParticleReleaseParameters.Rotation):
+                        parameters.Rotation = ReadParticleFloatParameter(subtree);
+                        break;
+
+                    case nameof(ParticleReleaseParameters.Mass):
+                        parameters.Mass = ReadParticleFloatParameter(subtree);
+                        break;
+                }
+            }
+        }
+
+        return parameters;
+    }
+
+    private static ParticleInt32Parameter ReadParticleInt32Parameter(XmlReader reader)
+    {
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleInt32Parameter.Kind));
+
+        if (kind == ParticleValueKind.Constant)
+        {
+            int value = reader.GetAttributeInt(nameof(ParticleInt32Parameter.Constant));
+            return new ParticleInt32Parameter(value);
+        }
+        else if (kind == ParticleValueKind.Random)
+        {
+            int min = reader.GetAttributeInt(nameof(ParticleInt32Parameter.RandomMin));
+            int max = reader.GetAttributeInt(nameof(ParticleInt32Parameter.RandomMax));
+            return new ParticleInt32Parameter(min, max);
+        }
+
+        return new ParticleInt32Parameter(0);
+    }
+
+    private static ParticleFloatParameter ReadParticleFloatParameter(XmlReader reader)
+    {
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleFloatParameter.Kind));
+
+        if (kind == ParticleValueKind.Constant)
+        {
+            float value = reader.GetAttributeFloat(nameof(ParticleFloatParameter.Constant));
+            return new ParticleFloatParameter(value);
+        }
+        else if (kind == ParticleValueKind.Random)
+        {
+            float min = reader.GetAttributeFloat(nameof(ParticleFloatParameter.RandomMin));
+            float max = reader.GetAttributeFloat(nameof(ParticleFloatParameter.RandomMax));
+            return new ParticleFloatParameter(min, max);
+        }
+
+        return new ParticleFloatParameter(0);
+    }
+
+    private static ParticleVector2Parameter ReadParticleVector2Parameter(XmlReader reader)
+    {
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleVector2Parameter.Kind));
+
+        if (kind == ParticleValueKind.Constant)
+        {
+            Vector2 value = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.Constant));
+            return new ParticleVector2Parameter(value);
+        }
+        else if (kind == ParticleValueKind.Random)
+        {
+            Vector2 min = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMin));
+            Vector2 max = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMax));
+            return new ParticleVector2Parameter(min, max);
+        }
+
+        return new ParticleVector2Parameter(Vector2.Zero);
+    }
+
+    private static ParticleColorParameter ReadParticleColorParameter(XmlReader reader)
+    {
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleColorParameter.Kind));
+
+        if (kind == ParticleValueKind.Constant)
+        {
+            Vector3 value = reader.GetAttributeVector3(nameof(ParticleColorParameter.Constant));
+            return new ParticleColorParameter(value);
+        }
+        else if (kind == ParticleValueKind.Random)
+        {
+            Vector3 min = reader.GetAttributeVector3(nameof(ParticleColorParameter.RandomMin));
+            Vector3 max = reader.GetAttributeVector3(nameof(ParticleColorParameter.RandomMax));
+            return new ParticleColorParameter(min, max);
+        }
+
+        return new ParticleColorParameter(Vector3.Zero);
+    }
+
+    private static Profile ReadProfile(XmlReader reader)
+    {
+        string type = reader.GetAttribute(nameof(Type));
+
+        return type switch
+        {
+            nameof(BoxProfile) => ReadBoxProfile(reader),
+            nameof(BoxFillProfile) => ReadBoxFillProfile(reader),
+            nameof(BoxUniformProfile) => ReadBoxUniformProfile(reader),
+            nameof(CircleProfile) => ReadCircleProfile(reader),
+            nameof(LineProfile) => ReadLineProfile(reader),
+            nameof(PointProfile) => ReadPointProfile(reader),
+            nameof(RingProfile) => ReadRingProfile(reader),
+            nameof(SprayProfile) => ReadSprayProfile(reader),
+            _ => ReadPointProfile(reader)
+        };
+    }
+
+    private static BoxProfile ReadBoxProfile(XmlReader reader)
+    {
+        float width = reader.GetAttributeFloat(nameof(BoxProfile.Width));
+        float height = reader.GetAttributeFloat(nameof(BoxProfile.Height));
+
+        return new BoxProfile { Width = width, Height = height };
+    }
+
+    private static BoxFillProfile ReadBoxFillProfile(XmlReader reader)
+    {
+        float width = reader.GetAttributeFloat(nameof(BoxFillProfile.Width));
+        float height = reader.GetAttributeFloat(nameof(BoxFillProfile.Height));
+
+        return new BoxFillProfile { Width = width, Height = height };
+    }
+
+    private static BoxUniformProfile ReadBoxUniformProfile(XmlReader reader)
+    {
+        float width = reader.GetAttributeFloat(nameof(BoxUniformProfile.Width));
+        float height = reader.GetAttributeFloat(nameof(BoxUniformProfile.Height));
+
+        return new BoxUniformProfile { Width = width, Height = height };
+    }
+
+    private static CircleProfile ReadCircleProfile(XmlReader reader)
+    {
+        float radius = reader.GetAttributeFloat(nameof(CircleProfile.Radius));
+        CircleRadiation radiation = reader.GetAttributeEnum<CircleRadiation>(nameof(CircleProfile.Radiate));
+
+        return new CircleProfile { Radius = radius, Radiate = radiation };
+    }
+
+    private static LineProfile ReadLineProfile(XmlReader reader)
+    {
+        Vector2 axis = reader.GetAttributeVector2(nameof(LineProfile.Axis));
+        float length = reader.GetAttributeFloat(nameof(LineProfile.Length));
+        Vector2 direction = reader.GetAttributeVector2(nameof(LineProfile.Direction));
+        LineRadiation radiate = reader.GetAttributeEnum<LineRadiation>(nameof(LineProfile.Radiate));
+
+        return new LineProfile { Axis = axis, Length = length, Direction = direction, Radiate = radiate };
+    }
+
+    private static PointProfile ReadPointProfile(XmlReader reader)
+    {
+        return new PointProfile();
+    }
+
+    private static RingProfile ReadRingProfile(XmlReader reader)
+    {
+        float radius = reader.GetAttributeFloat(nameof(RingProfile.Radius));
+        CircleRadiation radiation = reader.GetAttributeEnum<CircleRadiation>(nameof(RingProfile.Radiate));
+
+        return new RingProfile { Radius = radius, Radiate = radiation };
+    }
+
+    private static SprayProfile ReadSprayProfile(XmlReader reader)
+    {
+        Vector2 direction = reader.GetAttributeVector2(nameof(SprayProfile.Direction));
+        float spread = reader.GetAttributeFloat(nameof(SprayProfile.Spread));
+
+        return new SprayProfile { Direction = direction, Spread = spread };
+    }
+
+    private static void ReadModifiers(XmlReader reader, List<Modifier> modifiers)
+    {
+        using XmlReader subtree = reader.ReadSubtree();
+        while (subtree.Read())
+        {
+            if (subtree.NodeType == XmlNodeType.Element && subtree.LocalName == nameof(Modifier))
+            {
+                Modifier modifier = ReadModifier(subtree);
+
+                if (modifier != null)
+                {
+                    modifiers.Add(modifier);
+                }
+            }
+        }
+    }
+
+    private static Modifier ReadModifier(XmlReader reader)
+    {
+        string type = reader.GetAttribute(nameof(Type));
+        string name = reader.GetAttribute(nameof(Modifier.Name));
+        float frequency = reader.GetAttributeFloat(nameof(Modifier.Frequency));
+        bool enabled = reader.GetAttributeBool(nameof(Modifier.Enabled));
+
+        Modifier modifier = type switch
+        {
+            nameof(AgeModifier) => ReadAgeModifier(reader),
+            nameof(DragModifier) => ReadDragModifier(reader),
+            nameof(LinearGravityModifier) => ReadLinearGravityModifier(reader),
+            nameof(OpacityFastFadeModifier) => new OpacityFastFadeModifier(),
+            nameof(RotationModifier) => ReadRotationModifier(reader),
+            nameof(VelocityColorModifier) => ReadVelocityColorModifier(reader),
+            nameof(VelocityModifier) => ReadVelocityModifier(reader),
+            nameof(VortexModifier) => ReadVortexModifier(reader),
+            nameof(CircleContainerModifier) => ReadCircleContainerModifier(reader),
+            nameof(RectangleContainerModifier) => ReadRectangleContainerModifier(reader),
+            nameof(RectangleLoopContainerModifier) => ReadRectangleLoopContainerModifier(reader),
+            _ => null
+        };
+
+        if (modifier != null)
+        {
+            modifier.Name = name;
+            modifier.Frequency = frequency;
+            modifier.Enabled = enabled;
+        }
+
+        return modifier;
+    }
+
+    private static AgeModifier ReadAgeModifier(XmlReader reader)
+    {
+        AgeModifier modifier = new AgeModifier();
+
+        using XmlReader subtree = reader.ReadSubtree();
+        while (subtree.Read())
+        {
+            if (subtree.NodeType == XmlNodeType.Element && subtree.LocalName == nameof(AgeModifier.Interpolators))
+            {
+                ReadInterpolators(subtree, modifier.Interpolators);
+            }
+        }
+
+        return modifier;
+    }
+
+    private static DragModifier ReadDragModifier(XmlReader reader)
+    {
+        float dragCoefficient = reader.GetAttributeFloat(nameof(DragModifier.DragCoefficient));
+        float density = reader.GetAttributeFloat(nameof(DragModifier.Density));
+
+        return new DragModifier() { DragCoefficient = dragCoefficient, Density = density };
+    }
+
+    private static LinearGravityModifier ReadLinearGravityModifier(XmlReader reader)
+    {
+        Vector2 direction = reader.GetAttributeVector2(nameof(LinearGravityModifier.Direction));
+        float strength = reader.GetAttributeFloat(nameof(LinearGravityModifier.Strength));
+
+        return new LinearGravityModifier() { Direction = direction, Strength = strength };
+    }
+
+    private static RotationModifier ReadRotationModifier(XmlReader reader)
+    {
+        float rotationRate = reader.GetAttributeFloat(nameof(RotationModifier.RotationRate));
+
+        return new RotationModifier() { RotationRate = rotationRate };
+    }
+
+    private static VelocityColorModifier ReadVelocityColorModifier(XmlReader reader)
+    {
+        Vector3 stationaryColorValue = reader.GetAttributeVector3(nameof(VelocityColorModifier.StationaryColor));
+        Vector3 velocityColorValue = reader.GetAttributeVector3(nameof(VelocityColorModifier.VelocityColor));
+        float velocityThreshold = reader.GetAttributeFloat(nameof(VelocityColorModifier.VelocityThreshold));
+
+        HslColor stationaryColor = new HslColor(stationaryColorValue.X, stationaryColorValue.Y, stationaryColorValue.Z);
+        HslColor velocityColor = new HslColor(velocityColorValue.X, velocityColorValue.Y, velocityColorValue.Z);
+
+        return new VelocityColorModifier() { StationaryColor = stationaryColor, VelocityColor = velocityColor, VelocityThreshold = velocityThreshold };
+    }
+
+    private static VelocityModifier ReadVelocityModifier(XmlReader reader)
+    {
+        float velocityThreshold = reader.GetAttributeFloat(nameof(VelocityModifier.VelocityThreshold));
+
+        VelocityModifier modifier = new VelocityModifier() { VelocityThreshold = velocityThreshold };
+
+        using XmlReader subtree = reader.ReadSubtree();
+        while (subtree.Read())
+        {
+            if (subtree.NodeType == XmlNodeType.Element && subtree.LocalName == nameof(VelocityModifier.Interpolators))
+            {
+                ReadInterpolators(subtree, modifier.Interpolators);
+            }
+        }
+
+        return modifier;
+    }
+
+    private static VortexModifier ReadVortexModifier(XmlReader reader)
+    {
+        Vector2 position = reader.GetAttributeVector2(nameof(VortexModifier.Position));
+        float strength = reader.GetAttributeFloat(nameof(VortexModifier.Strength));
+        float outerRadius = reader.GetAttributeFloat(nameof(VortexModifier.OuterRadius));
+        float innerRadius = reader.GetAttributeFloat(nameof(VortexModifier.InnerRadius));
+        float maxVelocity = reader.GetAttributeFloat(nameof(VortexModifier.MaxVelocity));
+        float rotationAngle = reader.GetAttributeFloat(nameof(VortexModifier.RotationAngle));
+
+        return new VortexModifier { Position = position, Strength = strength, OuterRadius = outerRadius, InnerRadius = innerRadius, MaxVelocity = maxVelocity, RotationAngle = rotationAngle };
+    }
+
+    private static CircleContainerModifier ReadCircleContainerModifier(XmlReader reader)
+    {
+        float radius = reader.GetAttributeFloat(nameof(CircleContainerModifier.Radius));
+        bool inside = reader.GetAttributeBool(nameof(CircleContainerModifier.Inside));
+        float restitutionCoefficient = reader.GetAttributeFloat(nameof(CircleContainerModifier.RestitutionCoefficient));
+
+        return new CircleContainerModifier() { Radius = radius, Inside = inside, RestitutionCoefficient = restitutionCoefficient };
+    }
+
+    private static RectangleContainerModifier ReadRectangleContainerModifier(XmlReader reader)
+    {
+        int width = reader.GetAttributeInt(nameof(RectangleContainerModifier.Width));
+        int height = reader.GetAttributeInt(nameof(RectangleContainerModifier.Height));
+        float restitutionCoefficient = reader.GetAttributeFloat(nameof(RectangleContainerModifier.RestitutionCoefficient));
+
+        return new RectangleContainerModifier() { Width = width, Height = height, RestitutionCoefficient = restitutionCoefficient };
+    }
+
+    private static RectangleLoopContainerModifier ReadRectangleLoopContainerModifier(XmlReader reader)
+    {
+        int width = reader.GetAttributeInt(nameof(RectangleLoopContainerModifier.Width));
+        int height = reader.GetAttributeInt(nameof(RectangleLoopContainerModifier.Height));
+
+        return new RectangleLoopContainerModifier() { Width = width, Height = height };
+    }
+
+    private static void ReadInterpolators(XmlReader reader, List<Interpolator> interpolators)
+    {
+        using XmlReader subtree = reader.ReadSubtree();
+        while (subtree.Read())
+        {
+            if (subtree.NodeType == XmlNodeType.Element && subtree.LocalName == nameof(Interpolator))
+            {
+                Interpolator interpolator = ReadInterpolator(subtree);
+
+                if (interpolator != null)
+                {
+                    interpolators.Add(interpolator);
+                }
+            }
+        }
+    }
+
+    private static Interpolator ReadInterpolator(XmlReader reader)
+    {
+        string type = reader.GetAttribute(nameof(Type));
+        string name = reader.GetAttribute(nameof(Interpolator.Name));
+
+        Interpolator interpolator = type switch
+        {
+            nameof(ColorInterpolator) => ReadColorInterpolator(reader),
+            nameof(HueInterpolator) => ReadHueInterpolator(reader),
+            nameof(OpacityInterpolator) => ReadOpacityInterpolator(reader),
+            nameof(RotationInterpolator) => ReadRotationInterpolator(reader),
+            nameof(ScaleInterpolator) => ReadScaleInterpolator(reader),
+            nameof(VelocityInterpolator) => ReadVelocityInterpolator(reader),
+            _ => null
+        };
+
+        if (interpolator != null)
+        {
+            interpolator.Name = name;
+        }
+
+        return interpolator;
+    }
+
+    private static ColorInterpolator ReadColorInterpolator(XmlReader reader)
+    {
+        Vector3 start = reader.GetAttributeVector3(nameof(ColorInterpolator.StartValue));
+        Vector3 end = reader.GetAttributeVector3(nameof(ColorInterpolator.EndValue));
+
+        HslColor startValue = new HslColor(start.X, start.Y, start.Z);
+        HslColor endValue = new HslColor(end.X, end.Y, end.Z);
+
+        return new ColorInterpolator() { StartValue = startValue, EndValue = endValue };
+    }
+
+    private static HueInterpolator ReadHueInterpolator(XmlReader reader)
+    {
+        float startValue = reader.GetAttributeFloat(nameof(HueInterpolator.StartValue));
+        float endValue = reader.GetAttributeFloat(nameof(HueInterpolator.EndValue));
+
+        return new HueInterpolator() { StartValue = startValue, EndValue = endValue };
+    }
+
+    private static OpacityInterpolator ReadOpacityInterpolator(XmlReader reader)
+    {
+        float startValue = reader.GetAttributeFloat(nameof(OpacityInterpolator.StartValue));
+        float endValue = reader.GetAttributeFloat(nameof(OpacityInterpolator.EndValue));
+
+        return new OpacityInterpolator() { StartValue = startValue, EndValue = endValue };
+    }
+
+    private static RotationInterpolator ReadRotationInterpolator(XmlReader reader)
+    {
+        float startValue = reader.GetAttributeFloat(nameof(RotationInterpolator.StartValue));
+        float endValue = reader.GetAttributeFloat(nameof(RotationInterpolator.EndValue));
+
+        return new RotationInterpolator() { StartValue = startValue, EndValue = endValue };
+    }
+
+    private static ScaleInterpolator ReadScaleInterpolator(XmlReader reader)
+    {
+        Vector2 startValue = reader.GetAttributeVector2(nameof(ScaleInterpolator.StartValue));
+        Vector2 endValue = reader.GetAttributeVector2(nameof(ScaleInterpolator.EndValue));
+
+        return new ScaleInterpolator() { StartValue = startValue, EndValue = endValue };
+    }
+
+    private static VelocityInterpolator ReadVelocityInterpolator(XmlReader reader)
+    {
+        Vector2 startValue = reader.GetAttributeVector2(nameof(VelocityInterpolator.StartValue));
+        Vector2 endValue = reader.GetAttributeVector2(nameof(VelocityInterpolator.EndValue));
+
+        return new VelocityInterpolator() { StartValue = startValue, EndValue = endValue };
+    }
+}

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -191,6 +191,10 @@ public static class ParticleEffectSerializer
         }
 
         Texture2D texture = content.Load<Texture2D>(path);
+        if(string.IsNullOrEmpty(texture.Name))
+        {
+            texture.Name = Path.GetFileName(path);
+        }
 
         Rectangle bounds = reader.GetAttributeRectangle(nameof(Texture2DRegion.Bounds), default);
 

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -586,6 +586,7 @@ public static class ParticleEffectSerializer
     {
         string type = reader.GetAttribute(nameof(Type));
         string name = reader.GetAttribute(nameof(Interpolator.Name));
+        bool enabled = reader.GetAttributeBool(nameof(Interpolator.Enabled), default);
 
         Interpolator interpolator = type switch
         {
@@ -602,6 +603,8 @@ public static class ParticleEffectSerializer
         {
             interpolator.Name = name;
         }
+
+        interpolator.Enabled = enabled;
 
         return interpolator;
     }

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -95,11 +95,11 @@ public static class ParticleEffectSerializer
         string name = reader.GetAttribute(nameof(ParticleEffect.Name)) ?? nameof(ParticleEffect);
         ParticleEffect effect = new ParticleEffect(name);
 
-        effect.Position = reader.GetAttributeVector2(nameof(ParticleEffect.Position));
-        effect.Rotation = reader.GetAttributeFloat(nameof(ParticleEffect.Rotation));
-        effect.Scale = reader.GetAttributeVector2(nameof(ParticleEffect.Scale));
-        effect.AutoTrigger = reader.GetAttributeBool(nameof(ParticleEffect.AutoTrigger));
-        effect.AutoTriggerFrequency = reader.GetAttributeFloat(nameof(ParticleEffect.AutoTriggerFrequency));
+        effect.Position = reader.GetAttributeVector2(nameof(ParticleEffect.Position), default);
+        effect.Rotation = reader.GetAttributeFloat(nameof(ParticleEffect.Rotation), default);
+        effect.Scale = reader.GetAttributeVector2(nameof(ParticleEffect.Scale), default);
+        effect.AutoTrigger = reader.GetAttributeBool(nameof(ParticleEffect.AutoTrigger), default);
+        effect.AutoTriggerFrequency = reader.GetAttributeFloat(nameof(ParticleEffect.AutoTriggerFrequency), default);
 
         if (reader.ReadToDescendant(nameof(ParticleEffect.Emitters)))
         {
@@ -118,14 +118,14 @@ public static class ParticleEffectSerializer
 
     private static ParticleEmitter ReadParticleEmitter(XmlReader reader, ContentManager content, string baseDirectory)
     {
-        int capacity = reader.GetAttributeInt(nameof(ParticleEmitter.Capacity));
+        int capacity = reader.GetAttributeInt(nameof(ParticleEmitter.Capacity), default);
 
         ParticleEmitter emitter = new ParticleEmitter(capacity);
         emitter.Name = reader.GetAttribute(nameof(ParticleEmitter.Name)) ?? nameof(ParticleEmitter);
-        emitter.LifeSpan = reader.GetAttributeFloat(nameof(ParticleEmitter.LifeSpan));
-        emitter.Offset = reader.GetAttributeVector2(nameof(ParticleEmitter.Offset));
-        emitter.LayerDepth = reader.GetAttributeFloat(nameof(ParticleEmitter.LayerDepth));
-        emitter.ReclaimFrequency = reader.GetAttributeFloat(nameof(ParticleEmitter.ReclaimFrequency));
+        emitter.LifeSpan = reader.GetAttributeFloat(nameof(ParticleEmitter.LifeSpan), default);
+        emitter.Offset = reader.GetAttributeVector2(nameof(ParticleEmitter.Offset), default);
+        emitter.LayerDepth = reader.GetAttributeFloat(nameof(ParticleEmitter.LayerDepth), default);
+        emitter.ReclaimFrequency = reader.GetAttributeFloat(nameof(ParticleEmitter.ReclaimFrequency), default);
 
         string strategy = reader.GetAttribute(nameof(ParticleEmitter.ModifierExecutionStrategy));
 
@@ -142,7 +142,7 @@ public static class ParticleEffectSerializer
             emitter.ModifierExecutionStrategy = ModifierExecutionStrategy.Serial;
         }
 
-        emitter.RenderingOrder = reader.GetAttributeEnum<ParticleRenderingOrder>(nameof(ParticleEmitter.RenderingOrder));
+        emitter.RenderingOrder = reader.GetAttributeEnum<ParticleRenderingOrder>(nameof(ParticleEmitter.RenderingOrder), default);
 
         using XmlReader subtree = reader.ReadSubtree();
         while (subtree.Read())
@@ -192,7 +192,7 @@ public static class ParticleEffectSerializer
 
         Texture2D texture = content.Load<Texture2D>(path);
 
-        Rectangle bounds = reader.GetAttributeRectangle(nameof(Texture2DRegion.Bounds));
+        Rectangle bounds = reader.GetAttributeRectangle(nameof(Texture2DRegion.Bounds), default);
 
         if (bounds.IsEmpty)
         {
@@ -249,17 +249,17 @@ public static class ParticleEffectSerializer
 
     private static ParticleInt32Parameter ReadParticleInt32Parameter(XmlReader reader)
     {
-        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleInt32Parameter.Kind));
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleInt32Parameter.Kind), default);
 
         if (kind == ParticleValueKind.Constant)
         {
-            int value = reader.GetAttributeInt(nameof(ParticleInt32Parameter.Constant));
+            int value = reader.GetAttributeInt(nameof(ParticleInt32Parameter.Constant), default);
             return new ParticleInt32Parameter(value);
         }
         else if (kind == ParticleValueKind.Random)
         {
-            int min = reader.GetAttributeInt(nameof(ParticleInt32Parameter.RandomMin));
-            int max = reader.GetAttributeInt(nameof(ParticleInt32Parameter.RandomMax));
+            int min = reader.GetAttributeInt(nameof(ParticleInt32Parameter.RandomMin), default);
+            int max = reader.GetAttributeInt(nameof(ParticleInt32Parameter.RandomMax), default);
             return new ParticleInt32Parameter(min, max);
         }
 
@@ -268,17 +268,17 @@ public static class ParticleEffectSerializer
 
     private static ParticleFloatParameter ReadParticleFloatParameter(XmlReader reader)
     {
-        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleFloatParameter.Kind));
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleFloatParameter.Kind), default);
 
         if (kind == ParticleValueKind.Constant)
         {
-            float value = reader.GetAttributeFloat(nameof(ParticleFloatParameter.Constant));
+            float value = reader.GetAttributeFloat(nameof(ParticleFloatParameter.Constant), default);
             return new ParticleFloatParameter(value);
         }
         else if (kind == ParticleValueKind.Random)
         {
-            float min = reader.GetAttributeFloat(nameof(ParticleFloatParameter.RandomMin));
-            float max = reader.GetAttributeFloat(nameof(ParticleFloatParameter.RandomMax));
+            float min = reader.GetAttributeFloat(nameof(ParticleFloatParameter.RandomMin), default);
+            float max = reader.GetAttributeFloat(nameof(ParticleFloatParameter.RandomMax), default);
             return new ParticleFloatParameter(min, max);
         }
 
@@ -287,17 +287,17 @@ public static class ParticleEffectSerializer
 
     private static ParticleVector2Parameter ReadParticleVector2Parameter(XmlReader reader)
     {
-        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleVector2Parameter.Kind));
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleVector2Parameter.Kind), default);
 
         if (kind == ParticleValueKind.Constant)
         {
-            Vector2 value = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.Constant));
+            Vector2 value = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.Constant), default);
             return new ParticleVector2Parameter(value);
         }
         else if (kind == ParticleValueKind.Random)
         {
-            Vector2 min = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMin));
-            Vector2 max = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMax));
+            Vector2 min = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMin), default);
+            Vector2 max = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMax), default);
             return new ParticleVector2Parameter(min, max);
         }
 
@@ -306,17 +306,17 @@ public static class ParticleEffectSerializer
 
     private static ParticleColorParameter ReadParticleColorParameter(XmlReader reader)
     {
-        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleColorParameter.Kind));
+        ParticleValueKind kind = reader.GetAttributeEnum<ParticleValueKind>(nameof(ParticleColorParameter.Kind), default);
 
         if (kind == ParticleValueKind.Constant)
         {
-            Vector3 value = reader.GetAttributeVector3(nameof(ParticleColorParameter.Constant));
+            Vector3 value = reader.GetAttributeVector3(nameof(ParticleColorParameter.Constant), default);
             return new ParticleColorParameter(value);
         }
         else if (kind == ParticleValueKind.Random)
         {
-            Vector3 min = reader.GetAttributeVector3(nameof(ParticleColorParameter.RandomMin));
-            Vector3 max = reader.GetAttributeVector3(nameof(ParticleColorParameter.RandomMax));
+            Vector3 min = reader.GetAttributeVector3(nameof(ParticleColorParameter.RandomMin), default);
+            Vector3 max = reader.GetAttributeVector3(nameof(ParticleColorParameter.RandomMax), default);
             return new ParticleColorParameter(min, max);
         }
 
@@ -343,42 +343,42 @@ public static class ParticleEffectSerializer
 
     private static BoxProfile ReadBoxProfile(XmlReader reader)
     {
-        float width = reader.GetAttributeFloat(nameof(BoxProfile.Width));
-        float height = reader.GetAttributeFloat(nameof(BoxProfile.Height));
+        float width = reader.GetAttributeFloat(nameof(BoxProfile.Width), default);
+        float height = reader.GetAttributeFloat(nameof(BoxProfile.Height), default);
 
         return new BoxProfile { Width = width, Height = height };
     }
 
     private static BoxFillProfile ReadBoxFillProfile(XmlReader reader)
     {
-        float width = reader.GetAttributeFloat(nameof(BoxFillProfile.Width));
-        float height = reader.GetAttributeFloat(nameof(BoxFillProfile.Height));
+        float width = reader.GetAttributeFloat(nameof(BoxFillProfile.Width), default);
+        float height = reader.GetAttributeFloat(nameof(BoxFillProfile.Height), default);
 
         return new BoxFillProfile { Width = width, Height = height };
     }
 
     private static BoxUniformProfile ReadBoxUniformProfile(XmlReader reader)
     {
-        float width = reader.GetAttributeFloat(nameof(BoxUniformProfile.Width));
-        float height = reader.GetAttributeFloat(nameof(BoxUniformProfile.Height));
+        float width = reader.GetAttributeFloat(nameof(BoxUniformProfile.Width), default);
+        float height = reader.GetAttributeFloat(nameof(BoxUniformProfile.Height), default);
 
         return new BoxUniformProfile { Width = width, Height = height };
     }
 
     private static CircleProfile ReadCircleProfile(XmlReader reader)
     {
-        float radius = reader.GetAttributeFloat(nameof(CircleProfile.Radius));
-        CircleRadiation radiation = reader.GetAttributeEnum<CircleRadiation>(nameof(CircleProfile.Radiate));
+        float radius = reader.GetAttributeFloat(nameof(CircleProfile.Radius), default);
+        CircleRadiation radiation = reader.GetAttributeEnum<CircleRadiation>(nameof(CircleProfile.Radiate), default);
 
         return new CircleProfile { Radius = radius, Radiate = radiation };
     }
 
     private static LineProfile ReadLineProfile(XmlReader reader)
     {
-        Vector2 axis = reader.GetAttributeVector2(nameof(LineProfile.Axis));
-        float length = reader.GetAttributeFloat(nameof(LineProfile.Length));
-        Vector2 direction = reader.GetAttributeVector2(nameof(LineProfile.Direction));
-        LineRadiation radiate = reader.GetAttributeEnum<LineRadiation>(nameof(LineProfile.Radiate));
+        Vector2 axis = reader.GetAttributeVector2(nameof(LineProfile.Axis), default);
+        float length = reader.GetAttributeFloat(nameof(LineProfile.Length), default);
+        Vector2 direction = reader.GetAttributeVector2(nameof(LineProfile.Direction), default);
+        LineRadiation radiate = reader.GetAttributeEnum<LineRadiation>(nameof(LineProfile.Radiate), default);
 
         return new LineProfile { Axis = axis, Length = length, Direction = direction, Radiate = radiate };
     }
@@ -390,16 +390,16 @@ public static class ParticleEffectSerializer
 
     private static RingProfile ReadRingProfile(XmlReader reader)
     {
-        float radius = reader.GetAttributeFloat(nameof(RingProfile.Radius));
-        CircleRadiation radiation = reader.GetAttributeEnum<CircleRadiation>(nameof(RingProfile.Radiate));
+        float radius = reader.GetAttributeFloat(nameof(RingProfile.Radius), default);
+        CircleRadiation radiation = reader.GetAttributeEnum<CircleRadiation>(nameof(RingProfile.Radiate), default);
 
         return new RingProfile { Radius = radius, Radiate = radiation };
     }
 
     private static SprayProfile ReadSprayProfile(XmlReader reader)
     {
-        Vector2 direction = reader.GetAttributeVector2(nameof(SprayProfile.Direction));
-        float spread = reader.GetAttributeFloat(nameof(SprayProfile.Spread));
+        Vector2 direction = reader.GetAttributeVector2(nameof(SprayProfile.Direction), default);
+        float spread = reader.GetAttributeFloat(nameof(SprayProfile.Spread), default);
 
         return new SprayProfile { Direction = direction, Spread = spread };
     }
@@ -425,8 +425,8 @@ public static class ParticleEffectSerializer
     {
         string type = reader.GetAttribute(nameof(Type));
         string name = reader.GetAttribute(nameof(Modifier.Name));
-        float frequency = reader.GetAttributeFloat(nameof(Modifier.Frequency));
-        bool enabled = reader.GetAttributeBool(nameof(Modifier.Enabled));
+        float frequency = reader.GetAttributeFloat(nameof(Modifier.Frequency), default);
+        bool enabled = reader.GetAttributeBool(nameof(Modifier.Enabled), default);
 
         Modifier modifier = type switch
         {
@@ -472,32 +472,32 @@ public static class ParticleEffectSerializer
 
     private static DragModifier ReadDragModifier(XmlReader reader)
     {
-        float dragCoefficient = reader.GetAttributeFloat(nameof(DragModifier.DragCoefficient));
-        float density = reader.GetAttributeFloat(nameof(DragModifier.Density));
+        float dragCoefficient = reader.GetAttributeFloat(nameof(DragModifier.DragCoefficient), default);
+        float density = reader.GetAttributeFloat(nameof(DragModifier.Density), default);
 
         return new DragModifier() { DragCoefficient = dragCoefficient, Density = density };
     }
 
     private static LinearGravityModifier ReadLinearGravityModifier(XmlReader reader)
     {
-        Vector2 direction = reader.GetAttributeVector2(nameof(LinearGravityModifier.Direction));
-        float strength = reader.GetAttributeFloat(nameof(LinearGravityModifier.Strength));
+        Vector2 direction = reader.GetAttributeVector2(nameof(LinearGravityModifier.Direction), default);
+        float strength = reader.GetAttributeFloat(nameof(LinearGravityModifier.Strength), default);
 
         return new LinearGravityModifier() { Direction = direction, Strength = strength };
     }
 
     private static RotationModifier ReadRotationModifier(XmlReader reader)
     {
-        float rotationRate = reader.GetAttributeFloat(nameof(RotationModifier.RotationRate));
+        float rotationRate = reader.GetAttributeFloat(nameof(RotationModifier.RotationRate), default);
 
         return new RotationModifier() { RotationRate = rotationRate };
     }
 
     private static VelocityColorModifier ReadVelocityColorModifier(XmlReader reader)
     {
-        Vector3 stationaryColorValue = reader.GetAttributeVector3(nameof(VelocityColorModifier.StationaryColor));
-        Vector3 velocityColorValue = reader.GetAttributeVector3(nameof(VelocityColorModifier.VelocityColor));
-        float velocityThreshold = reader.GetAttributeFloat(nameof(VelocityColorModifier.VelocityThreshold));
+        Vector3 stationaryColorValue = reader.GetAttributeVector3(nameof(VelocityColorModifier.StationaryColor), default);
+        Vector3 velocityColorValue = reader.GetAttributeVector3(nameof(VelocityColorModifier.VelocityColor), default);
+        float velocityThreshold = reader.GetAttributeFloat(nameof(VelocityColorModifier.VelocityThreshold), default);
 
         HslColor stationaryColor = new HslColor(stationaryColorValue.X, stationaryColorValue.Y, stationaryColorValue.Z);
         HslColor velocityColor = new HslColor(velocityColorValue.X, velocityColorValue.Y, velocityColorValue.Z);
@@ -507,7 +507,7 @@ public static class ParticleEffectSerializer
 
     private static VelocityModifier ReadVelocityModifier(XmlReader reader)
     {
-        float velocityThreshold = reader.GetAttributeFloat(nameof(VelocityModifier.VelocityThreshold));
+        float velocityThreshold = reader.GetAttributeFloat(nameof(VelocityModifier.VelocityThreshold), default);
 
         VelocityModifier modifier = new VelocityModifier() { VelocityThreshold = velocityThreshold };
 
@@ -525,38 +525,38 @@ public static class ParticleEffectSerializer
 
     private static VortexModifier ReadVortexModifier(XmlReader reader)
     {
-        Vector2 position = reader.GetAttributeVector2(nameof(VortexModifier.Position));
-        float strength = reader.GetAttributeFloat(nameof(VortexModifier.Strength));
-        float outerRadius = reader.GetAttributeFloat(nameof(VortexModifier.OuterRadius));
-        float innerRadius = reader.GetAttributeFloat(nameof(VortexModifier.InnerRadius));
-        float maxVelocity = reader.GetAttributeFloat(nameof(VortexModifier.MaxVelocity));
-        float rotationAngle = reader.GetAttributeFloat(nameof(VortexModifier.RotationAngle));
+        Vector2 position = reader.GetAttributeVector2(nameof(VortexModifier.Position), default);
+        float strength = reader.GetAttributeFloat(nameof(VortexModifier.Strength), default);
+        float outerRadius = reader.GetAttributeFloat(nameof(VortexModifier.OuterRadius), default);
+        float innerRadius = reader.GetAttributeFloat(nameof(VortexModifier.InnerRadius), default);
+        float maxVelocity = reader.GetAttributeFloat(nameof(VortexModifier.MaxVelocity), default);
+        float rotationAngle = reader.GetAttributeFloat(nameof(VortexModifier.RotationAngle), default);
 
         return new VortexModifier { Position = position, Strength = strength, OuterRadius = outerRadius, InnerRadius = innerRadius, MaxVelocity = maxVelocity, RotationAngle = rotationAngle };
     }
 
     private static CircleContainerModifier ReadCircleContainerModifier(XmlReader reader)
     {
-        float radius = reader.GetAttributeFloat(nameof(CircleContainerModifier.Radius));
-        bool inside = reader.GetAttributeBool(nameof(CircleContainerModifier.Inside));
-        float restitutionCoefficient = reader.GetAttributeFloat(nameof(CircleContainerModifier.RestitutionCoefficient));
+        float radius = reader.GetAttributeFloat(nameof(CircleContainerModifier.Radius), default);
+        bool inside = reader.GetAttributeBool(nameof(CircleContainerModifier.Inside), default);
+        float restitutionCoefficient = reader.GetAttributeFloat(nameof(CircleContainerModifier.RestitutionCoefficient), default);
 
         return new CircleContainerModifier() { Radius = radius, Inside = inside, RestitutionCoefficient = restitutionCoefficient };
     }
 
     private static RectangleContainerModifier ReadRectangleContainerModifier(XmlReader reader)
     {
-        int width = reader.GetAttributeInt(nameof(RectangleContainerModifier.Width));
-        int height = reader.GetAttributeInt(nameof(RectangleContainerModifier.Height));
-        float restitutionCoefficient = reader.GetAttributeFloat(nameof(RectangleContainerModifier.RestitutionCoefficient));
+        int width = reader.GetAttributeInt(nameof(RectangleContainerModifier.Width), default);
+        int height = reader.GetAttributeInt(nameof(RectangleContainerModifier.Height), default);
+        float restitutionCoefficient = reader.GetAttributeFloat(nameof(RectangleContainerModifier.RestitutionCoefficient), default);
 
         return new RectangleContainerModifier() { Width = width, Height = height, RestitutionCoefficient = restitutionCoefficient };
     }
 
     private static RectangleLoopContainerModifier ReadRectangleLoopContainerModifier(XmlReader reader)
     {
-        int width = reader.GetAttributeInt(nameof(RectangleLoopContainerModifier.Width));
-        int height = reader.GetAttributeInt(nameof(RectangleLoopContainerModifier.Height));
+        int width = reader.GetAttributeInt(nameof(RectangleLoopContainerModifier.Width), default);
+        int height = reader.GetAttributeInt(nameof(RectangleLoopContainerModifier.Height), default);
 
         return new RectangleLoopContainerModifier() { Width = width, Height = height };
     }
@@ -604,8 +604,8 @@ public static class ParticleEffectSerializer
 
     private static ColorInterpolator ReadColorInterpolator(XmlReader reader)
     {
-        Vector3 start = reader.GetAttributeVector3(nameof(ColorInterpolator.StartValue));
-        Vector3 end = reader.GetAttributeVector3(nameof(ColorInterpolator.EndValue));
+        Vector3 start = reader.GetAttributeVector3(nameof(ColorInterpolator.StartValue), default);
+        Vector3 end = reader.GetAttributeVector3(nameof(ColorInterpolator.EndValue), default);
 
         HslColor startValue = new HslColor(start.X, start.Y, start.Z);
         HslColor endValue = new HslColor(end.X, end.Y, end.Z);
@@ -615,40 +615,40 @@ public static class ParticleEffectSerializer
 
     private static HueInterpolator ReadHueInterpolator(XmlReader reader)
     {
-        float startValue = reader.GetAttributeFloat(nameof(HueInterpolator.StartValue));
-        float endValue = reader.GetAttributeFloat(nameof(HueInterpolator.EndValue));
+        float startValue = reader.GetAttributeFloat(nameof(HueInterpolator.StartValue), default);
+        float endValue = reader.GetAttributeFloat(nameof(HueInterpolator.EndValue), default);
 
         return new HueInterpolator() { StartValue = startValue, EndValue = endValue };
     }
 
     private static OpacityInterpolator ReadOpacityInterpolator(XmlReader reader)
     {
-        float startValue = reader.GetAttributeFloat(nameof(OpacityInterpolator.StartValue));
-        float endValue = reader.GetAttributeFloat(nameof(OpacityInterpolator.EndValue));
+        float startValue = reader.GetAttributeFloat(nameof(OpacityInterpolator.StartValue), default);
+        float endValue = reader.GetAttributeFloat(nameof(OpacityInterpolator.EndValue), default);
 
         return new OpacityInterpolator() { StartValue = startValue, EndValue = endValue };
     }
 
     private static RotationInterpolator ReadRotationInterpolator(XmlReader reader)
     {
-        float startValue = reader.GetAttributeFloat(nameof(RotationInterpolator.StartValue));
-        float endValue = reader.GetAttributeFloat(nameof(RotationInterpolator.EndValue));
+        float startValue = reader.GetAttributeFloat(nameof(RotationInterpolator.StartValue), default);
+        float endValue = reader.GetAttributeFloat(nameof(RotationInterpolator.EndValue), default);
 
         return new RotationInterpolator() { StartValue = startValue, EndValue = endValue };
     }
 
     private static ScaleInterpolator ReadScaleInterpolator(XmlReader reader)
     {
-        Vector2 startValue = reader.GetAttributeVector2(nameof(ScaleInterpolator.StartValue));
-        Vector2 endValue = reader.GetAttributeVector2(nameof(ScaleInterpolator.EndValue));
+        Vector2 startValue = reader.GetAttributeVector2(nameof(ScaleInterpolator.StartValue), default);
+        Vector2 endValue = reader.GetAttributeVector2(nameof(ScaleInterpolator.EndValue), default);
 
         return new ScaleInterpolator() { StartValue = startValue, EndValue = endValue };
     }
 
     private static VelocityInterpolator ReadVelocityInterpolator(XmlReader reader)
     {
-        Vector2 startValue = reader.GetAttributeVector2(nameof(VelocityInterpolator.StartValue));
-        Vector2 endValue = reader.GetAttributeVector2(nameof(VelocityInterpolator.EndValue));
+        Vector2 startValue = reader.GetAttributeVector2(nameof(VelocityInterpolator.StartValue), default);
+        Vector2 endValue = reader.GetAttributeVector2(nameof(VelocityInterpolator.EndValue), default);
 
         return new VelocityInterpolator() { StartValue = startValue, EndValue = endValue };
     }

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -971,6 +971,7 @@ public static class ParticleEffectSerializer
     private static void WriteModifier(XmlWriter writer, Modifier modifier)
     {
         writer.WriteAttributeString(nameof(Modifier.Name), modifier.Name);
+        writer.WriteAttributeBool(nameof(Modifier.Enabled), modifier.Enabled);
         writer.WriteAttributeFloat(nameof(Modifier.Frequency), modifier.Frequency);
 
         switch (modifier)
@@ -1130,7 +1131,8 @@ public static class ParticleEffectSerializer
 
     private static void WriteInterpolator(XmlWriter writer, Interpolator interpolator)
     {
-        writer.WriteAttributeString(nameof(interpolator.Name), interpolator.Name);
+        writer.WriteAttributeString(nameof(Interpolator.Name), interpolator.Name);
+        writer.WriteAttributeBool(nameof(Interpolator.Enabled), interpolator.Enabled);
 
         switch (interpolator)
         {

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -20,6 +20,8 @@ namespace MonoGame.Extended.Particles;
 /// </summary>
 public static class ParticleEffectSerializer
 {
+    # region Deserialize
+
     /// <summary>
     /// Deserializes a <see cref="ParticleEffect"/> from an XML file.
     /// </summary>
@@ -643,4 +645,555 @@ public static class ParticleEffectSerializer
 
         return new VelocityInterpolator() { StartValue = startValue, EndValue = endValue };
     }
+
+    #endregion Deserialize
+
+    #region Serialize
+
+    /// <summary>
+    /// Serializes a <see cref="ParticleEffect"/> to an XML file.
+    /// </summary>
+    /// <param name="fileName">The file path to write the XML to.</param>
+    /// <param name="effect">The <see cref="ParticleEffect"/> to serialize.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="fileName"/> is an empty string.</exception>
+    /// <exception cref="ArgumentNullException">
+    /// Throw if either <paramref name="fileName"/> or <paramref name="effect"/> are <see langword="null"/>.
+    /// </exception>
+    public static void Serialize(string fileName, ParticleEffect effect)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(fileName);
+        ArgumentNullException.ThrowIfNull(effect);
+
+        XmlWriterSettings settings = new XmlWriterSettings();
+        settings.Indent = true;
+        settings.IndentChars = "  ";
+        settings.CloseOutput = true;
+        settings.NewLineChars = "\n";
+
+        using XmlWriter writer = XmlWriter.Create(fileName, settings);
+        Serialize(writer, effect);
+    }
+
+    /// <summary>
+    /// Serializes a <see cref="ParticleEffect"/> to a stream as XML data.
+    /// </summary>
+    /// <param name="stream">The stream to write to.</param>
+    /// <param name="effect">The <see cref="ParticleEffect"/> to serialize.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Throw if either <paramref name="stream"/> or <paramref name="effect"/> are <see langword="null"/>.
+    /// </exception>
+    public static void Serialize(Stream stream, ParticleEffect effect)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(effect);
+
+        XmlWriterSettings settings = new XmlWriterSettings();
+        settings.Indent = true;
+        settings.IndentChars = "  ";
+        settings.CloseOutput = false;
+        settings.NewLineChars = "\n";
+
+        using XmlWriter writer = XmlWriter.Create(stream, settings);
+        Serialize(writer, effect);
+    }
+
+    private static void Serialize(XmlWriter writer, ParticleEffect effect)
+    {
+        writer.WriteStartDocument();
+        writer.WriteStartElement(nameof(ParticleEffect));
+
+        writer.WriteAttributeString(nameof(ParticleEffect.Name), effect.Name);
+        writer.WriteAttributeVector2(nameof(ParticleEffect.Position), effect.Position);
+        writer.WriteAttributeFloat(nameof(ParticleEffect.Rotation), effect.Rotation);
+        writer.WriteAttributeVector2(nameof(ParticleEffect.Scale), effect.Scale);
+        writer.WriteAttributeBool(nameof(ParticleEffect.AutoTrigger), effect.AutoTrigger);
+        writer.WriteAttributeFloat(nameof(ParticleEffect.AutoTriggerFrequency), effect.AutoTriggerFrequency);
+
+        if (effect.Emitters.Count > 0)
+        {
+            writer.WriteStartElement(nameof(ParticleEffect.Emitters));
+            foreach (ParticleEmitter emitter in effect.Emitters)
+            {
+                writer.WriteStartElement(nameof(ParticleEmitter));
+                WriteParticleEmitter(writer, emitter);
+                writer.WriteEndElement();
+            }
+            writer.WriteEndElement();
+        }
+
+        writer.WriteEndElement();
+        writer.WriteEndDocument();
+
+        writer.Flush();
+    }
+
+    private static void WriteParticleEmitter(XmlWriter writer, ParticleEmitter emitter)
+    {
+        writer.WriteAttributeString(nameof(ParticleEmitter.Name), emitter.Name);
+        writer.WriteAttributeFloat(nameof(ParticleEmitter.LifeSpan), emitter.LifeSpan);
+        writer.WriteAttributeVector2(nameof(ParticleEmitter.Offset), emitter.Offset);
+        writer.WriteAttributeFloat(nameof(ParticleEmitter.LayerDepth), emitter.LayerDepth);
+        writer.WriteAttributeFloat(nameof(ParticleEmitter.ReclaimFrequency), emitter.ReclaimFrequency);
+        writer.WriteAttributeInt(nameof(ParticleEmitter.Capacity), emitter.Capacity);
+        writer.WriteAttributeString(nameof(ParticleEmitter.ModifierExecutionStrategy), emitter.ModifierExecutionStrategy.ToString());
+        writer.WriteAttributeString(nameof(ParticleEmitter.RenderingOrder), emitter.RenderingOrder.ToString());
+
+        if (emitter.TextureRegion is Texture2DRegion region)
+        {
+            writer.WriteStartElement(nameof(ParticleEmitter.TextureRegion));
+            WriteTexture2DRegion(writer, region);
+            writer.WriteEndElement();
+        }
+
+        writer.WriteStartElement(nameof(ParticleEmitter.Parameters));
+        WriteParticleReleaseParameters(writer, emitter.Parameters);
+        writer.WriteEndElement();
+
+        writer.WriteStartElement(nameof(ParticleEmitter.Profile));
+        WriteProfile(writer, emitter.Profile);
+        writer.WriteEndElement();
+
+
+        if (emitter.Modifiers.Count > 0)
+        {
+            writer.WriteStartElement(nameof(ParticleEmitter.Modifiers));
+            foreach (Modifier modifier in emitter.Modifiers)
+            {
+                writer.WriteStartElement(nameof(Modifier));
+                WriteModifier(writer, modifier);
+                writer.WriteEndElement();
+            }
+            writer.WriteEndElement();
+        }
+    }
+
+    private static void WriteTexture2DRegion(XmlWriter writer, Texture2DRegion region)
+    {
+        writer.WriteAttributeString(nameof(Texture2DRegion.Texture.Name), region.Texture.Name);
+        writer.WriteAttributeRectangle(nameof(Texture2DRegion.Bounds), region.Bounds);
+    }
+
+    private static void WriteParticleReleaseParameters(XmlWriter writer, ParticleReleaseParameters parameters)
+    {
+        WriteParticleInt32Parameter(writer, nameof(ParticleReleaseParameters.Quantity), parameters.Quantity);
+        WriteParticleFloatParameter(writer, nameof(ParticleReleaseParameters.Speed), parameters.Speed);
+        WriteParticleColorParameter(writer, nameof(ParticleReleaseParameters.Color), parameters.Color);
+        WriteParticleFloatParameter(writer, nameof(ParticleReleaseParameters.Opacity), parameters.Opacity);
+        WriteParticleVector2Parameter(writer, nameof(ParticleReleaseParameters.Scale), parameters.Scale);
+        WriteParticleFloatParameter(writer, nameof(ParticleReleaseParameters.Rotation), parameters.Rotation);
+        WriteParticleFloatParameter(writer, nameof(ParticleReleaseParameters.Mass), parameters.Mass);
+    }
+
+    private static void WriteParticleInt32Parameter(XmlWriter writer, string name, ParticleInt32Parameter parameter)
+    {
+        writer.WriteStartElement(name);
+        writer.WriteAttributeString(nameof(ParticleInt32Parameter.Kind), parameter.Kind.ToString());
+
+        if (parameter.Kind == ParticleValueKind.Constant)
+        {
+            writer.WriteAttributeInt(nameof(ParticleInt32Parameter.Constant), parameter.Constant);
+        }
+        else
+        {
+            writer.WriteAttributeInt(nameof(ParticleInt32Parameter.RandomMin), parameter.RandomMin);
+            writer.WriteAttributeInt(nameof(ParticleInt32Parameter.RandomMax), parameter.RandomMax);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static void WriteParticleFloatParameter(XmlWriter writer, string name, ParticleFloatParameter parameter)
+    {
+        writer.WriteStartElement(name);
+        writer.WriteAttributeString(nameof(ParticleFloatParameter.Kind), parameter.Kind.ToString());
+
+        if (parameter.Kind == ParticleValueKind.Constant)
+        {
+            writer.WriteAttributeFloat(nameof(ParticleFloatParameter.Constant), parameter.Constant);
+        }
+        else
+        {
+            writer.WriteAttributeFloat(nameof(ParticleFloatParameter.RandomMin), parameter.RandomMin);
+            writer.WriteAttributeFloat(nameof(ParticleFloatParameter.RandomMax), parameter.RandomMax);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static void WriteParticleVector2Parameter(XmlWriter writer, string name, ParticleVector2Parameter parameter)
+    {
+        writer.WriteStartElement(name);
+        writer.WriteAttributeString(nameof(ParticleVector2Parameter.Kind), parameter.Kind.ToString());
+
+        if (parameter.Kind == ParticleValueKind.Constant)
+        {
+            writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.Constant), parameter.Constant);
+        }
+        else
+        {
+            writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMin), parameter.RandomMin);
+            writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMax), parameter.RandomMax);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static void WriteParticleColorParameter(XmlWriter writer, string name, ParticleColorParameter parameter)
+    {
+        writer.WriteStartElement(name);
+        writer.WriteAttributeString(nameof(ParticleColorParameter.Kind), parameter.Kind.ToString());
+
+        if (parameter.Kind == ParticleValueKind.Constant)
+        {
+            writer.WriteAttributeVector3(nameof(ParticleColorParameter.Constant), parameter.Constant);
+        }
+        else
+        {
+            writer.WriteAttributeVector3(nameof(ParticleColorParameter.RandomMin), parameter.RandomMin);
+            writer.WriteAttributeVector3(nameof(ParticleColorParameter.RandomMax), parameter.RandomMax);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static void WriteProfile(XmlWriter writer, Profile profile)
+    {
+        switch (profile)
+        {
+            case BoxFillProfile boxFillProfile:
+                WriteBoxFillProfile(writer, boxFillProfile);
+                break;
+
+            case BoxProfile boxProfile:
+                WriteBoxProfile(writer, boxProfile);
+                break;
+
+            case BoxUniformProfile boxUniformProfile:
+                WriteBoxUniformProfile(writer, boxUniformProfile);
+                break;
+
+            case CircleProfile circleProfile:
+                WriteCircleProfile(writer, circleProfile);
+                break;
+
+            case LineProfile lineProfile:
+                WriteLineProfile(writer, lineProfile);
+                break;
+
+            case PointProfile pointProfile:
+                WritePointProfile(writer, pointProfile);
+                break;
+
+            case RingProfile ringProfile:
+                WriteRingProfile(writer, ringProfile);
+                break;
+
+            case SprayProfile sprayProfile:
+                WriteSprayProfile(writer, sprayProfile);
+                break;
+
+            default:
+                writer.WriteAttributeString(nameof(Type), profile.GetType().ToString());
+                break;
+        }
+    }
+
+    private static void WriteBoxFillProfile(XmlWriter writer, BoxFillProfile profile)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(BoxFillProfile));
+        writer.WriteAttributeFloat(nameof(BoxFillProfile.Width), profile.Width);
+        writer.WriteAttributeFloat(nameof(BoxFillProfile.Height), profile.Height);
+    }
+
+    private static void WriteBoxProfile(XmlWriter writer, BoxProfile profile)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(BoxProfile));
+        writer.WriteAttributeFloat(nameof(BoxProfile.Width), profile.Width);
+        writer.WriteAttributeFloat(nameof(BoxProfile.Height), profile.Height);
+    }
+
+    private static void WriteBoxUniformProfile(XmlWriter writer, BoxUniformProfile profile)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(BoxUniformProfile));
+        writer.WriteAttributeFloat(nameof(BoxUniformProfile.Width), profile.Width);
+        writer.WriteAttributeFloat(nameof(BoxUniformProfile.Height), profile.Height);
+    }
+
+    private static void WriteCircleProfile(XmlWriter writer, CircleProfile profile)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(CircleProfile));
+        writer.WriteAttributeFloat(nameof(CircleProfile.Radius), profile.Radius);
+        writer.WriteAttributeString(nameof(CircleProfile.Radiate), profile.Radiate.ToString());
+    }
+
+    private static void WriteLineProfile(XmlWriter writer, LineProfile profile)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(LineProfile));
+        writer.WriteAttributeVector2(nameof(LineProfile.Axis), profile.Axis);
+        writer.WriteAttributeFloat(nameof(LineProfile.Length), profile.Length);
+        writer.WriteAttributeString(nameof(LineProfile.Radiate), profile.Radiate.ToString());
+        writer.WriteAttributeVector2(nameof(LineProfile.Direction), profile.Direction);
+    }
+
+    private static void WritePointProfile(XmlWriter writer, PointProfile profile)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(PointProfile));
+    }
+
+    private static void WriteRingProfile(XmlWriter writer, RingProfile profile)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(RingProfile));
+        writer.WriteAttributeFloat(nameof(RingProfile.Radius), profile.Radius);
+        writer.WriteAttributeString(nameof(RingProfile.Radiate), profile.Radiate.ToString());
+    }
+
+    private static void WriteSprayProfile(XmlWriter writer, SprayProfile profile)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(SprayProfile));
+        writer.WriteAttributeVector2(nameof(SprayProfile.Direction), profile.Direction);
+        writer.WriteAttributeFloat(nameof(SprayProfile.Spread), profile.Spread);
+    }
+
+    private static void WriteModifier(XmlWriter writer, Modifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Modifier.Name), modifier.Name);
+        writer.WriteAttributeFloat(nameof(Modifier.Frequency), modifier.Frequency);
+
+        switch (modifier)
+        {
+            case AgeModifier ageModifier:
+                WriteAgeModifier(writer, ageModifier);
+                break;
+
+            case CircleContainerModifier circleContainerModifier:
+                WriteCircleContainerModifier(writer, circleContainerModifier);
+                break;
+
+            case DragModifier dragModifier:
+                WriteDragModifier(writer, dragModifier);
+                break;
+
+            case LinearGravityModifier linearGravityModifier:
+                WriteLinearGravityModifier(writer, linearGravityModifier);
+                break;
+
+            case OpacityFastFadeModifier opacityFastFadeModifier:
+                WriteOpacityFastFadeModifier(writer, opacityFastFadeModifier);
+                break;
+
+            case RectangleContainerModifier rectangleContainerModifier:
+                WriteRectangleContainerModifier(writer, rectangleContainerModifier);
+                break;
+
+            case RectangleLoopContainerModifier rectangleLoopContainerModifier:
+                WriteRectangleLoopContainerModifier(writer, rectangleLoopContainerModifier);
+                break;
+
+            case RotationModifier rotationModifier:
+                WriteRotationModifier(writer, rotationModifier);
+                break;
+
+            case VelocityColorModifier velocityColorModifier:
+                WriteVelocityColorModifier(writer, velocityColorModifier);
+                break;
+
+            case VelocityModifier velocityModifier:
+                WriteVelocityModifier(writer, velocityModifier);
+                break;
+
+            case VortexModifier vortexModifier:
+                WriteVortexModifier(writer, vortexModifier);
+                break;
+
+            default:
+                writer.WriteAttributeString(nameof(Type), modifier.GetType().Name);
+                break;
+        }
+    }
+
+    private static void WriteAgeModifier(XmlWriter writer, AgeModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(AgeModifier));
+        if (modifier.Interpolators.Count > 0)
+        {
+            writer.WriteStartElement(nameof(AgeModifier.Interpolators));
+            foreach (Interpolator interpolator in modifier.Interpolators)
+            {
+                writer.WriteStartElement(nameof(Interpolator));
+                WriteInterpolator(writer, interpolator);
+                writer.WriteEndElement();
+            }
+            writer.WriteEndElement();
+        }
+    }
+
+    private static void WriteCircleContainerModifier(XmlWriter writer, CircleContainerModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(CircleContainerModifier));
+        writer.WriteAttributeFloat(nameof(CircleContainerModifier.Radius), modifier.Radius);
+        writer.WriteAttributeBool(nameof(CircleContainerModifier.Inside), modifier.Inside);
+        writer.WriteAttributeFloat(nameof(CircleContainerModifier.RestitutionCoefficient), modifier.RestitutionCoefficient);
+    }
+
+    private static void WriteDragModifier(XmlWriter writer, DragModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(DragModifier));
+        writer.WriteAttributeFloat(nameof(DragModifier.DragCoefficient), modifier.DragCoefficient);
+        writer.WriteAttributeFloat(nameof(DragModifier.Density), modifier.Density);
+    }
+
+    private static void WriteLinearGravityModifier(XmlWriter writer, LinearGravityModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(LinearGravityModifier));
+        writer.WriteAttributeVector2(nameof(LinearGravityModifier.Direction), modifier.Direction);
+        writer.WriteAttributeFloat(nameof(LinearGravityModifier.Strength), modifier.Strength);
+    }
+
+    private static void WriteOpacityFastFadeModifier(XmlWriter writer, OpacityFastFadeModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(OpacityFastFadeModifier));
+    }
+
+    private static void WriteRectangleContainerModifier(XmlWriter writer, RectangleContainerModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(RectangleContainerModifier));
+        writer.WriteAttributeInt(nameof(RectangleContainerModifier.Width), modifier.Width);
+        writer.WriteAttributeInt(nameof(RectangleContainerModifier.Height), modifier.Height);
+        writer.WriteAttributeFloat(nameof(RectangleContainerModifier.RestitutionCoefficient), modifier.RestitutionCoefficient);
+    }
+
+    private static void WriteRectangleLoopContainerModifier(XmlWriter writer, RectangleLoopContainerModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(RectangleLoopContainerModifier));
+        writer.WriteAttributeInt(nameof(RectangleLoopContainerModifier.Width), modifier.Width);
+        writer.WriteAttributeInt(nameof(RectangleLoopContainerModifier.Height), modifier.Height);
+    }
+
+    private static void WriteRotationModifier(XmlWriter writer, RotationModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(RotationModifier));
+        writer.WriteAttributeFloat(nameof(RotationModifier.RotationRate), modifier.RotationRate);
+    }
+
+    private static void WriteVelocityColorModifier(XmlWriter writer, VelocityColorModifier modifier)
+    {
+        Vector3 stationaryColor = new Vector3(modifier.StationaryColor.H, modifier.StationaryColor.S, modifier.StationaryColor.L);
+        Vector3 velocityColor = new Vector3(modifier.VelocityColor.H, modifier.VelocityColor.S, modifier.VelocityColor.L);
+
+        writer.WriteAttributeString(nameof(Type), nameof(VelocityColorModifier));
+        writer.WriteAttributeVector3(nameof(VelocityColorModifier.StationaryColor), stationaryColor);
+        writer.WriteAttributeVector3(nameof(VelocityColorModifier.VelocityColor), velocityColor);
+        writer.WriteAttributeFloat(nameof(VelocityColorModifier.VelocityThreshold), modifier.VelocityThreshold);
+    }
+
+    private static void WriteVelocityModifier(XmlWriter writer, VelocityModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(VelocityModifier));
+        writer.WriteAttributeFloat(nameof(VelocityModifier.VelocityThreshold), modifier.VelocityThreshold);
+        if (modifier.Interpolators.Count > 0)
+        {
+            writer.WriteStartElement(nameof(VelocityModifier.Interpolators));
+            foreach (Interpolator interpolator in modifier.Interpolators)
+            {
+                writer.WriteStartElement(nameof(Interpolator));
+                WriteInterpolator(writer, interpolator);
+                writer.WriteEndElement();
+            }
+            writer.WriteEndElement();
+        }
+    }
+
+    private static void WriteVortexModifier(XmlWriter writer, VortexModifier modifier)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(VortexModifier));
+        writer.WriteAttributeVector2(nameof(VortexModifier.Position), modifier.Position);
+        writer.WriteAttributeFloat(nameof(VortexModifier.Strength), modifier.Strength);
+        writer.WriteAttributeFloat(nameof(VortexModifier.OuterRadius), modifier.OuterRadius);
+        writer.WriteAttributeFloat(nameof(VortexModifier.InnerRadius), modifier.InnerRadius);
+        writer.WriteAttributeFloat(nameof(VortexModifier.MaxVelocity), modifier.MaxVelocity);
+        writer.WriteAttributeFloat(nameof(VortexModifier.RotationAngle), modifier.RotationAngle);
+    }
+
+    private static void WriteInterpolator(XmlWriter writer, Interpolator interpolator)
+    {
+        writer.WriteAttributeString(nameof(interpolator.Name), interpolator.Name);
+
+        switch (interpolator)
+        {
+            case ColorInterpolator colorInterpolator:
+                WriteColorInterpolator(writer, colorInterpolator);
+                break;
+
+            case HueInterpolator hueInterpolator:
+                WriteHueInterpolator(writer, hueInterpolator);
+                break;
+
+            case OpacityInterpolator opacityInterpolator:
+                WriteOpacityInterpolator(writer, opacityInterpolator);
+                break;
+
+            case RotationInterpolator rotationInterpolator:
+                WriteRotationInterpolator(writer, rotationInterpolator);
+                break;
+
+            case ScaleInterpolator scaleInterpolator:
+                WriteScaleInterpolator(writer, scaleInterpolator);
+                break;
+
+            case VelocityInterpolator velocityInterpolator:
+                WriteVelocityInterpolator(writer, velocityInterpolator);
+                break;
+
+            default:
+                writer.WriteAttributeString(nameof(Type), interpolator.GetType().Name);
+                break;
+        }
+    }
+
+    private static void WriteColorInterpolator(XmlWriter writer, ColorInterpolator interpolator)
+    {
+        Vector3 startValue = new Vector3(interpolator.StartValue.H, interpolator.StartValue.S, interpolator.StartValue.L);
+        Vector3 endValue = new Vector3(interpolator.EndValue.H, interpolator.EndValue.S, interpolator.EndValue.L);
+
+        writer.WriteAttributeString(nameof(Type), nameof(ColorInterpolator));
+        writer.WriteAttributeVector3(nameof(ColorInterpolator.StartValue), startValue);
+        writer.WriteAttributeVector3(nameof(ColorInterpolator.EndValue), endValue);
+    }
+
+    private static void WriteHueInterpolator(XmlWriter writer, HueInterpolator interpolator)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(HueInterpolator));
+        writer.WriteAttributeFloat(nameof(HueInterpolator.StartValue), interpolator.StartValue);
+        writer.WriteAttributeFloat(nameof(HueInterpolator.EndValue), interpolator.EndValue);
+    }
+
+    private static void WriteOpacityInterpolator(XmlWriter writer, OpacityInterpolator interpolator)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(OpacityInterpolator));
+        writer.WriteAttributeFloat(nameof(OpacityInterpolator.StartValue), interpolator.StartValue);
+        writer.WriteAttributeFloat(nameof(OpacityInterpolator.EndValue), interpolator.EndValue);
+    }
+
+    private static void WriteRotationInterpolator(XmlWriter writer, RotationInterpolator interpolator)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(RotationInterpolator));
+        writer.WriteAttributeFloat(nameof(RotationInterpolator.StartValue), interpolator.StartValue);
+        writer.WriteAttributeFloat(nameof(RotationInterpolator.EndValue), interpolator.EndValue);
+    }
+
+    private static void WriteScaleInterpolator(XmlWriter writer, ScaleInterpolator interpolator)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(ScaleInterpolator));
+        writer.WriteAttributeVector2(nameof(ScaleInterpolator.StartValue), interpolator.StartValue);
+        writer.WriteAttributeVector2(nameof(ScaleInterpolator.EndValue), interpolator.EndValue);
+    }
+
+    private static void WriteVelocityInterpolator(XmlWriter writer, VelocityInterpolator interpolator)
+    {
+        writer.WriteAttributeString(nameof(Type), nameof(VelocityInterpolator));
+        writer.WriteAttributeVector2(nameof(VelocityInterpolator.StartValue), interpolator.StartValue);
+        writer.WriteAttributeVector2(nameof(VelocityInterpolator.EndValue), interpolator.EndValue);
+    }
+
+    #endregion Serialize
 }

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -20,7 +20,7 @@ namespace MonoGame.Extended.Particles;
 /// </summary>
 public static class ParticleEffectSerializer
 {
-    # region Deserialize
+    #region Deserialize
 
     /// <summary>
     /// Deserializes a <see cref="ParticleEffect"/> from an XML file.

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -183,6 +183,13 @@ public static class ParticleEffectSerializer
         }
 
         string path = Path.Combine(baseDirectory, name);
+
+        // Content manager will throw exception if the path given is a rooted path
+        if (Path.IsPathRooted(path))
+        {
+            path = Path.GetRelativePath(baseDirectory, path);
+        }
+
         Texture2D texture = content.Load<Texture2D>(path);
 
         Rectangle bounds = reader.GetAttributeRectangle(nameof(Texture2DRegion.Bounds));

--- a/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
@@ -15,6 +15,7 @@ namespace MonoGame.Extended.Particles;
 /// <summary>
 /// Represents a writer that serializes a <see cref="ParticleEffect"/> to an XML configuration.
 /// </summary>
+[Obsolete("Use ParticleEffectSerializer.Serialize.  ParticleEffectWriter will be removed in 6.0.0")]
 public class ParticleEffectWriter : IDisposable
 {
     private readonly XmlWriter _writer;

--- a/source/MonoGame.Extended/Serialization/Xml/XmlReaderExtensions.cs
+++ b/source/MonoGame.Extended/Serialization/Xml/XmlReaderExtensions.cs
@@ -46,6 +46,32 @@ public static class XmlReaderExtensions
     }
 
     /// <summary>
+    /// Reads an XML attribute as an <see langword="int"/> value, returning a default value if the attribute is missing or invalid.
+    /// </summary>
+    /// <param name="reader">The XML reader instance.</param>
+    /// <param name="attributeName">The name of the attribute to read.</param>
+    /// <param name="defaultValue">The default value to return if the attribute is missing or cannot be parsed.</param>
+    /// <returns>The <see langword="int"/> value parsed from the value of the specified attribute, or the default value if parsing fails.</returns>
+    public static int GetAttributeInt(this XmlReader reader, string attributeName, int defaultValue)
+    {
+        string value = reader.GetAttribute(attributeName);
+
+        if (value == null)
+        {
+            return defaultValue;
+        }
+
+        try
+        {
+            return int.Parse(value);
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+
+    /// <summary>
     /// Reads an XML attribute as a <see langword="float"/> value.
     /// </summary>
     /// <param name="reader">The XML reader instance.</param>
@@ -73,6 +99,32 @@ public static class XmlReaderExtensions
                 $"Invalid float format for attribute '{attributeName}'. Expected float, but got '{value}'",
                 ex
             );
+        }
+    }
+
+    /// <summary>
+    /// Reads an XML attribute as a <see langword="float"/> value, returning a default value if the attribute is missing or invalid.
+    /// </summary>
+    /// <param name="reader">The XML reader instance.</param>
+    /// <param name="attributeName">The name of the attribute to read.</param>
+    /// <param name="defaultValue">The default value to return if the attribute is missing or cannot be parsed.</param>
+    /// <returns>The <see langword="float"/> value parsed from the specified attribute, or the default value if parsing fails.</returns>
+    public static float GetAttributeFloat(this XmlReader reader, string attributeName, float defaultValue)
+    {
+        string value = reader.GetAttribute(attributeName);
+
+        if (value == null)
+        {
+            return defaultValue;
+        }
+
+        try
+        {
+            return float.Parse(value);
+        }
+        catch
+        {
+            return defaultValue;
         }
     }
 
@@ -108,6 +160,32 @@ public static class XmlReaderExtensions
     }
 
     /// <summary>
+    /// Reads an XML attribute as a <see langword="bool"/> value, returning a default value if the attribute is missing or invalid.
+    /// </summary>
+    /// <param name="reader">The XML reader instance.</param>
+    /// <param name="attributeName">The name of the attribute to read.</param>
+    /// <param name="defaultValue">The default value to return if the attribute is missing or cannot be parsed.</param>
+    /// <returns>The <see langword="bool"/> value parsed from the value of the specified attribute, or the default value if parsing fails.</returns>
+    public static bool GetAttributeBool(this XmlReader reader, string attributeName, bool defaultValue)
+    {
+        string value = reader.GetAttribute(attributeName);
+
+        if (value == null)
+        {
+            return defaultValue;
+        }
+
+        try
+        {
+            return bool.Parse(value);
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+
+    /// <summary>
     /// Reads an XML attribute as an enumeration value.
     /// </summary>
     /// <typeparam name="T">The enumeration type to parse.</typeparam>
@@ -136,6 +214,33 @@ public static class XmlReaderExtensions
                 $"Invalid {typeof(T).Name} format for attribute '{attributeName}'. Expected a {typeof(T).Name} value but got '{value}'",
                 ex
             );
+        }
+    }
+
+    /// <summary>
+    /// Reads an XML attribute as an enumeration value, returning a default value if the attribute is missing or invalid.
+    /// </summary>
+    /// <typeparam name="T">The enumeration type to parse.</typeparam>
+    /// <param name="reader">The XML reader instance.</param>
+    /// <param name="attributeName">The name of the attribute to read.</param>
+    /// <param name="defaultValue">The default value to return if the attribute is missing or cannot be parsed.</param>
+    /// <returns>The enumeration value parsed from the value of the specified attribute, or the default value if parsing fails.</returns>
+    public static T GetAttributeEnum<T>(this XmlReader reader, string attributeName, T defaultValue) where T : struct, Enum
+    {
+        string value = reader.GetAttribute(attributeName);
+
+        if (value == null)
+        {
+            return defaultValue;
+        }
+
+        try
+        {
+            return Enum.Parse<T>(value);
+        }
+        catch
+        {
+            return defaultValue;
         }
     }
 
@@ -183,6 +288,44 @@ public static class XmlReaderExtensions
     }
 
     /// <summary>
+    /// Reads an XML attribute as a <see cref="Rectangle"/> value, returning a default value if the attribute is missing or invalid.
+    /// </summary>
+    /// <param name="reader">The XML reader instance.</param>
+    /// <param name="attributeName">The name of the attribute to read.</param>
+    /// <param name="defaultValue">The default value to return if the attribute is missing or cannot be parsed.</param>
+    /// <returns>The <see cref="Rectangle"/> value parsed from the value of the specified attribute, or the default value if parsing fails.</returns>
+    public static Rectangle GetAttributeRectangle(this XmlReader reader, string attributeName, Rectangle defaultValue)
+    {
+        string value = reader.GetAttribute(attributeName);
+
+        if (value == null)
+        {
+            return defaultValue;
+        }
+
+        string[] split = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        try
+        {
+            if (split.Length != 4)
+            {
+                return defaultValue;
+            }
+
+            int x = int.Parse(split[0]);
+            int y = int.Parse(split[1]);
+            int width = int.Parse(split[2]);
+            int height = int.Parse(split[3]);
+
+            return new Rectangle(x, y, width, height);
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+
+    /// <summary>
     /// Reads an XML attribute as a <see cref="Vector2"/> value.
     /// </summary>
     /// <param name="reader">The XML reader instance.</param>
@@ -220,6 +363,42 @@ public static class XmlReaderExtensions
                 $"Invalid {nameof(Vector2)} format for attribute '{attributeName}'. Expected 'x,y', but got '{value}'",
                 ex
             );
+        }
+    }
+
+    /// <summary>
+    /// Reads an XML attribute as a <see cref="Vector2"/> value, returning a default value if the attribute is missing or invalid.
+    /// </summary>
+    /// <param name="reader">The XML reader instance.</param>
+    /// <param name="attributeName">The name of the attribute to read.</param>
+    /// <param name="defaultValue">The default value to return if the attribute is missing or cannot be parsed.</param>
+    /// <returns>The <see cref="Vector2"/> value parsed from the value of the specified attribute, or the default value if parsing fails.</returns>
+    public static Vector2 GetAttributeVector2(this XmlReader reader, string attributeName, Vector2 defaultValue)
+    {
+        string value = reader.GetAttribute(attributeName);
+
+        if (value == null)
+        {
+            return defaultValue;
+        }
+
+        string[] split = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        try
+        {
+            if (split.Length != 2)
+            {
+                return defaultValue;
+            }
+
+            float x = float.Parse(split[0]);
+            float y = float.Parse(split[1]);
+
+            return new Vector2(x, y);
+        }
+        catch
+        {
+            return defaultValue;
         }
     }
 
@@ -262,6 +441,43 @@ public static class XmlReaderExtensions
                 $"Invalid {nameof(Vector3)} format for attribute '{attributeName}'. Expected 'x,y,z', but got '{value}'",
                 ex
             );
+        }
+    }
+
+    /// <summary>
+    /// Reads an XML attribute as a <see cref="Vector3"/> value, returning a default value if the attribute is missing or invalid.
+    /// </summary>
+    /// <param name="reader">The XML reader instance.</param>
+    /// <param name="attributeName">The name of the attribute to read.</param>
+    /// <param name="defaultValue">The default value to return if the attribute is missing or cannot be parsed.</param>
+    /// <returns>The <see cref="Vector3"/> value parsed from the value of the specified attribute, or the default value if parsing fails.</returns>
+    public static Vector3 GetAttributeVector3(this XmlReader reader, string attributeName, Vector3 defaultValue)
+    {
+        string value = reader.GetAttribute(attributeName);
+
+        if (value == null)
+        {
+            return defaultValue;
+        }
+
+        string[] split = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        try
+        {
+            if (split.Length != 3)
+            {
+                return defaultValue;
+            }
+
+            float x = float.Parse(split[0]);
+            float y = float.Parse(split[1]);
+            float z = float.Parse(split[2]);
+
+            return new Vector3(x, y, z);
+        }
+        catch
+        {
+            return defaultValue;
         }
     }
 }

--- a/tests/MonoGame.Extended.Tests/Particles/ParticleEffectSerializerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Particles/ParticleEffectSerializerTests.cs
@@ -1,0 +1,2191 @@
+using System;
+using System.IO;
+using System.Xml;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Particles;
+using MonoGame.Extended.Particles.Modifiers;
+using MonoGame.Extended.Particles.Modifiers.Containers;
+using MonoGame.Extended.Particles.Modifiers.Interpolators;
+using MonoGame.Extended.Particles.Profiles;
+
+namespace MonoGame.Extended.Tests.Particles;
+
+public sealed class ParticleEffectSerializerTests
+{
+    private readonly MockContentManager _mockContentManager;
+
+    public ParticleEffectSerializerTests()
+    {
+        _mockContentManager = new MockContentManager();
+    }
+
+    private ParticleEffect ReadParticleEffectFromXml(string xml)
+    {
+        using MemoryStream stream = new MemoryStream();
+        using StreamWriter writer = new StreamWriter(stream);
+        writer.Write(xml);
+        writer.Flush();
+        stream.Position = 0;
+
+        return ParticleEffectSerializer.Deserialize(stream, _mockContentManager);
+    }
+
+    [Fact]
+    public void Deserialize_NullStream_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => ParticleEffectSerializer.Deserialize((Stream)null!, _mockContentManager));
+    }
+
+    [Fact]
+    public void Deserialize_NullContentManager_ThrowsArgumentNullException()
+    {
+        using MemoryStream stream = new MemoryStream();
+        Assert.Throws<ArgumentNullException>(() => ParticleEffectSerializer.Deserialize(stream, null));
+    }
+
+    [Fact]
+    public void Deserialize_InvalidXmlRoot_ThrowsXmlException()
+    {
+        string xml = "<InvalidRoot />";
+        Assert.Throws<XmlException>(() => ReadParticleEffectFromXml(xml));
+    }
+
+    [Fact]
+    public void Deserialize_EmptyEffect_ReturnsExpected()
+    {
+        string xml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="EmptyEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1" />
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Equal("EmptyEffect", effect.Name);
+        Assert.Equal(Vector2.Zero, effect.Position);
+        Assert.Equal(0.0f, effect.Rotation);
+        Assert.Equal(Vector2.One, effect.Scale);
+        Assert.Empty(effect.Emitters);
+        Assert.True(effect.AutoTrigger);
+        Assert.Equal(1.0f, effect.AutoTriggerFrequency);
+    }
+
+    [Fact]
+    public void Deserialize_EmptyModifiers_ReturnsExpected()
+    {
+        string xml =
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="EmptyModifiers" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Empty(emitter.Modifiers);
+    }
+
+    [Fact]
+    public void Deserialize_BoxFillProfile_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="BoxFillProfile" Width="1" Height="1" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        BoxFillProfile profile = Assert.IsType<BoxFillProfile>(emitter.Profile);
+        Assert.Equal(1.0f, profile.Height);
+        Assert.Equal(1.0f, profile.Height);
+    }
+
+    [Fact]
+    public void Deserialize_BoxProfile_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="BoxProfile" Width="1" Height="1" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        BoxProfile profile = Assert.IsType<BoxProfile>(emitter.Profile);
+        Assert.Equal(1.0f, profile.Height);
+        Assert.Equal(1.0f, profile.Height);
+    }
+
+    [Fact]
+    public void DeserializeBoxUniformProfile_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="BoxUniformProfile" Width="1" Height="1" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        BoxUniformProfile profile = Assert.IsType<BoxUniformProfile>(emitter.Profile);
+        Assert.Equal(1.0f, profile.Height);
+        Assert.Equal(1.0f, profile.Height);
+    }
+
+    [Fact]
+    public void DeserializeCircleProfile_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="CircleProfile" Radius="1" Radiate="Out" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        CircleProfile profile = Assert.IsType<CircleProfile>(emitter.Profile);
+        Assert.Equal(1.0f, profile.Radius);
+        Assert.Equal(CircleRadiation.Out, profile.Radiate);
+    }
+
+    [Fact]
+    public void DeserializeLineProfile_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="LineProfile" Axis="1,1" Length="1" Direction="0,0" Radiate="None" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        LineProfile profile = Assert.IsType<LineProfile>(emitter.Profile);
+        Assert.Equal(Vector2.One, profile.Axis);
+        Assert.Equal(1.0f, profile.Length);
+    }
+
+    [Fact]
+    public void DeserializePointProfile_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.IsType<PointProfile>(emitter.Profile);
+    }
+
+    [Fact]
+    public void DeserializeRingProfile_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="RingProfile" Radius="1" Radiate="In" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        RingProfile profile = Assert.IsType<RingProfile>(emitter.Profile);
+        Assert.Equal(1.0f, profile.Radius);
+        Assert.Equal(CircleRadiation.In, profile.Radiate);
+    }
+
+    [Fact]
+    public void DeserializeSprayProfile_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="SprayProfile" Direction="1,1" Spread="1" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        SprayProfile profile = Assert.IsType<SprayProfile>(emitter.Profile);
+        Assert.Equal(Vector2.One, profile.Direction);
+        Assert.Equal(1.0f, profile.Spread);
+    }
+
+    [Fact]
+    public void DeserializeAgeModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        AgeModifier modifier = Assert.IsType<AgeModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.Equal(nameof(AgeModifier), modifier.Name);
+    }
+
+    [Fact]
+    public void DeserializeCircleContainerModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="CircleContainerModifier" Enabled="true" Frequency="60" Type="CircleContainerModifier" Radius="0" Inside="True" RestitutionCoefficient="1" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        CircleContainerModifier modifier = Assert.IsType<CircleContainerModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(nameof(CircleContainerModifier), modifier.Name);
+        Assert.Equal(0.0f, modifier.Radius);
+        Assert.True(modifier.Inside);
+        Assert.Equal(1.0f, modifier.RestitutionCoefficient);
+    }
+
+    [Fact]
+    public void DeserializeDragModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="DragModifier" Enabled="true" Frequency="60" Type="DragModifier" DragCoefficient="0.47" Density="0.5" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        DragModifier modifier = Assert.IsType<DragModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(nameof(DragModifier), modifier.Name);
+        Assert.Equal(0.47f, modifier.DragCoefficient);
+        Assert.Equal(0.5f, modifier.Density);
+    }
+
+    [Fact]
+    public void DeserializeLinearGravityModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="LinearGravityModifier" Enabled="true" Frequency="60" Type="LinearGravityModifier" Direction="0,0" Strength="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        LinearGravityModifier modifier = Assert.IsType<LinearGravityModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(nameof(LinearGravityModifier), modifier.Name);
+        Assert.Equal(Vector2.Zero, modifier.Direction);
+        Assert.Equal(0.0f, modifier.Strength);
+    }
+
+    [Fact]
+    public void DeserializeOpacityFastFadeModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="OpacityFastFadeModifier" Enabled="true" Frequency="60" Type="OpacityFastFadeModifier" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        OpacityFastFadeModifier modifier = Assert.IsType<OpacityFastFadeModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(nameof(OpacityFastFadeModifier), modifier.Name);
+    }
+
+    [Fact]
+    public void DeserializeRectangleContainerModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="RectangleContainerModifier" Enabled="true" Frequency="60" Type="RectangleContainerModifier" Width="0" Height="0" RestitutionCoefficient="1" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        RectangleContainerModifier modifier = Assert.IsType<RectangleContainerModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(nameof(RectangleContainerModifier), modifier.Name);
+        Assert.Equal(0.0f, modifier.Width);
+        Assert.Equal(0.0f, modifier.Height);
+        Assert.Equal(1.0f, modifier.RestitutionCoefficient);
+    }
+
+    [Fact]
+    public void DeserializeRectangleLoopContainerModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="RectangleLoopContainerModifier" Enabled="true" Frequency="60" Type="RectangleLoopContainerModifier" Width="0" Height="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        RectangleLoopContainerModifier modifier = Assert.IsType<RectangleLoopContainerModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(nameof(RectangleLoopContainerModifier), modifier.Name);
+        Assert.Equal(0.0f, modifier.Width);
+        Assert.Equal(0.0f, modifier.Height);
+    }
+
+    [Fact]
+    public void DeserializeRotationModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="RotationModifier" Enabled="true" Frequency="60" Type="RotationModifier" RotationRate="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        RotationModifier modifier = Assert.IsType<RotationModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(nameof(RotationModifier), modifier.Name);
+        Assert.Equal(0.0f, modifier.RotationRate);
+    }
+
+    [Fact]
+    public void DeserializeVelocityColorModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="VelocityColorModifier" Enabled="true" Frequency="60" Type="VelocityColorModifier" StationaryColor="0,0,0" VelocityColor="0,0,0" VelocityThreshold="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        VelocityColorModifier modifier = Assert.IsType<VelocityColorModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.True(modifier.Enabled);
+        Assert.Equal(nameof(VelocityColorModifier), modifier.Name);
+        Assert.Equal(new HslColor(0, 0, 0), modifier.StationaryColor);
+        Assert.Equal(new HslColor(0, 0, 0), modifier.VelocityColor);
+        Assert.Equal(0.0f, modifier.VelocityThreshold);
+    }
+
+    [Fact]
+    public void DeserializeVelocityModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="VelocityModifier" Enabled="true" Frequency="60" Type="VelocityModifier" VelocityThreshold="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        VelocityModifier modifier = Assert.IsType<VelocityModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.Equal(nameof(VelocityModifier), modifier.Name);
+        Assert.Equal(0.0f, modifier.VelocityThreshold);
+    }
+
+    [Fact]
+    public void DeserializeVortexModifier_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="VortexModifier" Enabled="true" Frequency="60" Type="VortexModifier" Position="0,0" Strength="1" OuterRadius="2" InnerRadius="3" MaxVelocity="4" RotationAngle="5" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+
+        VortexModifier modifier = Assert.IsType<VortexModifier>(effect.Emitters[0].Modifiers[0]);
+        Assert.Equal(60.0f, modifier.Frequency);
+        Assert.Equal(nameof(VortexModifier), modifier.Name);
+        Assert.Equal(Vector2.Zero, modifier.Position);
+        Assert.Equal(1.0f, modifier.Strength);
+        Assert.Equal(2.0f, modifier.OuterRadius);
+        Assert.Equal(3.0f, modifier.InnerRadius);
+        Assert.Equal(4.0f, modifier.MaxVelocity);
+        Assert.Equal(5.0f, modifier.RotationAngle);
+    }
+
+    [Fact]
+    public void DeserializeColorInterpolator_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="ColorInterpolator" Type="ColorInterpolator" Enabled="true" StartValue="0,0,0" EndValue="0,0,0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+        AgeModifier modifier = Assert.IsType<AgeModifier>(emitter.Modifiers[0]);
+
+        Assert.Single(modifier.Interpolators);
+
+        ColorInterpolator interpolator = Assert.IsType<ColorInterpolator>(modifier.Interpolators[0]);
+        Assert.True(interpolator.Enabled);
+        Assert.Equal(new HslColor(0, 0, 0), interpolator.StartValue);
+        Assert.Equal(new HslColor(0, 0, 0), interpolator.EndValue);
+    }
+
+    [Fact]
+    public void DeserializeHueInterpolator_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="HueInterpolator" Type="HueInterpolator" Enabled="true" StartValue="0" EndValue="0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+        AgeModifier modifier = Assert.IsType<AgeModifier>(emitter.Modifiers[0]);
+
+        Assert.Single(modifier.Interpolators);
+
+        HueInterpolator interpolator = Assert.IsType<HueInterpolator>(modifier.Interpolators[0]);
+        Assert.True(interpolator.Enabled);
+        Assert.Equal(0.0f, interpolator.StartValue);
+        Assert.Equal(0.0f, interpolator.EndValue);
+    }
+
+    [Fact]
+    public void DeserializeOpacityInterpolator_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="OpacityInterpolator" Type="OpacityInterpolator" Enabled="true" StartValue="0" EndValue="0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+        AgeModifier modifier = Assert.IsType<AgeModifier>(emitter.Modifiers[0]);
+
+        Assert.Single(modifier.Interpolators);
+
+        OpacityInterpolator interpolator = Assert.IsType<OpacityInterpolator>(modifier.Interpolators[0]);
+        Assert.True(interpolator.Enabled);
+        Assert.Equal(0.0f, interpolator.StartValue);
+        Assert.Equal(0.0f, interpolator.EndValue);
+    }
+
+    [Fact]
+    public void DeserializeRotationInterpolator_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="RotationInterpolator" Type="RotationInterpolator" Enabled="true" StartValue="0" EndValue="0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+        AgeModifier modifier = Assert.IsType<AgeModifier>(emitter.Modifiers[0]);
+
+        Assert.Single(modifier.Interpolators);
+
+        RotationInterpolator interpolator = Assert.IsType<RotationInterpolator>(modifier.Interpolators[0]);
+        Assert.True(interpolator.Enabled);
+        Assert.Equal(0.0f, interpolator.StartValue);
+        Assert.Equal(0.0f, interpolator.EndValue);
+    }
+
+    [Fact]
+    public void DeserializeScaleInterpolator_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0,0" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" Enabled="true" StartValue="0,0" EndValue="1,1" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+        AgeModifier modifier = Assert.IsType<AgeModifier>(emitter.Modifiers[0]);
+
+        Assert.Single(modifier.Interpolators);
+
+        ScaleInterpolator interpolator = Assert.IsType<ScaleInterpolator>(modifier.Interpolators[0]);
+        Assert.True(interpolator.Enabled);
+        Assert.Equal(Vector2.Zero, interpolator.StartValue);
+        Assert.Equal(Vector2.One, interpolator.EndValue);
+    }
+
+    [Fact]
+    public void DeserializeVelocityInterpolator_ReadsExpected()
+    {
+        string xml =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="VelocityInterpolator" Type="VelocityInterpolator" Enabled="true" StartValue="0,0" EndValue="0,0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        ParticleEffect effect = ReadParticleEffectFromXml(xml);
+
+        Assert.Single(effect.Emitters);
+        ParticleEmitter emitter = effect.Emitters[0];
+
+        Assert.Single(emitter.Modifiers);
+        AgeModifier modifier = Assert.IsType<AgeModifier>(emitter.Modifiers[0]);
+
+        Assert.Single(modifier.Interpolators);
+
+        VelocityInterpolator interpolator = Assert.IsType<VelocityInterpolator>(modifier.Interpolators[0]);
+        Assert.True(interpolator.Enabled);
+        Assert.Equal(Vector2.Zero, interpolator.StartValue);
+        Assert.Equal(Vector2.Zero, interpolator.EndValue);
+    }
+
+    [Fact]
+    public void SerializeNulLEffect_ThrowsArgumentNullException()
+    {
+        using MemoryStream stream = new MemoryStream();
+        using ParticleEffectWriter writer = new ParticleEffectWriter(stream);
+        Assert.Throws<ArgumentNullException>(() => writer.WriteParticleEffect(null));
+    }
+
+    [Fact]
+    public void SerializeEmptyEffect_WritesMinimalXml()
+    {
+        ParticleEffect effect = new ParticleEffect("EmptyEffect");
+
+        string expected =
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="EmptyEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1" />
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeEmptyModifiers_WritesMinimalXml()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "EmptyModifiers";
+        effect.Emitters.Add(emitter);
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="EmptyModifiers" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeEmptyInterpolators_WritesMinimalXml()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        effect.Emitters.Add(emitter);
+        AgeModifier ageModifier = new AgeModifier();
+        emitter.Modifiers.Add(ageModifier);
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeBoxFillProfile_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.BoxFill(1.0f, 2.0f);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="BoxFillProfile" Width="1" Height="2" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeBoxProfile_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Box(1.0f, 2.0f);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="BoxProfile" Width="1" Height="2" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeBoxUniformProfile_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.BoxUniform(1.0f, 2.0f);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="BoxUniformProfile" Width="1" Height="2" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeCircleProfile_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Circle(1.0f, CircleRadiation.Out);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="CircleProfile" Radius="1" Radiate="Out" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeLineProfile_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Line(Vector2.One, 1.0f);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="LineProfile" Axis="1,1" Length="1" Radiate="None" Direction="0,1" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializePointProfile_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeRingProfile_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Ring(1.0f, CircleRadiation.In);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="RingProfile" Radius="1" Radiate="In" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeSprayProfile_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Spray(Vector2.One, 1.0f);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="SprayProfile" Direction="1,1" Spread="1" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeAgeModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        AgeModifier modifier = new AgeModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeCircleContainerModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        CircleContainerModifier modifier = new CircleContainerModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="CircleContainerModifier" Frequency="60" Type="CircleContainerModifier" Radius="0" Inside="True" RestitutionCoefficient="1" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeDragModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        DragModifier modifier = new DragModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="DragModifier" Frequency="60" Type="DragModifier" DragCoefficient="0.47" Density="0.5" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeLinearGravityModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        LinearGravityModifier modifier = new LinearGravityModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="LinearGravityModifier" Frequency="60" Type="LinearGravityModifier" Direction="0,0" Strength="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeOpacityFastFadeModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        OpacityFastFadeModifier modifier = new OpacityFastFadeModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="OpacityFastFadeModifier" Frequency="60" Type="OpacityFastFadeModifier" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeRectangleContainerModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        RectangleContainerModifier modifier = new RectangleContainerModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="RectangleContainerModifier" Frequency="60" Type="RectangleContainerModifier" Width="0" Height="0" RestitutionCoefficient="1" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeRectangleLoopContainerModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        RectangleLoopContainerModifier modifier = new RectangleLoopContainerModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="RectangleLoopContainerModifier" Frequency="60" Type="RectangleLoopContainerModifier" Width="0" Height="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeRotationModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        RotationModifier modifier = new RotationModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="RotationModifier" Frequency="60" Type="RotationModifier" RotationRate="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeVelocityColorModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        VelocityColorModifier modifier = new VelocityColorModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="VelocityColorModifier" Frequency="60" Type="VelocityColorModifier" StationaryColor="0,0,0" VelocityColor="0,0,0" VelocityThreshold="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeVelocityModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        VelocityModifier modifier = new VelocityModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="VelocityModifier" Frequency="60" Type="VelocityModifier" VelocityThreshold="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeVortexModifier_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        VortexModifier modifier = new VortexModifier();
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="VortexModifier" Frequency="60" Type="VortexModifier" Position="0,0" Strength="0" OuterRadius="0" InnerRadius="0" MaxVelocity="0" RotationAngle="0" />
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeColorInterpolator_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        AgeModifier modifier = new AgeModifier();
+        ColorInterpolator interpolator = new ColorInterpolator();
+        modifier.Interpolators.Add(interpolator);
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="ColorInterpolator" Type="ColorInterpolator" StartValue="0,0,0" EndValue="0,0,0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeHueInterpolator_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        AgeModifier modifier = new AgeModifier();
+        HueInterpolator interpolator = new HueInterpolator();
+        modifier.Interpolators.Add(interpolator);
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="HueInterpolator" Type="HueInterpolator" StartValue="0" EndValue="0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeOpacityInterpolator_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        AgeModifier modifier = new AgeModifier();
+        OpacityInterpolator interpolator = new OpacityInterpolator();
+        modifier.Interpolators.Add(interpolator);
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="OpacityInterpolator" Type="OpacityInterpolator" StartValue="0" EndValue="0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeRotationInterpolator_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        AgeModifier modifier = new AgeModifier();
+        RotationInterpolator interpolator = new RotationInterpolator();
+        modifier.Interpolators.Add(interpolator);
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="RotationInterpolator" Type="RotationInterpolator" StartValue="0" EndValue="0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeScaleInterpolator_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        AgeModifier modifier = new AgeModifier();
+        ScaleInterpolator interpolator = new ScaleInterpolator();
+        modifier.Interpolators.Add(interpolator);
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" StartValue="0,0" EndValue="0,0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    [Fact]
+    public void SerializeVelocityInterpolator_WritesExpected()
+    {
+        ParticleEffect effect = new ParticleEffect("TestEffect");
+        ParticleEmitter emitter = new ParticleEmitter(1);
+        emitter.Name = "TestEmitter";
+        emitter.Profile = Profile.Point();
+        AgeModifier modifier = new AgeModifier();
+        VelocityInterpolator interpolator = new VelocityInterpolator();
+        modifier.Interpolators.Add(interpolator);
+        emitter.Modifiers.Add(modifier);
+        effect.Emitters.Add(emitter);
+
+
+        string expected =
+           $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect" Position="0,0" Rotation="0" Scale="1,1" AutoTrigger="True" AutoTriggerFrequency="1">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <Parameters>
+                    <Quantity Kind="Random" RandomMin="5" RandomMax="100" />
+                    <Speed Kind="Random" RandomMin="50" RandomMax="100" />
+                    <Color Kind="Constant" Constant="1,1,1" />
+                    <Opacity Kind="Random" RandomMin="0" RandomMax="1" />
+                    <Scale Kind="Random" RandomMin="0.5,0.5" RandomMax="1,1" />
+                    <Rotation Kind="Random" RandomMin="{-MathF.PI}" RandomMax="{MathF.PI}" />
+                    <Mass Kind="Constant" Constant="1" />
+                  </Parameters>
+                  <Profile Type="PointProfile" />
+                  <Modifiers>
+                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                      <Interpolators>
+                        <Interpolator Name="VelocityInterpolator" Type="VelocityInterpolator" StartValue="0,0" EndValue="0,0" />
+                      </Interpolators>
+                    </Modifier>
+                  </Modifiers>
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        AssertParticleEffect(effect, expected);
+    }
+
+    private static void AssertParticleEffect(ParticleEffect effect, string expected)
+    {
+        using MemoryStream stream = new MemoryStream();
+        ParticleEffectSerializer.Serialize(stream, effect);
+
+        stream.Position = 0;
+        using StreamReader reader = new StreamReader(stream);
+        string actual = reader.ReadToEnd();
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tests/MonoGame.Extended.Tests/Particles/ParticleEffectSerializerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Particles/ParticleEffectSerializerTests.cs
@@ -392,7 +392,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier" />
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -432,7 +432,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="CircleContainerModifier" Enabled="true" Frequency="60" Type="CircleContainerModifier" Radius="0" Inside="True" RestitutionCoefficient="1" />
+                    <Modifier Name="CircleContainerModifier" Enabled="True" Frequency="60" Type="CircleContainerModifier" Radius="0" Inside="True" RestitutionCoefficient="1" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -475,7 +475,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="DragModifier" Enabled="true" Frequency="60" Type="DragModifier" DragCoefficient="0.47" Density="0.5" />
+                    <Modifier Name="DragModifier" Enabled="True" Frequency="60" Type="DragModifier" DragCoefficient="0.47" Density="0.5" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -517,7 +517,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="LinearGravityModifier" Enabled="true" Frequency="60" Type="LinearGravityModifier" Direction="0,0" Strength="0" />
+                    <Modifier Name="LinearGravityModifier" Enabled="True" Frequency="60" Type="LinearGravityModifier" Direction="0,0" Strength="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -559,7 +559,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="OpacityFastFadeModifier" Enabled="true" Frequency="60" Type="OpacityFastFadeModifier" />
+                    <Modifier Name="OpacityFastFadeModifier" Enabled="True" Frequency="60" Type="OpacityFastFadeModifier" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -599,7 +599,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="RectangleContainerModifier" Enabled="true" Frequency="60" Type="RectangleContainerModifier" Width="0" Height="0" RestitutionCoefficient="1" />
+                    <Modifier Name="RectangleContainerModifier" Enabled="True" Frequency="60" Type="RectangleContainerModifier" Width="0" Height="0" RestitutionCoefficient="1" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -642,7 +642,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="RectangleLoopContainerModifier" Enabled="true" Frequency="60" Type="RectangleLoopContainerModifier" Width="0" Height="0" />
+                    <Modifier Name="RectangleLoopContainerModifier" Enabled="True" Frequency="60" Type="RectangleLoopContainerModifier" Width="0" Height="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -684,7 +684,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="RotationModifier" Enabled="true" Frequency="60" Type="RotationModifier" RotationRate="0" />
+                    <Modifier Name="RotationModifier" Enabled="True" Frequency="60" Type="RotationModifier" RotationRate="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -725,7 +725,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="VelocityColorModifier" Enabled="true" Frequency="60" Type="VelocityColorModifier" StationaryColor="0,0,0" VelocityColor="0,0,0" VelocityThreshold="0" />
+                    <Modifier Name="VelocityColorModifier" Enabled="True" Frequency="60" Type="VelocityColorModifier" StationaryColor="0,0,0" VelocityColor="0,0,0" VelocityThreshold="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -768,7 +768,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="VelocityModifier" Enabled="true" Frequency="60" Type="VelocityModifier" VelocityThreshold="0" />
+                    <Modifier Name="VelocityModifier" Enabled="True" Frequency="60" Type="VelocityModifier" VelocityThreshold="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -808,7 +808,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="VortexModifier" Enabled="true" Frequency="60" Type="VortexModifier" Position="0,0" Strength="1" OuterRadius="2" InnerRadius="3" MaxVelocity="4" RotationAngle="5" />
+                    <Modifier Name="VortexModifier" Enabled="True" Frequency="60" Type="VortexModifier" Position="0,0" Strength="1" OuterRadius="2" InnerRadius="3" MaxVelocity="4" RotationAngle="5" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -853,9 +853,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="ColorInterpolator" Type="ColorInterpolator" Enabled="true" StartValue="0,0,0" EndValue="0,0,0" />
+                        <Interpolator Name="ColorInterpolator" Type="ColorInterpolator" Enabled="True" StartValue="0,0,0" EndValue="0,0,0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -900,9 +900,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="HueInterpolator" Type="HueInterpolator" Enabled="true" StartValue="0" EndValue="0" />
+                        <Interpolator Name="HueInterpolator" Type="HueInterpolator" Enabled="True" StartValue="0" EndValue="0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -947,9 +947,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="OpacityInterpolator" Type="OpacityInterpolator" Enabled="true" StartValue="0" EndValue="0" />
+                        <Interpolator Name="OpacityInterpolator" Type="OpacityInterpolator" Enabled="True" StartValue="0" EndValue="0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -994,9 +994,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="RotationInterpolator" Type="RotationInterpolator" Enabled="true" StartValue="0" EndValue="0" />
+                        <Interpolator Name="RotationInterpolator" Type="RotationInterpolator" Enabled="True" StartValue="0" EndValue="0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -1041,9 +1041,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" Enabled="true" StartValue="0,0" EndValue="1,1" />
+                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" Enabled="True" StartValue="0,0" EndValue="1,1" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -1088,9 +1088,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Enabled="true" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="VelocityInterpolator" Type="VelocityInterpolator" Enabled="true" StartValue="0,0" EndValue="0,0" />
+                        <Interpolator Name="VelocityInterpolator" Type="VelocityInterpolator" Enabled="True" StartValue="0,0" EndValue="0,0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -1196,7 +1196,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier" />
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1507,7 +1507,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier" />
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1546,7 +1546,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="CircleContainerModifier" Frequency="60" Type="CircleContainerModifier" Radius="0" Inside="True" RestitutionCoefficient="1" />
+                    <Modifier Name="CircleContainerModifier" Enabled="True" Frequency="60" Type="CircleContainerModifier" Radius="0" Inside="True" RestitutionCoefficient="1" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1585,7 +1585,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="DragModifier" Frequency="60" Type="DragModifier" DragCoefficient="0.47" Density="0.5" />
+                    <Modifier Name="DragModifier" Enabled="True" Frequency="60" Type="DragModifier" DragCoefficient="0.47" Density="0.5" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1624,7 +1624,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="LinearGravityModifier" Frequency="60" Type="LinearGravityModifier" Direction="0,0" Strength="0" />
+                    <Modifier Name="LinearGravityModifier" Enabled="True" Frequency="60" Type="LinearGravityModifier" Direction="0,0" Strength="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1663,7 +1663,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="OpacityFastFadeModifier" Frequency="60" Type="OpacityFastFadeModifier" />
+                    <Modifier Name="OpacityFastFadeModifier" Enabled="True" Frequency="60" Type="OpacityFastFadeModifier" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1702,7 +1702,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="RectangleContainerModifier" Frequency="60" Type="RectangleContainerModifier" Width="0" Height="0" RestitutionCoefficient="1" />
+                    <Modifier Name="RectangleContainerModifier" Enabled="True" Frequency="60" Type="RectangleContainerModifier" Width="0" Height="0" RestitutionCoefficient="1" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1741,7 +1741,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="RectangleLoopContainerModifier" Frequency="60" Type="RectangleLoopContainerModifier" Width="0" Height="0" />
+                    <Modifier Name="RectangleLoopContainerModifier" Enabled="True" Frequency="60" Type="RectangleLoopContainerModifier" Width="0" Height="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1780,7 +1780,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="RotationModifier" Frequency="60" Type="RotationModifier" RotationRate="0" />
+                    <Modifier Name="RotationModifier" Enabled="True" Frequency="60" Type="RotationModifier" RotationRate="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1819,7 +1819,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="VelocityColorModifier" Frequency="60" Type="VelocityColorModifier" StationaryColor="0,0,0" VelocityColor="0,0,0" VelocityThreshold="0" />
+                    <Modifier Name="VelocityColorModifier" Enabled="True" Frequency="60" Type="VelocityColorModifier" StationaryColor="0,0,0" VelocityColor="0,0,0" VelocityThreshold="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1858,7 +1858,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="VelocityModifier" Frequency="60" Type="VelocityModifier" VelocityThreshold="0" />
+                    <Modifier Name="VelocityModifier" Enabled="True" Frequency="60" Type="VelocityModifier" VelocityThreshold="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1897,7 +1897,7 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="VortexModifier" Frequency="60" Type="VortexModifier" Position="0,0" Strength="0" OuterRadius="0" InnerRadius="0" MaxVelocity="0" RotationAngle="0" />
+                    <Modifier Name="VortexModifier" Enabled="True" Frequency="60" Type="VortexModifier" Position="0,0" Strength="0" OuterRadius="0" InnerRadius="0" MaxVelocity="0" RotationAngle="0" />
                   </Modifiers>
                 </ParticleEmitter>
               </Emitters>
@@ -1938,9 +1938,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="ColorInterpolator" Type="ColorInterpolator" StartValue="0,0,0" EndValue="0,0,0" />
+                        <Interpolator Name="ColorInterpolator" Enabled="True" Type="ColorInterpolator" StartValue="0,0,0" EndValue="0,0,0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -1983,9 +1983,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="HueInterpolator" Type="HueInterpolator" StartValue="0" EndValue="0" />
+                        <Interpolator Name="HueInterpolator" Enabled="True" Type="HueInterpolator" StartValue="0" EndValue="0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -2028,9 +2028,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="OpacityInterpolator" Type="OpacityInterpolator" StartValue="0" EndValue="0" />
+                        <Interpolator Name="OpacityInterpolator" Enabled="True" Type="OpacityInterpolator" StartValue="0" EndValue="0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -2073,9 +2073,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="RotationInterpolator" Type="RotationInterpolator" StartValue="0" EndValue="0" />
+                        <Interpolator Name="RotationInterpolator" Enabled="True" Type="RotationInterpolator" StartValue="0" EndValue="0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -2118,9 +2118,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="ScaleInterpolator" Type="ScaleInterpolator" StartValue="0,0" EndValue="0,0" />
+                        <Interpolator Name="ScaleInterpolator" Enabled="True" Type="ScaleInterpolator" StartValue="0,0" EndValue="0,0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>
@@ -2163,9 +2163,9 @@ public sealed class ParticleEffectSerializerTests
                   </Parameters>
                   <Profile Type="PointProfile" />
                   <Modifiers>
-                    <Modifier Name="AgeModifier" Frequency="60" Type="AgeModifier">
+                    <Modifier Name="AgeModifier" Enabled="True" Frequency="60" Type="AgeModifier">
                       <Interpolators>
-                        <Interpolator Name="VelocityInterpolator" Type="VelocityInterpolator" StartValue="0,0" EndValue="0,0" />
+                        <Interpolator Name="VelocityInterpolator" Enabled="True" Type="VelocityInterpolator" StartValue="0,0" EndValue="0,0" />
                       </Interpolators>
                     </Modifier>
                   </Modifiers>


### PR DESCRIPTION
## Description

Consolidates the `ParticleEffectReader` and `ParticleEffectWriter` into a single static `ParticleEffectSerializer` class.  This ensures consistency with other .NET framework serializers like `JsonSerializer`
* Briefly describe the purpose of this pull request and the problem it solves.

## Related Issues/Tickets

* Closes #1020 

## Changes Made

* Created `ParticleEffectSerailizer` class
* Marked `ParticleEffectReader` and `ParticleEffectWriter` as obsolete. Will be removed in 6.0 as removing them would be a breaking change and major semver increase.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
