### PR TITLE
Add a copy constructor and Clone method to the Sprite class

### DIFF
--- a/source/MonoGame.Extended/Graphics/Sprite.cs
+++ b/source/MonoGame.Extended/Graphics/Sprite.cs
@@ -106,7 +106,7 @@ public class Sprite : IColorable
                 throw new ObjectDisposedException(nameof(value), $"The source {nameof(Texture2D)} of the {nameof(TextureRegion)} was disposed prior to setting this property.");
             }
             _textureRegion = value;
-            
+
             if (value.OriginNormalized.HasValue)
             {
                 OriginNormalized = value.OriginNormalized.Value;
@@ -157,6 +157,33 @@ public class Sprite : IColorable
         Effect = SpriteEffects.None;
         OriginNormalized = textureRegion.OriginNormalized ?? Vector2.Zero;
         Depth = 0.0f;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Sprite"/> class by copying property values from an existing sprite.
+    /// </summary>
+    /// <remarks>
+    /// Creates a shallow copy where the new sprite shares the same <see cref="TextureRegion"/> reference.
+    /// The <see cref="Tag"/> reference is copied but the object itself is not cloned.
+    /// </remarks>
+    /// <param name="source">The sprite to copy from.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ObjectDisposedException">
+    /// Thrown if the source texture of the <see cref="TextureRegion"/> of the provided source sprite has been disposed of.
+    /// </exception>
+    public Sprite(Sprite source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ObjectDisposedException.ThrowIf(source.TextureRegion.Texture.IsDisposed, source.TextureRegion.Texture);
+
+        _textureRegion = source._textureRegion;
+        Alpha = source.Alpha;
+        Color = source.Color;
+        IsVisible = source.IsVisible;
+        Effect = source.Effect;
+        Depth = source.Depth;
+        Origin = source.Origin;
+        Tag = source.Tag;
     }
 
     /// <summary>
@@ -225,5 +252,21 @@ public class Sprite : IColorable
         }
 
         return corners;
+    }
+
+    /// <summary>
+    /// Creates a shallow copy of this sprite with the same texture region and property values.
+    /// </summary>
+    /// <remarks>
+    /// The returned sprite shares the same <see cref="TextureRegion"/> reference.
+    /// The <see cref="Tag"/> reference is copied but the object itself is not cloned.
+    /// </remarks>
+    /// <returns>A new <see cref="Sprite"/> instance with copied property values.</returns>
+    /// <exception cref="ObjectDisposedException">
+    /// Thrown if the source texture of the <see cref="TextureRegion"/> of this sprite has been disposed of.
+    /// </exception>
+    public Sprite Clone()
+    {
+        return new Sprite(this);
     }
 }


### PR DESCRIPTION
## Description

Implements a copy constructor and `Clone()` method to enable creating copies of `Sprite` instances without mutating the original. This addresses the use case of needing multiple sprite instances with different properties (such as `SpriteEffects`) that share the same texture region.

The implementation performs a shallow copy where the new sprite shares the same `TextureRegion` reference but has independent copies of all other properties. The `Clone()` method delegates to the copy constructor.

## Related Issues/Tickets

* Closes #1028

## Changes Made

* Added `Sprite(Sprite)` copy constructor
* Added `Sprite.Cone()` method

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
