### PR TITLE
Fixed build error when using FNA

### DIFF
--- a/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
@@ -242,7 +242,7 @@ public sealed class ParticleEffectReader : IDisposable
         {
             try
             {
-#if KNI
+#if KNI || FNA
                 using FileStream stream = File.OpenRead(filePath);
                 Texture2D texture = Texture2D.FromStream(graphicsDeviceService.GraphicsDevice, stream);
 #else


### PR DESCRIPTION
## Description

* Fixes FNA build error

## Related Issues/Tickets

* Link to Issue: https://github.com/MonoGame-Extended/Monogame-Extended/issues/1050

## Changes Made

* Included FNA in the existing preprocessor directive for KNI so FNA also uses `Texture2D.FromStream`

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x ] I have verified that there are no existing pull requests that would overlap with this pull request.
* [ x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [ x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [ x] I have provided appropriate test coverage were applicable.
