### PR TITLE
Add Normalize() method to RectangleF to handle negative width/height

### DIFF
--- a/source/MonoGame.Extended/Math/RectangleF.cs
+++ b/source/MonoGame.Extended/Math/RectangleF.cs
@@ -442,6 +442,77 @@ namespace MonoGame.Extended
         }
 
         /// <summary>
+        /// Normalizes this <see cref="RectangleF"/> so that the <see cref="Width"/> and <see cref="Height"/> are
+        /// positive without changing the location of the rectangle.
+        /// </summary>
+        public void Normalize()
+        {
+            if (Width < 0)
+            {
+                X += Width;
+                Width = -Width;
+            }
+
+            if (Height < 0)
+            {
+                Y += Height;
+                Height = -Height;
+            }
+        }
+
+        /// <summary>
+        /// Normalizes the specified <see cref="RectangleF"/> so that the <see cref="Width"/> and <see cref="Height"/>
+        /// are positive without changing the location of the rectangle.
+        /// </summary>
+        /// <param name="rectangle">The <see cref="RectangleF"/> to normalize.</param>
+        /// <returns>A <see cref="RectangleF"/> with positive width and height.</returns>
+        public static RectangleF Normalize(RectangleF rectangle)
+        {
+            if (rectangle.Width < 0)
+            {
+                rectangle.X += rectangle.Width;
+                rectangle.Width = -rectangle.Width;
+            }
+
+            if (rectangle.Height < 0)
+            {
+                rectangle.Y += rectangle.Height;
+                rectangle.Height = -rectangle.Height;
+            }
+
+            return rectangle;
+        }
+
+        /// <summary>
+        /// Normalizes a <see cref="RectangleF"/> so that the <see cref="Width"/> and <see cref="Height"/> are positive
+        /// without changing the location of the rectangle.
+        /// </summary>
+        /// <param name="rectangle">The source <see cref="RectangleF"/>.</param>
+        /// <param name="result">
+        /// When this method returns, contains the a normalized <see cref="RectangleF"/> with positive width and height.
+        /// </param>
+        public static void Normalize(ref RectangleF rectangle, out RectangleF result)
+        {
+            result.X = rectangle.X;
+            result.Width = rectangle.Width;
+
+            if (result.Width < 0)
+            {
+                result.X += result.Width;
+                result.Width = -result.Width;
+            }
+
+            result.Y = rectangle.Y;
+            result.Height = rectangle.Height;
+
+            if (result.Height < 0)
+            {
+                result.Y += result.Height;
+                result.Height = -result.Height;
+            }
+        }
+
+        /// <summary>
         ///     Determines whether the specified <see cref="RectangleF" /> contains the specified
         ///     <see cref="Vector2" />.
         /// </summary>

--- a/source/MonoGame.Extended/Rectangle.Extensions.cs
+++ b/source/MonoGame.Extended/Rectangle.Extensions.cs
@@ -93,4 +93,56 @@ public static class RectangleExtensions
 
     }
 #endif
+
+    /// <summary>
+    /// Normalizes the specified <see cref="Rectangle"/> so that the <see cref="Rectangle.Width"/> and
+    /// <see cref="Rectangle.Height"/> are positive without changing the location of the rectangle.
+    /// </summary>
+    /// <param name="rectangle">The <see cref="Rectangle"/> to normalize.</param>
+    /// <returns>A <see cref="Rectangle"/> with positive width and height.</returns>
+    public static Rectangle Normalize(Rectangle rectangle)
+    {
+        if (rectangle.Width < 0)
+        {
+            rectangle.X += rectangle.Width;
+            rectangle.Width = -rectangle.Width;
+        }
+
+        if (rectangle.Height < 0)
+        {
+            rectangle.Y += rectangle.Height;
+            rectangle.Height = -rectangle.Height;
+        }
+
+        return rectangle;
+    }
+
+    /// <summary>
+    /// Normalizes a <see cref="Rectangle"/> so that the <see cref="Rectangle.Width"/> and
+    /// <see cref="Rectangle.Height"/> are positive without changing the location of the rectangle.
+    /// </summary>
+    /// <param name="rectangle">The source <see cref="Rectangle"/>.</param>
+    /// <param name="result">
+    /// When this method returns, contains the a normalized <see cref="Rectangle"/> with positive width and height.
+    /// </param>
+    public static void Normalize(ref this Rectangle rectangle, out Rectangle result)
+    {
+        result.X = rectangle.X;
+        result.Width = rectangle.Width;
+
+        if (result.Width < 0)
+        {
+            result.X += result.Width;
+            result.Width = -result.Width;
+        }
+
+        result.Y = rectangle.Y;
+        result.Height = rectangle.Height;
+
+        if (result.Height < 0)
+        {
+            result.Y += result.Height;
+            result.Height = -result.Height;
+        }
+    }
 }

--- a/tests/MonoGame.Extended.Tests/Math/RectangleFTests.cs
+++ b/tests/MonoGame.Extended.Tests/Math/RectangleFTests.cs
@@ -1,0 +1,83 @@
+namespace MonoGame.Extended.Tests;
+
+public sealed class RectangleFTests
+{
+    [Fact]
+    public void Normalize_WithNegativeWidthAndHeight_AdjustsPositionAndMakesDimensionsPositive()
+    {
+        RectangleF rectangle = new RectangleF(32, 32, -32, -32);
+        rectangle.Normalize();
+
+        RectangleF expected = new RectangleF(0, 0, 32, 32);
+        Assert.Equal(expected, rectangle);
+    }
+
+    [Fact]
+    public void Normalize_WithNegativeWidthOnly_AdjustsXAndMakesWidthPositive()
+    {
+        RectangleF rectangle = new RectangleF(100, 50, -20, 30);
+        rectangle.Normalize();
+
+        RectangleF expected = new RectangleF(80, 50, 20, 30);
+        Assert.Equal(expected, rectangle);
+    }
+
+    [Fact]
+    public void Normalize_WithNegativeHeightOnly_AdjustsYAndMakesHeightPositive()
+    {
+        RectangleF rectangle = new RectangleF(50, 100, 30, -20);
+        rectangle.Normalize();
+
+        RectangleF expected = new RectangleF(50, 80, 30, 20);
+        Assert.Equal(expected, rectangle);
+    }
+
+    [Fact]
+    public void Normalize_WithPositiveDimensions_DoesNotModifyRectangle()
+    {
+        RectangleF rectangle = new RectangleF(10, 20, 30, 40);
+        rectangle.Normalize();
+
+        RectangleF expected = new RectangleF(10, 20, 30, 40);
+        Assert.Equal(expected, rectangle);
+    }
+
+    [Fact]
+    public void Normalize_StaticMethod_ReturnsNormalizedRectangle()
+    {
+        RectangleF rectangle = new RectangleF(32, 32, -32, -32);
+
+        RectangleF actual = RectangleF.Normalize(rectangle);
+        RectangleF expected = new RectangleF(0, 0, 32, 32);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Normalize_RefOutMethod_OutputsNormalizedRectangle()
+    {
+        RectangleF rectangle = new RectangleF(32, 32, -32, -32);
+
+        RectangleF.Normalize(ref rectangle, out RectangleF actual);
+        RectangleF expected = new RectangleF(0, 0, 32, 32);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Trait("Issue", "#793")]
+    public sealed class RectangleFIssue747
+    {
+        [Fact]
+        public void Normalize_FixesIntersectionIssue_FromGitHubIssue747()
+        {
+            // This was the original reported issue
+            RectangleF shape1 = new RectangleF(32, 32, -32, -32);
+            RectangleF shape2 = new RectangleF(16, 16, -32, -32);
+
+            shape1.Normalize();
+            shape2.Normalize();
+
+            Assert.True(shape1.Intersects(shape2));
+        }
+    }
+}

--- a/tests/MonoGame.Extended.Tests/RectangleExtensionsTests.cs
+++ b/tests/MonoGame.Extended.Tests/RectangleExtensionsTests.cs
@@ -16,5 +16,67 @@ namespace MonoGame.Extended.Tests
             Assert.Equal(new Rectangle(2, 2, 8, 8), rect.Clip(clip2));
             Assert.Equal(new Rectangle(0, 0, 3, 3), rect.Clip(clip3));
         }
+
+        [Fact]
+        public void Normalize_WithNegativeWidthAndHeight_AdjustsPositionAndMakesDimensionsPositive()
+        {
+            Rectangle rectangle = new Rectangle(32, 32, -32, -32);
+            Rectangle actual = RectangleExtensions.Normalize(rectangle);
+
+            Rectangle expected = new Rectangle(0, 0, 32, 32);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Normalize_WithNegativeWidthOnly_AdjustsXAndMakesWidthPositive()
+        {
+            Rectangle rectangle = new Rectangle(100, 50, -20, 30);
+            Rectangle actual = RectangleExtensions.Normalize(rectangle);
+
+            Rectangle expected = new Rectangle(80, 50, 20, 30);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Normalize_WithNegativeHeightOnly_AdjustsYAndMakesHeightPositive()
+        {
+            Rectangle rectangle = new Rectangle(50, 100, 30, -20);
+            Rectangle actual = RectangleExtensions.Normalize(rectangle);
+
+            Rectangle expected = new Rectangle(50, 80, 30, 20);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Normalize_WithPositiveDimensions_DoesNotModifyRectangle()
+        {
+            Rectangle rectangle = new Rectangle(10, 20, 30, 40);
+            Rectangle actual = RectangleExtensions.Normalize(rectangle);
+
+            Rectangle expected = new Rectangle(10, 20, 30, 40);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Normalize_StaticMethod_ReturnsNormalizedRectangle()
+        {
+            Rectangle rectangle = new Rectangle(32, 32, -32, -32);
+
+            Rectangle actual = RectangleExtensions.Normalize(rectangle);
+            Rectangle expected = new Rectangle(0, 0, 32, 32);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Normalize_RefOutMethod_OutputsNormalizedRectangle()
+        {
+            Rectangle rectangle = new Rectangle(32, 32, -32, -32);
+
+            RectangleExtensions.Normalize(ref rectangle, out Rectangle actual);
+            Rectangle expected = new Rectangle(0, 0, 32, 32);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
## Description

Adds `Normalize()` methods to `RectangleF` to handle negative width and height values. When a rectangle has negative dimensions (common when creating rectangles from directional vectors or drag operations), the normalize method adjusts the position and makes the dimensions positive without changing the rectangle's actual location.


## Related Issues/Tickets

* Closes #747

## Changes Made

* Added `Normalize()` method overloads to `RectangleF`:
  * `void Normalize()` - Instance method for in-place normalization
  * `static RectangleF Normalize(RectangleF rectangle)` - Static method returning normalized copy
  * `static void Normalize(ref RectangleF rectangle, out RectangleF result)`

* Added `Normalize()` methods `RectangleExtensions`:
  * `static Rectangle Normalize(Rectangle rectangle)`:  Static method returning normalized copy
  * `static void Normalize(ref Rectangle rectangle, out Rectangle result)`

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.