### PR TITLE
Remove duplicated CreateComponentBits call in Update when when entities are changed

### DIFF
--- a/source/MonoGame.Extended/ECS/EntityManager.cs
+++ b/source/MonoGame.Extended/ECS/EntityManager.cs
@@ -79,8 +79,6 @@ namespace MonoGame.Extended.ECS
         private void OnComponentsChanged(int entityId)
         {
             _changedEntities.Add(entityId);
-            // TODO: Do we need to call create component bits here when it's called again
-            //       during the next update cycle?
             _entityToComponentBits[entityId] = _componentManager.CreateComponentBits(entityId);
         }
 
@@ -95,7 +93,6 @@ namespace MonoGame.Extended.ECS
 
             foreach (var entityId in _changedEntities)
             {
-                _entityToComponentBits[entityId] = _componentManager.CreateComponentBits(entityId);
                 EntityChanged?.Invoke(entityId);
             }
 


### PR DESCRIPTION
## Description

When #724 was implemented, it added the call to `CreateComponentBits` during the `OnComponentsChanged` event to resolve issue #723.  However, in doing so, this made it so that `CreateComponentBits` is called a again during `Update` when it doesn't need to be.  This call should have been removed. 

## Related Issues/Tickets

* Closes #1057 
* #724 
* #723 

## Changes Made

* Removed call to `CreateComponentBits` in `Update` method for changed entities.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
