### PR TITLE
Add zoom-to-point methods for OrthographicCamera

### DIFF
--- a/source/MonoGame.Extended/OrthographicCamera.cs
+++ b/source/MonoGame.Extended/OrthographicCamera.cs
@@ -266,10 +266,48 @@ namespace MonoGame.Extended
             Zoom += deltaZoom;
         }
 
+        /// <summary>
+        /// Increases the camera's zoom level while maintaining a specified world position as the zoom center.
+        /// </summary>
+        /// <param name="deltaZoom">The amount to increase the zoom by.</param>
+        /// <param name="zoomCenter">
+        /// The world position to use as the zoom center. This point will remain fixed in screen space
+        /// as the zoom changes.
+        /// </param>
+        public void ZoomIn(float deltaZoom, Vector2 zoomCenter)
+        {
+            float previousZoom = Zoom;
+            Zoom += deltaZoom;
+
+            if (Zoom != previousZoom)
+            {
+                Position += (zoomCenter - Origin - Position) * ((Zoom - previousZoom) / Zoom);
+            }
+        }
+
         /// <inheritdoc/>
         public override void ZoomOut(float deltaZoom)
         {
             Zoom -= deltaZoom;
+        }
+
+        /// <summary>
+        /// Decreases the camera's zoom level while maintaining a specified world position as the zoom center.
+        /// </summary>
+        /// <param name="deltaZoom">The amount to decrease the zoom by.</param>
+        /// <param name="zoomCenter">
+        /// The world position to use as the zoom center. This point will remain fixed in screen space
+        /// as the zoom changes.
+        /// </param>
+        public void ZoomOut(float deltaZoom, Vector2 zoomCenter)
+        {
+            float previousZoom = Zoom;
+            Zoom -= deltaZoom;
+
+            if (Zoom != previousZoom)
+            {
+                Position += (zoomCenter - Origin - Position) * ((Zoom - previousZoom) / Zoom);
+            }
         }
 
         /// <inheritdoc/>

--- a/tests/MonoGame.Extended.Tests/OrthographicCameraTests.cs
+++ b/tests/MonoGame.Extended.Tests/OrthographicCameraTests.cs
@@ -685,6 +685,153 @@ public sealed class OrthographicCameraTests
         Assert.Equal(0, corners[7].Z, 2);
     }
 
+    [Fact]
+    public void ZoomIn_WithZoomCenter_KeepsZoomCenterFixedOnScreen()
+    {
+        OrthographicCamera camera = new OrthographicCamera(_graphicsFixture.GraphicsDevice);
+        camera.Position = Vector2.Zero;
+        camera.Zoom = 1.0f;
+
+        Vector2 zoomCenter = new Vector2(100, 100);
+        Vector2 screenBefore = camera.WorldToScreen(zoomCenter);
+
+        camera.ZoomIn(0.5f, zoomCenter);
+        Vector2 screenAfter = camera.WorldToScreen(zoomCenter);
+
+        Assert.Equal(screenBefore.X, screenAfter.X, 1);
+        Assert.Equal(screenBefore.Y, screenAfter.Y, 1);
+    }
+
+    [Fact]
+    public void ZoomOut_WithZoomCenter_KeepsZoomCenterFixedOnScreen()
+    {
+        OrthographicCamera camera = new OrthographicCamera(_graphicsFixture.GraphicsDevice);
+        camera.Position = Vector2.Zero;
+        camera.Zoom = 2.0f;
+
+        Vector2 zoomCenter = new Vector2(100, 100);
+        Vector2 screenBefore = camera.WorldToScreen(zoomCenter);
+
+        camera.ZoomOut(0.5f, zoomCenter);
+        Vector2 screenAfter = camera.WorldToScreen(zoomCenter);
+
+        Assert.Equal(screenBefore.X, screenAfter.X, 1);
+        Assert.Equal(screenBefore.Y, screenAfter.Y, 1);
+    }
+
+    [Fact]
+    public void ZoomIn_WithZoomCenter_ClampedByMinimumZoom_DoesNotAdjustPosition()
+    {
+        OrthographicCamera camera = new OrthographicCamera(_graphicsFixture.GraphicsDevice);
+        camera.MaximumZoom = 2.0f;
+        camera.Zoom = camera.MaximumZoom;
+        camera.Position = new Vector2(50, 50);
+
+        Vector2 zoomCenter = new Vector2(100, 100);
+        Vector2 positionBefore = camera.Position;
+
+        camera.ZoomIn(1.0f, zoomCenter);
+
+        Assert.Equal(2.0f, camera.Zoom);
+        Assert.Equal(positionBefore, camera.Position);
+    }
+
+    [Fact]
+    public void ZoomOut_WithZoomCenter_ClampedByMinimumZoom_DoesNotAdjustPosition()
+    {
+        OrthographicCamera camera = new OrthographicCamera(_graphicsFixture.GraphicsDevice);
+        camera.MinimumZoom = 0.5f;
+        camera.Zoom = camera.MinimumZoom;
+        camera.Position = new Vector2(50, 50);
+
+        Vector2 zoomCenter = new Vector2(100, 100);
+        Vector2 positionBefore = camera.Position;
+
+        camera.ZoomOut(1.0f, zoomCenter);
+
+        Assert.Equal(0.5f, camera.Zoom);
+        Assert.Equal(positionBefore, camera.Position);
+    }
+
+
+    [Fact]
+    public void ZoomIn_WithZoomCenter_AtOrigin_AdjustsPositionCorrectly()
+    {
+        OrthographicCamera camera = new OrthographicCamera(_graphicsFixture.GraphicsDevice);
+
+        camera.Position = new Vector2(100, 100);
+        camera.Zoom = 1.0f;
+
+        Vector2 zoomCenter = camera.Origin;
+        Vector2 screenBefore = camera.WorldToScreen(zoomCenter);
+
+        camera.ZoomIn(0.5f, zoomCenter);
+        Vector2 screenAfter = camera.WorldToScreen(zoomCenter);
+
+        Assert.Equal(screenBefore.X, screenAfter.X, 1);
+        Assert.Equal(screenBefore.Y, screenAfter.Y, 1);
+    }
+
+    [Fact]
+    public void ZoomOut_WithZoomCenter_AtOrigin_AdjustsPositionCorrectly()
+    {
+        OrthographicCamera camera = new OrthographicCamera(_graphicsFixture.GraphicsDevice);
+
+        camera.Position = new Vector2(100, 100);
+        camera.Zoom = 2.0f;
+
+        Vector2 zoomCenter = camera.Origin;
+        Vector2 screenBefore = camera.WorldToScreen(zoomCenter);
+
+        camera.ZoomOut(0.5f, zoomCenter);
+        Vector2 screenAfter = camera.WorldToScreen(zoomCenter);
+
+        Assert.Equal(screenBefore.X, screenAfter.X, 1);
+        Assert.Equal(screenBefore.Y, screenAfter.Y, 1);
+    }
+
+    [Fact]
+    public void ZoomIn_WithZoomCenter_WorldBoundsEnabled_RespectsBounds()
+    {
+        OrthographicCamera camera = new OrthographicCamera(_graphicsFixture.GraphicsDevice);
+        Viewport viewport = _graphicsFixture.GraphicsDevice.Viewport;
+        Rectangle worldBounds = new Rectangle(0, 0, viewport.Width * 2, viewport.Height * 2);
+
+        camera.EnableWorldBounds(worldBounds);
+        camera.Position = new Vector2(viewport.Width / 2, viewport.Height / 2);
+        camera.Zoom = 1.0f;
+
+        Vector2 zoomCenter = new Vector2(200, 200);
+
+        camera.ZoomIn(0.5f, zoomCenter);
+
+        Assert.True(camera.Position.X >= 0);
+        Assert.True(camera.Position.Y >= 0);
+        Assert.True(camera.Position.X <= worldBounds.Right - viewport.Width / camera.Zoom);
+        Assert.True(camera.Position.Y <= worldBounds.Bottom - viewport.Height / camera.Zoom);
+    }
+
+    [Fact]
+    public void ZoomOut_WithZoomCenter_WorldBoundsEnabled_RespectsBounds()
+    {
+        OrthographicCamera camera = new OrthographicCamera(_graphicsFixture.GraphicsDevice);
+        Viewport viewport = _graphicsFixture.GraphicsDevice.Viewport;
+        Rectangle worldBounds = new Rectangle(0, 0, viewport.Width * 2, viewport.Height * 2);
+
+        camera.EnableWorldBounds(worldBounds);
+        camera.Position = new Vector2(viewport.Width / 2, viewport.Height / 2);
+        camera.Zoom = 2.0f;
+
+        Vector2 zoomCenter = new Vector2(200, 200);
+
+        camera.ZoomOut(0.5f, zoomCenter);
+
+        Assert.True(camera.Position.X >= 0);
+        Assert.True(camera.Position.Y >= 0);
+        Assert.True(camera.Position.X <= worldBounds.Right - viewport.Width / camera.Zoom);
+        Assert.True(camera.Position.Y <= worldBounds.Bottom - viewport.Height / camera.Zoom);
+    }
+
     // -----------------------------------------------------------------------------
     // Tests for issue #793
     // OrthographicCamera.ScreenToWorld and similar methods interact poorly with


### PR DESCRIPTION
## Description

This pull request adds zoom-to-point functionality to `OrthographicCamera`, allowing developers to zoom toward a specific world position while keeping that point fixed on screen. 

## Related Issues/Tickets

* Closes #625

## Changes Made

### OrthographicCamera.cs
* Added `ZoomIn(float deltaZoom, Vector2 zoomCenter)` method that zooms in while keeping a world position fixed on screen
* Added `ZoomOut(float deltaZoom, Vector2 zoomCenter)` method that zooms out while keeping a world position fixed on screen
* Both methods include position adjustment formula: `Position += (zoomCenter - Origin - Position) * ((newZoom - oldZoom) / newZoom)`
* Position adjustment is skipped when zoom is clamped by `MinimumZoom`, `MaximumZoom`, or world bounds to prevent unexpected camera movement

## Checklist

Please read and check the following items. Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.