### PR TITLE
Expose entity lifecycle events on World

### DIFF
--- a/source/MonoGame.Extended/ECS/EntityManager.cs
+++ b/source/MonoGame.Extended/ECS/EntityManager.cs
@@ -80,7 +80,6 @@ namespace MonoGame.Extended.ECS
         {
             _changedEntities.Add(entityId);
             _entityToComponentBits[entityId] = _componentManager.CreateComponentBits(entityId);
-            EntityChanged?.Invoke(entityId);
         }
 
         public override void Update(GameTime gameTime)

--- a/source/MonoGame.Extended/ECS/EntityManager.cs
+++ b/source/MonoGame.Extended/ECS/EntityManager.cs
@@ -79,6 +79,8 @@ namespace MonoGame.Extended.ECS
         private void OnComponentsChanged(int entityId)
         {
             _changedEntities.Add(entityId);
+            // TODO: Do we need to call create component bits here when it's called again
+            //       during the next update cycle?
             _entityToComponentBits[entityId] = _componentManager.CreateComponentBits(entityId);
         }
 

--- a/source/MonoGame.Extended/ECS/World.cs
+++ b/source/MonoGame.Extended/ECS/World.cs
@@ -73,7 +73,7 @@ namespace MonoGame.Extended.ECS
 
             EntityManager.EntityAdded += OnEntityAdded;
             EntityManager.EntityRemoved += OnEntityRemoved;
-            EntityManager.EntityRemoved += OnEntityChanged;
+            EntityManager.EntityChanged += OnEntityChanged;
         }
 
         private void OnEntityAdded(int entityId)

--- a/source/MonoGame.Extended/ECS/World.cs
+++ b/source/MonoGame.Extended/ECS/World.cs
@@ -9,6 +9,11 @@ namespace MonoGame.Extended.ECS
         private readonly Bag<IUpdateSystem> _updateSystems;
         private readonly Bag<IDrawSystem> _drawSystems;
 
+        internal EntityManager EntityManager { get; }
+        internal ComponentManager ComponentManager { get; }
+
+        public int EntityCount => EntityManager.ActiveCount;
+
         internal World()
         {
             _updateSystems = new Bag<IUpdateSystem>();
@@ -21,30 +26,33 @@ namespace MonoGame.Extended.ECS
         public override void Dispose()
         {
             foreach (var updateSystem in _updateSystems)
+            {
                 updateSystem.Dispose();
+            }
 
             foreach (var drawSystem in _drawSystems)
+            {
                 drawSystem.Dispose();
+            }
 
             _updateSystems.Clear();
             _drawSystems.Clear();
-            
+
             base.Dispose();
         }
-
-        internal EntityManager EntityManager { get; }
-        internal ComponentManager ComponentManager { get; }
-
-        public int EntityCount => EntityManager.ActiveCount;
 
         internal void RegisterSystem(ISystem system)
         {
             // ReSharper disable once ConvertIfStatementToSwitchStatement
             if (system is IUpdateSystem updateSystem)
+            {
                 _updateSystems.Add(updateSystem);
+            }
 
             if (system is IDrawSystem drawSystem)
+            {
                 _drawSystems.Add(drawSystem);
+            }
 
             system.Initialize(this);
         }
@@ -68,17 +76,21 @@ namespace MonoGame.Extended.ECS
         {
             EntityManager.Destroy(entity);
         }
-        
+
         public override void Update(GameTime gameTime)
         {
             foreach (var system in _updateSystems)
+            {
                 system.Update(gameTime);
+            }
         }
 
         public override void Draw(GameTime gameTime)
         {
             foreach (var system in _drawSystems)
+            {
                 system.Draw(gameTime);
+            }
         }
     }
 }

--- a/source/MonoGame.Extended/ECS/World.cs
+++ b/source/MonoGame.Extended/ECS/World.cs
@@ -5,6 +5,13 @@ using MonoGame.Extended.ECS.Systems;
 
 namespace MonoGame.Extended.ECS
 {
+    /// <summary>
+    /// Represents an Entity Component System (ECS) world that manages entities, components, and system.s
+    /// </summary>
+    /// <remarks>
+    /// The World is the central container for all ECS operations.  It manages the lifecycle of entities, coordinates
+    /// component storage, and executes registered systems during update and draw cycles.
+    /// </remarks>
     public class World : SimpleDrawableGameComponent
     {
         private readonly Bag<IUpdateSystem> _updateSystems;
@@ -13,10 +20,47 @@ namespace MonoGame.Extended.ECS
         internal EntityManager EntityManager { get; }
         internal ComponentManager ComponentManager { get; }
 
+        /// <summary>
+        /// Occurs when an entity is added to the world during the update cycle.
+        /// </summary>
+        /// <remarks>
+        /// This event is raised after the entity has been fully initialized with it initial components.
+        /// The entity ID is valid and can be used to retrieve the entity or query its components.
+        /// Subscribers can use this even to perform initialization logic such as adding the entity to external
+        /// collections, registering it with other systems, or creating associated resources.
+        /// </remarks>
         public event Action<int> EntityAdded;
+
+        /// <summary>
+        /// Occurs when an entity is removed from the world during the update cycle.
+        /// </summary>
+        /// <remarks>
+        /// This event is raised before the entity is returned to the pool and before its components are destroyed,
+        /// allowing subscribers to perform cleanup operations such as removing the entity from external collections,
+        /// unregistering it from other systems, or releasing associated resources.
+        /// After this event completes, the entity ID becomes invalid and should not be used.
+        /// </remarks>
         public event Action<int> EntityRemoved;
+
+        /// <summary>
+        /// Occurs when an entity's component composition changes during the update cycle.
+        /// </summary>
+        /// <remarks>
+        /// This event is raised whenever components are attached to or detached from an entity.
+        /// Subscribers can use this event to respond to composition changes, such as updating cached component
+        /// references, recalculating entity classifications, or refreshing system queries.
+        /// The event is not raised for component value modifications, only structural changes to which components are
+        /// present on the entity.
+        /// </remarks>
         public event Action<int> EntityChanged;
 
+        /// <summary>
+        /// Gets the number of active entities in the world.
+        /// </summary>
+        /// <remarks>
+        /// This count reflects entities that have been created and not yet destroyed.
+        /// Entities queued for destruction are still counted until the next update cycle completes.
+        /// </remarks>
         public int EntityCount => EntityManager.ActiveCount;
 
         internal World()
@@ -30,80 +74,6 @@ namespace MonoGame.Extended.ECS
             EntityManager.EntityAdded += OnEntityAdded;
             EntityManager.EntityRemoved += OnEntityRemoved;
             EntityManager.EntityRemoved += OnEntityChanged;
-        }
-
-        public override void Dispose()
-        {
-            EntityManager.EntityAdded -= OnEntityAdded;
-            EntityManager.EntityRemoved -= OnEntityRemoved;
-            EntityManager.EntityChanged -= OnEntityChanged;
-
-            foreach (var updateSystem in _updateSystems)
-            {
-                updateSystem.Dispose();
-            }
-
-            foreach (var drawSystem in _drawSystems)
-            {
-                drawSystem.Dispose();
-            }
-
-            _updateSystems.Clear();
-            _drawSystems.Clear();
-
-            base.Dispose();
-        }
-
-        internal void RegisterSystem(ISystem system)
-        {
-            // ReSharper disable once ConvertIfStatementToSwitchStatement
-            if (system is IUpdateSystem updateSystem)
-            {
-                _updateSystems.Add(updateSystem);
-            }
-
-            if (system is IDrawSystem drawSystem)
-            {
-                _drawSystems.Add(drawSystem);
-            }
-
-            system.Initialize(this);
-        }
-
-        public Entity GetEntity(int entityId)
-        {
-            return EntityManager.Get(entityId);
-        }
-
-        public Entity CreateEntity()
-        {
-            return EntityManager.Create();
-        }
-
-        public void DestroyEntity(int entityId)
-        {
-            EntityManager.Destroy(entityId);
-        }
-
-        public void DestroyEntity(Entity entity)
-        {
-            EntityManager.Destroy(entity);
-        }
-
-        public override void Update(GameTime gameTime)
-        {
-            foreach (var system in _updateSystems)
-            {
-                system.Update(gameTime);
-            }
-        }
-
-        public override void Draw(GameTime gameTime)
-        {
-            foreach (var system in _drawSystems)
-            {
-                system.Draw(gameTime);
-            }
         }
 
         private void OnEntityAdded(int entityId)
@@ -124,10 +94,146 @@ namespace MonoGame.Extended.ECS
 
         private void OnEntityChanged(int entityId)
         {
-            if(EntityChanged != null)
+            if (EntityChanged != null)
             {
                 EntityChanged.Invoke(entityId);
             }
+        }
+
+        internal void RegisterSystem(ISystem system)
+        {
+            // ReSharper disable once ConvertIfStatementToSwitchStatement
+            if (system is IUpdateSystem updateSystem)
+            {
+                _updateSystems.Add(updateSystem);
+            }
+
+            if (system is IDrawSystem drawSystem)
+            {
+                _drawSystems.Add(drawSystem);
+            }
+
+            system.Initialize(this);
+        }
+
+        /// <summary>
+        /// Retrieves an entity by its unique identifier.
+        /// </summary>
+        /// <param name="entityId">The unique identifier of the entity to retrieve.</param>
+        /// <returns>
+        /// The entity with the specified identifier, or <c>null</c> if the entity has been destroyed or the ID is
+        /// invalid.
+        /// </returns>
+        public Entity GetEntity(int entityId)
+        {
+            return EntityManager.Get(entityId);
+        }
+
+        /// <summary>
+        /// Creates a new entity in the world.
+        /// </summary>
+        /// <remarks>
+        /// The entity is created immediately, but the <see cref="EntityAdded"/> event is not raised until
+        /// the next <see cref="Update(GameTime)"/> cycle.  The returned entity can be used immediately to
+        /// attach components.
+        /// Entity IDs are reused from a pool after entities are destroyed.
+        /// </remarks>
+        /// <returns>A new entity with a unique identifier.</returns>
+        public Entity CreateEntity()
+        {
+            return EntityManager.Create();
+        }
+
+        /// <summary>
+        /// Destroys an entity in the world.
+        /// </summary>
+        /// <remarks>
+        /// The entity is queued for destruction and the <see cref="EntityRemoved"/> event is raised during
+        /// the next <see cref="Update(GameTime)"/> cycle, before the entity and its components are removed from
+        /// memory.
+        /// Calling this method multiple times with the same entity ID has no additional effect.
+        /// After destruction completes, the entity ID may be reused for new entities.
+        /// </remarks>
+        /// <param name="entityId">The unique identifier of the entity to destroy.</param>
+        public void DestroyEntity(int entityId)
+        {
+            EntityManager.Destroy(entityId);
+        }
+
+        /// <summary>
+        /// Destroys an entity in the world.
+        /// </summary>
+        /// <remarks>
+        /// The entity is queued for destruction and the <see cref="EntityRemoved"/> event is raised during
+        /// the next <see cref="Update(GameTime)"/> cycle, before the entity and its components are removed from
+        /// memory.
+        /// Calling this method multiple times with the same entity ID has no additional effect.
+        /// After destruction completes, the entity ID may be reused for new entities.
+        /// </remarks>
+        /// <param name="entity">The entity to destroy.</param>
+        public void DestroyEntity(Entity entity)
+        {
+            EntityManager.Destroy(entity);
+        }
+
+        /// <summary>
+        /// Updates all registered systems in the world.
+        /// </summary>
+        /// <remarks>
+        /// This method invokes <see cref="IUpdateSystem.Update(GameTime)"/> on all registered update systems in
+        /// registration order.
+        /// Entity lifecycle events (<see cref="EntityAdded"/>, <see cref="EntityRemoved"/>,
+        /// <see cref="EntityChanged"/>) are raised during this update cycle as entities are processed by the
+        /// <see cref="EntityManager"/>.
+        /// </remarks>
+        /// <param name="gameTime">A snapshot of the timing values for the current cycle.</param>
+        public override void Update(GameTime gameTime)
+        {
+            foreach (var system in _updateSystems)
+            {
+                system.Update(gameTime);
+            }
+        }
+
+        /// <summary>
+        /// Draws all registered systems in the world.
+        /// </summary>
+        /// <remarks>
+        /// This method invokes <see cref="IDrawSystem.Draw(GameTime)"/> on all registered draw systems in
+        /// registration order.
+        /// </remarks>
+        /// <param name="gameTime">A snapshot of the timing values for the current cycle.</param>
+        public override void Draw(GameTime gameTime)
+        {
+            foreach (var system in _drawSystems)
+            {
+                system.Draw(gameTime);
+            }
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="World"/>
+        /// </summary>
+        public override void Dispose()
+        {
+            EntityManager.EntityAdded -= OnEntityAdded;
+            EntityManager.EntityRemoved -= OnEntityRemoved;
+            EntityManager.EntityChanged -= OnEntityChanged;
+
+            foreach (var updateSystem in _updateSystems)
+            {
+                updateSystem.Dispose();
+            }
+
+            foreach (var drawSystem in _drawSystems)
+            {
+                drawSystem.Dispose();
+            }
+
+            _updateSystems.Clear();
+            _drawSystems.Clear();
+
+            base.Dispose();
         }
     }
 }

--- a/source/MonoGame.Extended/ECS/World.cs
+++ b/source/MonoGame.Extended/ECS/World.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System;
+using Microsoft.Xna.Framework;
 using MonoGame.Extended.Collections;
 using MonoGame.Extended.ECS.Systems;
 
@@ -12,6 +13,10 @@ namespace MonoGame.Extended.ECS
         internal EntityManager EntityManager { get; }
         internal ComponentManager ComponentManager { get; }
 
+        public event Action<int> EntityAdded;
+        public event Action<int> EntityRemoved;
+        public event Action<int> EntityChanged;
+
         public int EntityCount => EntityManager.ActiveCount;
 
         internal World()
@@ -21,10 +26,18 @@ namespace MonoGame.Extended.ECS
 
             RegisterSystem(ComponentManager = new ComponentManager());
             RegisterSystem(EntityManager = new EntityManager(ComponentManager));
+
+            EntityManager.EntityAdded += OnEntityAdded;
+            EntityManager.EntityRemoved += OnEntityRemoved;
+            EntityManager.EntityRemoved += OnEntityChanged;
         }
 
         public override void Dispose()
         {
+            EntityManager.EntityAdded -= OnEntityAdded;
+            EntityManager.EntityRemoved -= OnEntityRemoved;
+            EntityManager.EntityChanged -= OnEntityChanged;
+
             foreach (var updateSystem in _updateSystems)
             {
                 updateSystem.Dispose();
@@ -90,6 +103,30 @@ namespace MonoGame.Extended.ECS
             foreach (var system in _drawSystems)
             {
                 system.Draw(gameTime);
+            }
+        }
+
+        private void OnEntityAdded(int entityId)
+        {
+            if (EntityAdded != null)
+            {
+                EntityAdded.Invoke(entityId);
+            }
+        }
+
+        private void OnEntityRemoved(int entityId)
+        {
+            if (EntityRemoved != null)
+            {
+                EntityRemoved.Invoke(entityId);
+            }
+        }
+
+        private void OnEntityChanged(int entityId)
+        {
+            if(EntityChanged != null)
+            {
+                EntityChanged.Invoke(entityId);
             }
         }
     }

--- a/tests/MonoGame.Extended.Tests/ECS/WorldManagerTests.cs
+++ b/tests/MonoGame.Extended.Tests/ECS/WorldManagerTests.cs
@@ -17,8 +17,13 @@ public class WorldManagerTests
         worldBuilder.AddSystem(dummySystem);
         var world = worldBuilder.Build();
 
+        var addedEntities = new List<int>();
+        var removedEntities = new List<int>();
+        var changedEntities = new List<int>();
+
         world.Initialize();
 
+        world.EntityAdded += entityId => addedEntities.Add(entityId);
         var entity = world.CreateEntity();
         entity.Attach(new Transform2());
         world.Update(_gameTime);
@@ -27,15 +32,27 @@ public class WorldManagerTests
         Assert.Equal(entity, otherEntity);
         Assert.True(otherEntity.Has<Transform2>());
         Assert.Contains(entity.Id, dummySystem.AddedEntitiesId);
+        Assert.Single(addedEntities);
+        Assert.Equal(entity.Id, addedEntities[0]);
 
+        world.EntityChanged += entityId => changedEntities.Add(entityId);
+        entity.Attach(new TestComponent());
+        world.Update(_gameTime);
+        Assert.Single(changedEntities);
+        Assert.Equal(entity.Id, changedEntities[0]);
+
+        world.EntityRemoved += entityId => removedEntities.Add(entityId);
         entity.Destroy();
         world.Update(_gameTime);
         world.Draw(_gameTime);
         otherEntity = world.GetEntity(entity.Id);
         Assert.Null(otherEntity);
         Assert.Contains(entity.Id, dummySystem.RemovedEntitiesId);
+        Assert.Single(removedEntities);
+        Assert.Equal(entity.Id, removedEntities[0]);
     }
 
+    private class TestComponent { }
     private class DummyComponent { }
 
     private class DummySystem : EntitySystem, IUpdateSystem, IDrawSystem


### PR DESCRIPTION
## Description

This pull request exposes entity lifecycle events on the `World `class, allowing external systems to react when entities are added, removed, or have their component composition changed. This enables integration between the ECS and other subsystems (such as `CollisionComponent`) without requiring each system to implement its own entity tracking.

The events are raised during the `World.Update()` cycle and provide entity IDs to subscribers, who can then perform necessary initialization or cleanup operations.

## Related Issues/Tickets

* Closes #1026

## Changes Made

* **Added three public events to `World `class**:
    * `EntityAdded `: Fires when an entity is added to the world during the update cycle
    * `EntityRemoved`:  Fires when an entity is removed from the world during the update cycle (before destruction)
    * `EntityChanged`:  Fires when an entity's component composition changes
* **Event wiring in `World` constructor**: Subscribes to internal `EntityManager `events to forward them to public subscribers
* **Cleanup in `World.Dispose()`**: Unsubscribes from `EntityManager `events 

## Bug Fixed
* **Fixed duplicate `EntityChanged `invocation in `EntityManager`**: Removed immediate event invocation in `OnComponentsChanged()` to ensure the event only fires once during the Update() cycle, consistent with `EntityAdded `and `EntityRemoved `behavior

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
