### PR TITLE
Feature/move ondelete call timing 1062

### DIFF
--- a/source/MonoGame.Extended/ECS/ComponentMapper.cs
+++ b/source/MonoGame.Extended/ECS/ComponentMapper.cs
@@ -73,9 +73,9 @@ namespace MonoGame.Extended.ECS
 
         public override void Delete(int entityId)
         {
+            OnDelete?.Invoke(entityId);
             Components[entityId] = null;
             _onCompositionChanged(entityId);
-            OnDelete?.Invoke(entityId);
         }
     }
 }

--- a/tests/MonoGame.Extended.Tests/ECS/ComponentMapperTests.cs
+++ b/tests/MonoGame.Extended.Tests/ECS/ComponentMapperTests.cs
@@ -81,11 +81,15 @@ namespace MonoGame.Extended.ECS.Tests
             mapper.OnDelete += (entId) =>
             {
                 Assert.Equal(entityId, entId);
-                Assert.False(mapper.Has(entityId));
+                Assert.True(mapper.Has(entityId));
+                Assert.NotNull(mapper.Get(entityId));
             };
 
             mapper.Put(entityId, component);
             mapper.Delete(entityId);
+
+            // Component should be removed after Delete completes
+            Assert.False(mapper.Has(entityId));
         }
 
         [Fact]


### PR DESCRIPTION
## Description

This pull request moves the timing of the `ComponentMapper.OnDelete` event invocation to occur before component removal rather than after. This change allows event handlers to access and reference the component data during cleanup operations, enabling cleanup tasks that require access to the component being deleted.

## Related Issues/Tickets

* Closes #1062

## Changes Made

* Moved `OnDelete?.Invoke(entityId)` call to execute before `Components[entityId] = null` in the `ComponentMapper<T>.Delete()` method
* Updated the `OnDelete` test in to verify that components are accessible during the event and properly removed after deletion completes

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
