### PR TITLE
Change ExtendedContentManager method accessors to protected

### DIFF
--- a/source/MonoGame.Extended/Content/ExtendedContentManager.cs
+++ b/source/MonoGame.Extended/Content/ExtendedContentManager.cs
@@ -256,20 +256,22 @@ public class ExtendedContentManager : ContentManager
         return font;
     }
 
+#if KNI || FNA
+    /// <summary>
+    /// Loads a <see cref="Texture2DAtlas"/> from a TexturePacker JSON file.
+    /// <summary>
+    /// <param name="path">The path to the TexturePacker JSON file</param>
+    /// <returns>The <see cref="Texture2DAtlas"/> created from the TexturePacker JSON file content.</returns>
+    public Texture2DAtlas LoadTexturePacker(string path)
+#else
     /// <summary>
     /// Loads a <see cref="Texture2DAtlas"/> from a TexturePacker JSON file.
     /// </summary>
     /// <param name="path">The path to the TexturePacker JSON file</param>
-
-#if !KNI && !FNA
     /// <param name="premultiplyAlpha">
     /// Specifies whether the color data of the texture should be premultiplied by its alpha value.
     /// </param>
-#endif
     /// <returns>The <see cref="Texture2DAtlas"/> created from the TexturePacker JSON file content.</returns>
-#if KNI || FNA
-    public Texture2DAtlas LoadTexturePacker(string path)
-#else
     public Texture2DAtlas LoadTexturePacker(string path, bool premultiplyAlpha)
 #endif
     {

--- a/source/MonoGame.Extended/Content/ExtendedContentManager.cs
+++ b/source/MonoGame.Extended/Content/ExtendedContentManager.cs
@@ -283,7 +283,7 @@ public class ExtendedContentManager : ContentManager
 
 
 
-    private FileStream GetStream(string path)
+    protected FileStream GetStream(string path)
     {
         if (Path.IsPathRooted(path))
         {
@@ -293,7 +293,7 @@ public class ExtendedContentManager : ContentManager
         return (FileStream)TitleContainer.OpenStream(path);
     }
 
-    private void CacheAsset(string name, object obj)
+    protected void CacheAsset(string name, object obj)
     {
         LoadedAssets.Add(name, obj);
         if (obj is IDisposable disposable)
@@ -302,8 +302,8 @@ public class ExtendedContentManager : ContentManager
         }
     }
 
-    private bool NoExtension(string name) => string.IsNullOrEmpty(Path.GetExtension(name));
-    private bool TryGetCachedAsset<T>(string name, out T asset)
+    protected bool NoExtension(string name) => string.IsNullOrEmpty(Path.GetExtension(name));
+    protected bool TryGetCachedAsset<T>(string name, out T asset)
     {
         asset = default;
 

--- a/source/MonoGame.Extended/Content/ExtendedContentManager.cs
+++ b/source/MonoGame.Extended/Content/ExtendedContentManager.cs
@@ -18,11 +18,17 @@ using MonoGame.Extended.Graphics;
 
 namespace MonoGame.Extended.Content;
 
+/// <summary>
+/// Extends the <see cref="ContentManager"/> to provide additional loading functionality and additional asset types
+/// </summary>
 public class ExtendedContentManager : ContentManager
 {
     private List<IDisposable> _disposableAssets;
     private readonly IGraphicsDeviceService _graphicsDeviceService;
 
+    /// <summary>
+    /// Gets the collection of loaded disposable assets that will be disposed when this content manager is disposed.
+    /// </summary>
     public List<IDisposable> DisposeableAssets
     {
         get
@@ -45,6 +51,10 @@ public class ExtendedContentManager : ContentManager
 
 #if KNI || FNA
     private Dictionary<string, object> _loadedAssets;
+
+    /// <summary>
+    /// Gets the dictionary of loaded assets keyed by asset name.
+    /// </summary>
     public Dictionary<string, object> LoadedAssets
     {
         get
@@ -65,16 +75,31 @@ public class ExtendedContentManager : ContentManager
     }
 #endif
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtendedContentManager"/> class.
+    /// </summary>
+    /// <remarks>
+    /// By default, the content manager searches for content in the directory where the executable is located.
+    /// </remarks>
+    /// <param name="serviceProvider">The service provided used for resolving services.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="serviceProvider"/> is <see langword="null"/>.
+    /// </exception>
     public ExtendedContentManager(IServiceProvider serviceProvider) : base(serviceProvider)
     {
         _graphicsDeviceService = serviceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtendedContentManager"/> class with a specified root directory.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider to use for resolving services.</param>
+    /// <param name="rootDirectory">The root directory the content manager will search for content in.</param>
     public ExtendedContentManager(IServiceProvider serviceProvider, string rootDirectory) : base(serviceProvider, rootDirectory)
     {
         _graphicsDeviceService = serviceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
     }
-    
+
 #if KNI || FNA
     /// <summary>
     /// Loads a <see cref="Texture2D"/> asset.
@@ -87,7 +112,7 @@ public class ExtendedContentManager : ContentManager
     /// <param name="premultiplyAlpha">
     /// Specifies whether the color data of the texture should be premultiplied by its alpha value.
     /// </param>
-    /// <returns></returns>
+    /// <returns>The <see cref="Texture2D"/> loaded. </returns>
     public Texture2D LoadTexture2D(string path)
     {
         if (TryGetCachedAsset<Texture2D>(path, out Texture2D texture))
@@ -130,7 +155,7 @@ public class ExtendedContentManager : ContentManager
     /// <param name="premultiplyAlpha">
     /// Specifies whether the color data of the texture should be premultiplied by its alpha value.
     /// </param>
-    /// <returns></returns>
+    /// <returns>The <see cref="Texture2D"/> loaded.</returns>
     public Texture2D LoadTexture2D(string path, bool premultiplyAlpha)
     {
         if (TryGetCachedAsset<Texture2D>(path, out Texture2D texture))
@@ -259,7 +284,7 @@ public class ExtendedContentManager : ContentManager
         }
 
         using var stream = GetStream(path);
-        
+
         var tpFile = TexturePackerFileReader.Read(stream);
         var dir = Path.GetDirectoryName(path);
         var imageAssetPath = Path.Combine(dir, tpFile.Meta.Image);
@@ -271,7 +296,7 @@ public class ExtendedContentManager : ContentManager
 #endif
         atlas = new Texture2DAtlas(Path.GetFileNameWithoutExtension(tpFile.Meta.Image), texture);
 
-        foreach(var region in tpFile.Regions)
+        foreach (var region in tpFile.Regions)
         {
             var frame = region.Frame;
             atlas.CreateRegion(frame.X, frame.Y, frame.Width, frame.Height, Path.GetFileNameWithoutExtension(region.FileName));
@@ -281,8 +306,15 @@ public class ExtendedContentManager : ContentManager
         return atlas;
     }
 
-
-
+    /// <summary>
+    /// Opens a file stream for the specified asset path.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="path"/> argument can be either an absolute or relative path.  When it is a relative path, it
+    /// is resolved using <see cref="TitleContainer"/>.
+    /// </remarks>
+    /// <param name="path">The path to the asset file.</param>
+    /// <returns>A <see cref="FileStream"/> for reading the asset file.</returns>
     protected FileStream GetStream(string path)
     {
         if (Path.IsPathRooted(path))
@@ -293,6 +325,15 @@ public class ExtendedContentManager : ContentManager
         return (FileStream)TitleContainer.OpenStream(path);
     }
 
+    /// <summary>
+    /// Caches a loaded asset in the loaded assets dictionary/
+    /// </summary>
+    /// <remarks>
+    /// Assets that implement <see cref="IDisposable"/> are registered with the <see cref="DisposeableAssets"/>
+    /// collection for automatic disposal.
+    /// </remarks>
+    /// <param name="name">The cache key for the asset, typically the asset path.</param>
+    /// <param name="obj">The asset instance to cache.</param>
     protected void CacheAsset(string name, object obj)
     {
         LoadedAssets.Add(name, obj);
@@ -302,7 +343,27 @@ public class ExtendedContentManager : ContentManager
         }
     }
 
+    /// <summary>
+    /// Determines whether the specified asset name has no file extension.
+    /// </summary>
+    /// <param name="name">The asset name to check.</param>
+    /// <returns>
+    /// <see langword="true"/> if the name has no extension or the extension is empty; otherwise, <see langword="false"/>.
+    /// </returns>
     protected bool NoExtension(string name) => string.IsNullOrEmpty(Path.GetExtension(name));
+
+    /// <summary>
+    /// Attempts to retrieve a previously cached asset of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the cached asset.</typeparam>
+    /// <param name="name">The cache key for the asset, typically the asset path.</param>
+    /// <param name="asset">
+    /// When this method returns, contains the cached asset if found and of type <typeparamref name="T"/>; otherwise,
+    /// the default value for <typeparamref name="T"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if a cached asset of type <typeparamref name="T"/> was found; otherwise, <see langword="false"/>.
+    /// </returns>
     protected bool TryGetCachedAsset<T>(string name, out T asset)
     {
         asset = default;


### PR DESCRIPTION
## Description

This PR changes the accessibility of four utility methods in `ExtendedContentManager` from `private` to `protected`, enabling developers to create derived classes without unnecessary code duplication. Additionally, XML documentation has been added to all previously undocumented members.

## Related Issues/Tickets

* Closes #973

## Changes Made

* Changed `GetStream(string path)` from `private` to `protected`
* Changed `CacheAsset(string name, object obj)` from `private` to `protected`
* Changed `NoExtension(string name)` from `private` to `protected`
* Changed `TryGetCachedAsset<T>(string name, out T asset)` from `private` to `protected`
* Added documentation to all members missing documentation
* Added documentation to the methods that have changed from `private` to `protected`
* Fixed issue with split documentation for the `LoadTexturePacker` between FNA/KNI and MonoGame implementations

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
