### PR TITLE
Add stack-based screen management with background update support

### DIFF
--- a/source/MonoGame.Extended/Screens/GameScreen.cs
+++ b/source/MonoGame.Extended/Screens/GameScreen.cs
@@ -1,19 +1,52 @@
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace MonoGame.Extended.Screens
-{
-    public abstract class GameScreen : Screen
-    {
-        protected GameScreen(Game game)
-        {
-            Game = game;
-        }
+namespace MonoGame.Extended.Screens;
 
-        public Game Game { get; }
-        public ContentManager Content => Game.Content;
-        public GraphicsDevice GraphicsDevice => Game.GraphicsDevice;
-        public GameServiceContainer Services => Game.Services;
+/// <summary>
+/// Provides an abstract base class for game screens that require access to core game services and components.
+/// </summary>
+/// <remarks>
+/// <para>
+///     The <see cref="GameScreen"/> class extends <see cref="Screen"/> by providing convenient access to commonly
+///     used game services such as the content manager, graphics device, and service container. This eliminates
+///     the need for derived screens to manually access these services through the game instance.
+/// </para>
+/// </remarks>
+public abstract class GameScreen : Screen
+{
+    /// <summary>
+    /// Gets the game instance associated with this screen that provides access to core services and components.
+    /// </summary>
+    public Game Game { get; }
+
+    /// <summary>
+    /// Gets the content manager for loading game assets.
+    /// </summary>
+    public ContentManager Content => Game.Content;
+
+    /// <summary>
+    /// Gets the graphics device for rendering operations.
+    /// </summary>
+    public GraphicsDevice GraphicsDevice => Game.GraphicsDevice;
+
+    /// <summary>
+    /// Gets the service container for accessing registered game services.
+    /// </summary>
+    public GameServiceContainer Services => Game.Services;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GameScreen"/> class.
+    /// </summary>
+    /// <param name="game">The game instance that provides access to core services.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="game"/> is <see langword="null"/>.
+    /// </exception>
+    protected GameScreen(Game game)
+    {
+        ArgumentNullException.ThrowIfNull(game);
+        Game = game;
     }
 }

--- a/source/MonoGame.Extended/Screens/Screen.cs
+++ b/source/MonoGame.Extended/Screens/Screen.cs
@@ -1,17 +1,111 @@
 using System;
 using Microsoft.Xna.Framework;
 
-namespace MonoGame.Extended.Screens
-{
-    public abstract class Screen : IDisposable
-    {
-        public ScreenManager ScreenManager { get; internal set; }
+namespace MonoGame.Extended.Screens;
 
-        public virtual void Dispose() { }
-        public virtual void Initialize() { }
-        public virtual void LoadContent() { }
-        public virtual void UnloadContent() { }
-        public abstract void Update(GameTime gameTime);
-        public abstract void Draw(GameTime gameTime);
-    }
+/// <summary>
+/// Represents an abstract base class for game screens that can be managed by a <see cref="ScreenManager"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+///     Screens provide a way to organize game logic into discrete states such as menus, gameplay, loading screens,
+///     or different game areas.
+/// </para>
+/// <para>
+///     When screen are used with a <see cref="Screens.ScreenManager"/>, multiple screens can be active
+///     simultaneously in the manager's screen stack based on their <see cref="UpdateWhenInactive"/> and
+///     <see cref="DrawWhenInactive"/> properties.
+/// </para>
+/// </remarks>
+public abstract class Screen : IDisposable
+{
+    /// <summary>
+    /// Gets the <see cref="Screens.ScreenManager"/> that manages this screen or <see langword="null"/> if the
+    /// screen is not managed.
+    /// </summary>
+    public ScreenManager ScreenManager { get; internal set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this screen is currently the active screen.
+    /// </summary>
+    public bool IsActive { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this screen should continue to update when it is not the active screen.
+    /// </summary>
+    /// <remarks>
+    /// This property allows background screens to continue processing logic even when they are not the topmost
+    /// screen in the screen stack of a screen manager.  This is useful for scenarios were persistent game systems
+    /// should run regardless of screen state.
+    /// </remarks>
+    public bool UpdateWhenInactive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this screen should continue to draw when it is not the active screen.
+    /// </summary>
+    /// <remarks>
+    /// This property allows background screens to continue rendering even when they are not the topmost screen
+    /// in the screen stack of a screen manager.  This is useful for creating layered visual effects where multiple
+    /// screens nee dto be visible simultaneously such as a game world visible behind a semi-transparent menu or
+    /// overlay.
+    /// </remarks>
+    public bool DrawWhenInactive { get; set; }
+
+    /// <summary>
+    /// Releases all resources used by the screen.
+    /// </summary>
+    /// <remarks>
+    /// The base implementation does nothing.
+    /// </remarks>
+    public virtual void Dispose() { }
+
+    /// <summary>
+    /// Initializes the screen.
+    /// </summary>
+    /// <remarks>
+    /// When the screen is added to a <see cref="Screens.ScreenManager"/>, this method will be called automatically
+    /// when the screen is first shown.
+    /// The base implementation does nothing.
+    /// </remarks>
+    public virtual void Initialize() { }
+
+    /// <summary>
+    /// Loads content and resources needed by the screen.
+    /// </summary>
+    /// <remarks>
+    /// When the screen is added to a <see cref="Screens.ScreenManager"/>, this method will be called automatically
+    /// after <see cref="Initialize()"/> when the screen is first shown.
+    /// The base implementation does nothing.
+    /// </remarks>
+    public virtual void LoadContent() { }
+
+    /// <summary>
+    /// Unloads content and resources used by the screen.
+    /// </summary>
+    /// <remarks>
+    /// When the screen is added to a <see cref="Screens.ScreenManager"/>, this method is called automatically when
+    /// the screen is closed.
+    /// The base implementation does nothing.
+    /// </remarks>
+    public virtual void UnloadContent() { }
+
+    /// <summary>
+    /// Updates the screen's logic.
+    /// </summary>
+    /// <param name="gameTime">Provides a snapshot of timing values.</param>
+    /// <remarks>
+    /// When added to a <see cref="Screens.ScreenManager"/>, this method is called automatically every frame when
+    /// either the <see cref="IsActive"/> or <see cref="UpdateWhenInactive"/> properties are <see langword="true"/>.
+    /// </remarks>
+    public abstract void Update(GameTime gameTime);
+
+    /// <summary>
+    /// Draws the screen's visual content.
+    /// </summary>
+    /// <param name="gameTime">Provides a snapshot of timing values.</param>
+    /// <remarks>
+    /// When added to a <see cref="Screens.ScreenManager"/>, this method is called automatically every frame when
+    /// either the <see cref="IsActive"/> or <see cref="DrawWhenInactive"/> properties are <see langword="true"/>.
+    /// </remarks>
+    public abstract void Draw(GameTime gameTime);
 }

--- a/source/MonoGame.Extended/Screens/ScreenManager.cs
+++ b/source/MonoGame.Extended/Screens/ScreenManager.cs
@@ -1,78 +1,330 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended.Screens.Transitions;
 
-namespace MonoGame.Extended.Screens
+namespace MonoGame.Extended.Screens;
+
+/// <summary>
+/// Manages a stack of <see cref="Screen"/> instances in a game.
+/// </summary>
+/// <remarks>
+/// <para>
+///     Screens are managed using a stack based approach where the topmost screen is considered the active screen,
+///     while underlying screens can continue to update and draw in the background based on their settings.
+/// </para>
+/// <para>
+///     Note: Developers should be aware of performance considerations when keeping multiple screens active in the
+///     background for updates and/or drawing.
+/// </para>
+/// </remarks>
+public class ScreenManager : SimpleDrawableGameComponent
 {
-    public class ScreenManager : SimpleDrawableGameComponent
+    private readonly Stack<Screen> _screens;
+    private Screen _activeScreen;
+    private Transition _activeTransition;
+    private Screen[] _cachedScreens;
+    private bool _isScreenArrayDirty;
+
+    /// <summary>
+    /// Gets the currently active screen at the top of the screen stack,
+    /// or <see langword="null"/> if no screens are loaded.
+    /// </summary>
+    public Screen ActiveScreen => _activeScreen;
+
+    /// <summary>
+    /// Gets a read-only list of all screens in the stack, ordered from bottom to top.
+    /// </summary>
+    /// <remarks>
+    /// For performance, the list is cached internally and only rebuilt when the screen stack has been modified.
+    /// </remarks>
+    public IReadOnlyList<Screen> Screens
     {
-        public ScreenManager()
+        get
         {
-        }
-
-        private Screen _activeScreen;
-        //private bool _isInitialized;
-        //private bool _isLoaded;
-        private Transition _activeTransition;
-
-        public void LoadScreen(Screen screen, Transition transition)
-        {
-            if(_activeTransition != null)
-                return;
-
-            _activeTransition = transition;
-            _activeTransition.StateChanged += (sender, args) => LoadScreen(screen);
-            _activeTransition.Completed += (sender, args) =>
+            if (_isScreenArrayDirty)
             {
-                _activeTransition.Dispose();
-                _activeTransition = null;
-            };
+                _cachedScreens = _screens.Reverse().ToArray();
+                _isScreenArrayDirty = false;
+            }
+
+            return _cachedScreens;
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScreenManager"/> class.
+    /// </summary>
+    public ScreenManager()
+    {
+        _screens = new Stack<Screen>();
+        _cachedScreens = Array.Empty<Screen>();
+        _isScreenArrayDirty = true;
+    }
+
+    /// <summary>
+    /// Pushes a new screen onto the stack and makes it the active screen.
+    /// </summary>
+    /// <remarks>
+    /// The previous active screen remains in the screen stack but becomes inactive.
+    /// </remarks>
+    /// <param name="screen">The screen to show.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="screen"/> is <see langword="null"/>.</exception>
+    public void ShowScreen(Screen screen)
+    {
+        ArgumentNullException.ThrowIfNull(screen);
+
+        if (_activeScreen != null)
+        {
+            _activeScreen.IsActive = false;
         }
 
-        public void LoadScreen(Screen screen)
+        screen.ScreenManager = this;
+        screen.IsActive = true;
+        screen.Initialize();
+        screen.LoadContent();
+
+        _screens.Push(screen);
+        _activeScreen = screen;
+        _isScreenArrayDirty = true;
+    }
+
+    /// <summary>
+    /// Pushes a new screen onto the stack with a transition effect and makes it the active screen.
+    /// </summary>
+    /// <remarks>
+    /// The previous active screen remains in the screen stack but becomes inactive.
+    /// </remarks>
+    /// <param name="screen">The screen to show.</param>
+    /// <param name="transition">The transition effect to use when showing the screen.</param>
+    public void ShowScreen(Screen screen, Transition transition)
+    {
+        if (_activeTransition != null)
         {
-            _activeScreen?.UnloadContent();
-            _activeScreen?.Dispose();
-
-            screen.ScreenManager = this;
-
-            screen.Initialize();
-
-            screen.LoadContent();
-
-            _activeScreen = screen;
+            return;
         }
 
-        public override void Initialize()
+        _activeTransition = transition;
+        _activeTransition.StateChanged += (sender, args) => ShowScreen(screen);
+        _activeTransition.Completed += (sender, args) =>
         {
-            base.Initialize();
-            _activeScreen?.Initialize();
-            //_isInitialized = true;
+            _activeTransition.Dispose();
+            _activeTransition = null;
+        };
+    }
+
+    /// <summary>
+    /// Pops the current active screen from the stack, disposing it and making the next screen active.
+    /// </summary>
+    /// <remarks>
+    /// If the screen stack becomes empty, no screen will be active.
+    /// </remarks>
+    public void CloseScreen()
+    {
+        if (!_screens.TryPop(out Screen screen))
+        {
+            return;
         }
 
-        protected override void LoadContent()
+        screen.IsActive = false;
+        screen.UnloadContent();
+        screen.Dispose();
+
+        _isScreenArrayDirty = true;
+
+        if (_screens.TryPeek(out _activeScreen))
         {
-            base.LoadContent();
-            _activeScreen?.LoadContent();
-            //_isLoaded = true;
+            _activeScreen.IsActive = true;
+        }
+    }
+
+    /// <summary>
+    /// Pops the current active screen from the stack with a transition effect, disposing it and making the next screen active.
+    /// </summary>
+    /// <remarks>
+    /// If the screen stack becomes empty, no screen will be active.
+    /// </remarks>
+    /// <param name="transition">The transition effect to use when closing the screen.</param>
+    public void CloseScreen(Transition transition)
+    {
+        if (_activeTransition != null)
+        {
+            return;
         }
 
-        protected override void UnloadContent()
+        _activeTransition = transition;
+        _activeTransition.StateChanged += (sender, args) => CloseScreen();
+        _activeTransition.Completed += (sender, args) =>
         {
-            base.UnloadContent();
-            _activeScreen?.UnloadContent();
-            //_isLoaded = false;
+            _activeTransition.Dispose();
+            _activeTransition = null;
+        };
+    }
+
+    /// <summary>
+    /// Replaces the current active screen with a new screen by closing the current screen and showing the new one.
+    /// </summary>
+    /// <remarks>
+    /// This is equivalent to calling <see cref="CloseScreen()"/> followed by <see cref="ShowScreen(Screen)"/>
+    /// </remarks>
+    /// <param name="screen">The screen to replace the current active screen with.</param>
+    public void ReplaceScreen(Screen screen)
+    {
+        CloseScreen();
+        ShowScreen(screen);
+    }
+
+    /// <summary>
+    /// Replaces the current active screen with a new screen using a transition effect.
+    /// </summary>
+    /// <remarks>
+    /// This is equivalent to calling <see cref="CloseScreen(Transition)"/> followed by <see cref="ShowScreen(Screen, Transition)"/>.
+    /// </remarks>
+    /// <param name="screen">The screen to replace the current active screen with.</param>
+    /// <param name="transition">The transition effect to use when replacing the screen.</param>
+    public void ReplaceScreen(Screen screen, Transition transition)
+    {
+        if (_activeTransition != null)
+        {
+            return;
         }
 
-        public override void Update(GameTime gameTime)
+        _activeTransition = transition;
+        _activeTransition.StateChanged += (sender, args) => ReplaceScreen(screen);
+        _activeTransition.Completed += (sender, args) =>
         {
-            _activeScreen?.Update(gameTime);
-            _activeTransition?.Update(gameTime);
+            _activeTransition.Dispose();
+            _activeTransition = null;
+        };
+    }
+    /// <summary>
+    /// Loads a screen, replacing any existing screens.
+    /// </summary>
+    /// <param name="screen">The screen to load</param>
+    [Obsolete("This method is provided for backward compatibility and will be removed in the next major release. For new code, use ShowScreen(Screen), CloseScreen(), or ReplaceScreen(Screen).")]
+    public void LoadScreen(Screen screen)
+    {
+        ReplaceScreen(screen);
+    }
+
+    /// <summary>
+    /// Loads a screen with a transition effect, replacing any existing screens.
+    /// </summary>
+    /// <param name="screen">The screen to load</param>
+    /// <param name="transition">The transition effect to use.</param>
+    [Obsolete("This method is provided for backward compatibility and will be removed in the next major release. For new code, use ShowScreen(Screen), CloseScreen(), or ReplaceScreen(Screen).")]
+    public void LoadScreen(Screen screen, Transition transition)
+    {
+        ReplaceScreen(screen, transition);
+    }
+
+    /// <summary>
+    /// Clears all screens from the stack, disposing them and setting no active screen.
+    /// </summary>
+    public void ClearScreens()
+    {
+        while (_screens.TryPop(out Screen screen))
+        {
+            screen.IsActive = false;
+            screen.UnloadContent();
+            screen.Dispose();
         }
 
-        public override void Draw(GameTime gameTime)
+        _activeScreen = null;
+        _isScreenArrayDirty = true;
+    }
+
+    /// <summary>
+    /// Initializes the screen manager and the currently active screen if one exists.
+    /// </summary>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        if (_activeScreen != null)
         {
-            _activeScreen?.Draw(gameTime);
-            _activeTransition?.Draw(gameTime);
+            _activeScreen.Initialize();
+        }
+    }
+
+    /// <summary>
+    /// Loads content for the screen manager and the currently active screen if one exists.
+    /// </summary>
+    protected override void LoadContent()
+    {
+        base.LoadContent();
+
+        if (_activeScreen != null)
+        {
+            _activeScreen.LoadContent();
+        }
+    }
+
+    /// <summary>
+    /// Unloads content for the screen manager and the currently active screen if one exists.
+    /// </summary>
+    protected override void UnloadContent()
+    {
+        base.UnloadContent();
+
+        if (_activeScreen != null)
+        {
+            _activeScreen.UnloadContent();
+        }
+    }
+
+    /// <summary>
+    /// Updates all screens in the stack where the <see cref="Screen.IsActive"/> or
+    /// <see cref="Screen.UpdateWhenInactive"/> property is set to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Update order for screens is done from the bottom of the stack to the top of.
+    /// </remarks>
+    /// <param name="gameTime">Provides a snapshot of timing values.</param>
+    public override void Update(GameTime gameTime)
+    {
+        IReadOnlyList<Screen> screens = Screens;
+        for (int i = 0; i < screens.Count; i++)
+        {
+            Screen screen = screens[i];
+            if (screen.IsActive || screen.UpdateWhenInactive)
+            {
+                screen.Update(gameTime);
+            }
+        }
+
+        if (_activeTransition != null)
+        {
+            _activeTransition.Update(gameTime);
+        }
+    }
+
+    /// <summary>
+    /// Draws all screens in the stack where the <see cref="Screen.IsActive"/> or
+    /// <see cref="Screen.DrawWhenInactive"/> property is set to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Draw order for screens is done from the bottom of the stack to the top to allow background screens
+    /// to draw before foreground ones for property visual stacking.
+    /// </remarks>
+    /// <param name="gameTime">Provides a snapshot of timing values.</param>
+    public override void Draw(GameTime gameTime)
+    {
+        IReadOnlyList<Screen> screens = Screens;
+        for (int i = 0; i < screens.Count; i++)
+        {
+            Screen screen = screens[i];
+            if (screen.IsActive || screen.DrawWhenInactive)
+            {
+                screen.Draw(gameTime);
+            }
+        }
+
+        if (_activeTransition != null)
+        {
+            _activeTransition.Draw(gameTime);
         }
     }
 }
+

--- a/tests/MonoGame.Extended.Tests/Screens/GameScreenTests.cs
+++ b/tests/MonoGame.Extended.Tests/Screens/GameScreenTests.cs
@@ -1,0 +1,15 @@
+using System;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Screens;
+using MonoGame.Extended.Tests.Fixtures;
+
+namespace MonoGame.Extended.Tests.Screens;
+
+public sealed class GameScreenTests
+{
+    [Fact]
+    public void Constructor_WithNullGame_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new TestGameScreen(null));
+    }
+}

--- a/tests/MonoGame.Extended.Tests/Screens/ScreenManagerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Screens/ScreenManagerTests.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Screens;
+
+namespace MonoGame.Extended.Tests.Screens;
+
+[Collection("GraphicsTest")]
+public sealed class ScreenManagerTests
+{
+    #region ShowScreen Tests
+
+    [Fact]
+    public void ShowScreen_FirstScreen_BecomesActive()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen = new TestScreen("Screen1");
+
+        manager.ShowScreen(screen);
+
+        Assert.Equal(screen, manager.ActiveScreen);
+        Assert.True(screen.IsActive);
+        Assert.Single(manager.Screens);
+    }
+
+    [Fact]
+    public void ShowScreen_SecondScreen_DeactivatesFirstAndBecomesActive()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+
+        Assert.Equal(screen2, manager.ActiveScreen);
+        Assert.True(screen2.IsActive);
+        Assert.False(screen1.IsActive);
+        Assert.Equal(2, manager.Screens.Count);
+    }
+
+    [Fact]
+    public void ShowScreen_SetsScreenManagerProperty()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen = new TestScreen("Screen1");
+
+        manager.ShowScreen(screen);
+
+        Assert.Equal(manager, screen.ScreenManager);
+    }
+
+    [Fact]
+    public void ShowScreen_WithNull_ThrowsArgumentNullException()
+    {
+        ScreenManager manager = new ScreenManager();
+        Assert.Throws<ArgumentNullException>(() => manager.ShowScreen(null));
+    }
+
+    #endregion
+
+    #region CloseScreen Tests
+
+    [Fact]
+    public void CloseScreen_RemovesActiveAndActivatesPrevious()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+
+        manager.CloseScreen();
+
+        Assert.Equal(screen1, manager.ActiveScreen);
+        Assert.True(screen1.IsActive);
+        Assert.True(screen2.DisposeCalled);
+        Assert.Single(manager.Screens);
+    }
+
+    [Fact]
+    public void CloseScreen_OnLastScreen_LeavesEmptyStack()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen = new TestScreen("Screen1");
+        manager.ShowScreen(screen);
+
+        manager.CloseScreen();
+
+        Assert.Null(manager.ActiveScreen);
+        Assert.Empty(manager.Screens);
+        Assert.True(screen.DisposeCalled);
+    }
+
+    [Fact]
+    public void CloseScreen_OnEmptyStack_DoesNotThrow()
+    {
+        ScreenManager manager = new ScreenManager();
+
+        manager.CloseScreen();
+
+        Assert.Null(manager.ActiveScreen);
+        Assert.Empty(manager.Screens);
+    }
+
+    #endregion
+
+    #region ReplaceScreen Tests
+
+    [Fact]
+    public void ReplaceScreen_ClosesActiveAndShowsNew()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+        manager.ShowScreen(screen1);
+
+        manager.ReplaceScreen(screen2);
+
+        Assert.Equal(screen2, manager.ActiveScreen);
+        Assert.True(screen2.IsActive);
+        Assert.True(screen1.DisposeCalled);
+        Assert.Single(manager.Screens);
+    }
+
+    [Fact]
+    public void ReplaceScreen_OnEmptyStack_JustShowsScreen()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen = new TestScreen("Screen1");
+
+        manager.ReplaceScreen(screen);
+
+        Assert.Equal(screen, manager.ActiveScreen);
+        Assert.Single(manager.Screens);
+    }
+
+    [Fact]
+    public void ReplaceScreen_WithNull_ThrowsArgumentNullException()
+    {
+        ScreenManager manager = new ScreenManager();
+        Assert.Throws<ArgumentNullException>(() => manager.ReplaceScreen(null));
+    }
+
+    #endregion
+
+    #region ClearScreens Tests
+
+    [Fact]
+    public void ClearScreens_DisposesAllScreensAndClearsStack()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+        TestScreen screen3 = new TestScreen("Screen3");
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+        manager.ShowScreen(screen3);
+
+        manager.ClearScreens();
+
+        Assert.Null(manager.ActiveScreen);
+        Assert.Empty(manager.Screens);
+        Assert.True(screen1.DisposeCalled);
+        Assert.True(screen2.DisposeCalled);
+        Assert.True(screen3.DisposeCalled);
+    }
+
+    [Fact]
+    public void ClearScreens_OnEmptyStack_DoesNotThrow()
+    {
+        ScreenManager manager = new ScreenManager();
+
+        manager.ClearScreens();
+
+        Assert.Null(manager.ActiveScreen);
+    }
+
+    #endregion
+
+    #region Update Tests
+
+    [Fact]
+    public void Update_OnlyUpdatesActiveScreen_ByDefault()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+        GameTime gameTime = new GameTime();
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+
+        manager.Update(gameTime);
+
+        Assert.Equal(0, screen1.UpdateCallCount);
+        Assert.Equal(1, screen2.UpdateCallCount);
+    }
+
+    [Fact]
+    public void Update_UpdatesInactiveScreens_WhenUpdateWhenInactiveIsTrue()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1") { UpdateWhenInactive = true };
+        TestScreen screen2 = new TestScreen("Screen2");
+        GameTime gameTime = new GameTime();
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+
+        manager.Update(gameTime);
+
+        Assert.Equal(1, screen1.UpdateCallCount);
+        Assert.Equal(1, screen2.UpdateCallCount);
+    }
+
+    [Fact]
+    public void Update_UpdatesScreensInBottomToTopOrder()
+    {
+        ScreenManager manager = new ScreenManager();
+        List<string> updateOrder = new List<string>();
+        TestScreen screen1 = new TestScreen("Screen1") { UpdateWhenInactive = true };
+        TestScreen screen2 = new TestScreen("Screen2") { UpdateWhenInactive = true };
+        TestScreen screen3 = new TestScreen("Screen3");
+
+        screen1.OnUpdate += name => updateOrder.Add(name);
+        screen2.OnUpdate += name => updateOrder.Add(name);
+        screen3.OnUpdate += name => updateOrder.Add(name);
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+        manager.ShowScreen(screen3);
+
+        manager.Update(new GameTime());
+
+        Assert.Equal(["Screen1", "Screen2", "Screen3"], updateOrder);
+    }
+
+    [Fact]
+    public void Update_OnEmptyStack_DoesNotThrow()
+    {
+        ScreenManager manager = new ScreenManager();
+
+        manager.Update(new GameTime());
+    }
+
+    #endregion
+
+    #region Draw Tests
+
+    [Fact]
+    public void Draw_OnlyDrawsActiveScreen_ByDefault()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+        GameTime gameTime = new GameTime();
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+
+        manager.Draw(gameTime);
+
+        Assert.Equal(0, screen1.DrawCallCount);
+        Assert.Equal(1, screen2.DrawCallCount);
+    }
+
+    [Fact]
+    public void Draw_DrawsInactiveScreens_WhenDrawWhenInactiveIsTrue()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1") { DrawWhenInactive = true };
+        TestScreen screen2 = new TestScreen("Screen2");
+        GameTime gameTime = new GameTime();
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+
+        manager.Draw(gameTime);
+
+        Assert.Equal(1, screen1.DrawCallCount);
+        Assert.Equal(1, screen2.DrawCallCount);
+    }
+
+    [Fact]
+    public void Draw_DrawsScreensInBottomToTopOrder()
+    {
+        ScreenManager manager = new ScreenManager();
+        List<string> drawOrder = new List<string>();
+        TestScreen screen1 = new TestScreen("Screen1") { DrawWhenInactive = true };
+        TestScreen screen2 = new TestScreen("Screen2") { DrawWhenInactive = true };
+        TestScreen screen3 = new TestScreen("Screen3");
+
+        screen1.OnDraw += name => drawOrder.Add(name);
+        screen2.OnDraw += name => drawOrder.Add(name);
+        screen3.OnDraw += name => drawOrder.Add(name);
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+        manager.ShowScreen(screen3);
+
+        manager.Draw(new GameTime());
+
+        Assert.Equal(["Screen1", "Screen2", "Screen3"], drawOrder);
+    }
+
+    [Fact]
+    public void Draw_OnEmptyStack_DoesNotThrow()
+    {
+        ScreenManager manager = new ScreenManager();
+
+        manager.Draw(new GameTime());
+    }
+
+    #endregion
+
+    #region Stack Ordering Tests
+
+    [Fact]
+    public void Screens_ReturnsScreensInBottomToTopOrder()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+        TestScreen screen3 = new TestScreen("Screen3");
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+        manager.ShowScreen(screen3);
+
+        IReadOnlyList<Screen> screens = manager.Screens;
+        Assert.Equal(3, screens.Count);
+        Assert.Equal(screen1, screens[0]);
+        Assert.Equal(screen2, screens[1]);
+        Assert.Equal(screen3, screens[2]);
+    }
+
+    #endregion
+
+    #region Cache Invalidation Tests
+
+    [Fact]
+    public void Screens_CachesResultsBetweenCalls()
+    {
+        ScreenManager manager = new ScreenManager();
+        manager.ShowScreen(new TestScreen("Screen1"));
+
+        IReadOnlyList<Screen> screens1 = manager.Screens;
+        IReadOnlyList<Screen> screens2 = manager.Screens;
+
+        Assert.Same(screens1, screens2);
+    }
+
+    [Fact]
+    public void Screens_InvalidatesCacheOnShowScreen()
+    {
+        ScreenManager manager = new ScreenManager();
+        manager.ShowScreen(new TestScreen("Screen1"));
+        IReadOnlyList<Screen> screensBefore = manager.Screens;
+
+        manager.ShowScreen(new TestScreen("Screen2"));
+        IReadOnlyList<Screen> screensAfter = manager.Screens;
+
+        Assert.NotSame(screensBefore, screensAfter);
+        Assert.Equal(2, screensAfter.Count);
+    }
+
+    [Fact]
+    public void Screens_InvalidatesCacheOnCloseScreen()
+    {
+        ScreenManager manager = new ScreenManager();
+        manager.ShowScreen(new TestScreen("Screen1"));
+        manager.ShowScreen(new TestScreen("Screen2"));
+        IReadOnlyList<Screen> screensBefore = manager.Screens;
+
+        manager.CloseScreen();
+        IReadOnlyList<Screen> screensAfter = manager.Screens;
+
+        Assert.NotSame(screensBefore, screensAfter);
+        Assert.Single(screensAfter);
+    }
+
+    [Fact]
+    public void Screens_InvalidatesCacheOnClearScreens()
+    {
+        ScreenManager manager = new ScreenManager();
+        manager.ShowScreen(new TestScreen("Screen1"));
+        IReadOnlyList<Screen> screensBefore = manager.Screens;
+
+        manager.ClearScreens();
+        IReadOnlyList<Screen> screensAfter = manager.Screens;
+
+        Assert.NotSame(screensBefore, screensAfter);
+        Assert.Empty(screensAfter);
+    }
+
+    #endregion
+}

--- a/tests/MonoGame.Extended.Tests/Screens/TestScreens.cs
+++ b/tests/MonoGame.Extended.Tests/Screens/TestScreens.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Screens;
+
+namespace MonoGame.Extended.Tests.Screens;
+
+public class TestScreen : Screen
+{
+    public bool DisposeCalled { get; private set; }
+    public int UpdateCallCount { get; private set; }
+    public int DrawCallCount { get; private set; }
+    public GameTime LastUpdateGameTime { get; private set; }
+    public GameTime LastDrawGameTime { get; private set; }
+
+    public string Name { get; set; }
+
+    // Events for tracking order
+    public event Action<string> OnUpdate;
+    public event Action<string> OnDraw;
+
+    public TestScreen(string name = "TestScreen")
+    {
+        Name = name;
+    }
+
+    public override void Dispose()
+    {
+        DisposeCalled = true;
+        base.Dispose();
+    }
+
+    public override void Update(GameTime gameTime)
+    {
+        OnUpdate?.Invoke(Name);
+        UpdateCallCount++;
+        LastUpdateGameTime = gameTime;
+    }
+
+    public override void Draw(GameTime gameTime)
+    {
+        OnDraw?.Invoke(Name);
+        DrawCallCount++;
+        LastDrawGameTime = gameTime;
+    }
+
+    public void Reset()
+    {
+        DisposeCalled = false;
+        UpdateCallCount = 0;
+        DrawCallCount = 0;
+        LastUpdateGameTime = null;
+        LastDrawGameTime = null;
+        OnUpdate = null;
+        OnDraw = null;
+    }
+}
+
+public class TestGameScreen : GameScreen
+{
+    public TestGameScreen(Game game) : base(game) { }
+    public override void Update(GameTime gameTime) { }
+    public override void Draw(GameTime gameTime) { }
+}


### PR DESCRIPTION
## Description

This PR implements stack-based screen management for the `ScreenManager`, enabling multiple screens to be active simultaneously when control over their background behavior.

Previously, `ScreenManager` only supported a single active screen at a time, requiring workarounds for common scenarios like:

- Games where background rooms should continue simulating while the player explores elsewhere
- Pause menus that need to overlay frozen gameplay
- Dialog systems that stack multiple conversations

The new stack-based approach allows developers to show screens on top of existing ones and control whether inactive screens continue to update and draw via the `UpdateWHenInactive` and `DrawWhenInactive` properties.  

## Related Issues/Tickets

* Closes #958 

## Changes Made

### Screen.cs

- Added `IsActive` property (read-only): indicates if screen is topmost in stack
- Added `UpdateWhenInactive` property: controls background updates
- Added `DrawWhenInactive` property: controls background rendering

### ScreenManager.cs

- Replaced single `_activeScreen` field with `Stack<Screen>` for multiscreen support
- Added `ShowScreen(Screen)`: displays new screen, keeps previous in background
- Added `ShowScreen(Screen, Transition)`: displays new screen with transition effect, keeps previous screen in background
- Added `CloseScreen()`: closes active screen, returns to previous
- Added `CloseScreen(Transition)` closes actives screen with transition effect, returns to previous
- Added `ReplaceScreen(Screen)`: closes active and shows new screen (explicit behavior)
- Added `ReplaceScreen(Screen, Transition)`: closses active with transition effect and shows new screen (explicit behavior)
- Implemented cached screen array with dirty flag that is set to invalidate cache on `ShowScreen()`, `CloseScreen()` and `ClearScreen()` calls
- Screens update bottom-to-top, respecting `IsActive` and `UpdateWhenInActive`
- Screens render bottom-to-top, respecting `IsActive` and `DrawWhenInactive`
- Active screen always updates and draws regardless of properties
- Provide a high-level overview of the technical changes.
- `LoadScreen()` methods marked obsolete with suggestion to use new methods

### Testing

- Unit tests created to ensure new stack-based functionality of the `ScreenManager`

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
