### PR TITLE
Check for UTF-8 Byte Order Mark Preamble at the start of stream.

### DIFF
--- a/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileReader.cs
+++ b/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileReader.cs
@@ -57,8 +57,31 @@ public static class BitmapFontFileReader
     public static BitmapFontFileContent Read(Stream stream, string name)
     {
         long position = stream.Position;
-        var sig = stream.ReadByte();
-        stream.Position = position;
+
+        // Issue: MonoGame.Extended won't load XML format .fnt files if they begin with the byte order mark.
+        // https://github.com/MonoGame-Extended/Monogame-Extended/issues/1073
+        // It's possible that a consumer might edit the BMFont file using a different library such as SharpFNT.BitmapFont
+        // which could save it with UTF-8 Byte Order Mark (BOM) preamble at the start of the file.
+        // To get around this, we need to detect if the preamble is there and advance the stream past it if so.
+
+        Span<byte> buffer = stackalloc byte[3];
+        int bytesRead = stream.Read(buffer);
+        if (bytesRead < 1)
+        {
+            throw new InvalidOperationException("Stream is empty or unreadable");
+        }
+
+        int sig;
+        if (buffer.SequenceEqual(Encoding.UTF8.GetPreamble()))
+        {
+            sig = stream.ReadByte();
+            stream.Seek(-1, SeekOrigin.Current);
+        }
+        else
+        {
+            sig = buffer[0];
+            stream.Position = position;
+        }
 
         var bmfFile = sig switch
         {

--- a/tests/MonoGame.Extended.Tests/BitmapFonts/BitmapFontFileReaderTests.cs
+++ b/tests/MonoGame.Extended.Tests/BitmapFonts/BitmapFontFileReaderTests.cs
@@ -129,6 +129,25 @@ public class BitmapFontFileReaderTests
         Assert.True(_expected.Kernings.SequenceEqual(actual.Kernings));
     }
 
+    // Issue: MonoGame.Extended won't load XML format .fnt files if they begin with the byte order mark.
+    // https://github.com/MonoGame-Extended/Monogame-Extended/issues/1073
+    // It's possible that a consumer might edit the BMFont file using a different library such as SharpFNT.BitmapFont
+    // which could save it with UTF-8 Byte Order Mark (BOM) preamble at the start of the file.
+    [Fact]
+    public void Read_XmlFile_With_UTF8_BOM_Test()
+    {
+        string path = "BitmapFonts/files/bmfont/test-font-xml-utf8-bom.fnt";
+        using FileStream stream = File.OpenRead(path);
+        var actual = BitmapFontFileReader.Read(stream, path);
+        Assert.Equal(_expected.Header, actual.Header);
+        Assert.Equal(_expected.Info, actual.Info);
+        Assert.Equal(_expected.Common, actual.Common);
+        Assert.Equal(_expected.FontName, actual.FontName);
+        Assert.True(_expected.Pages.SequenceEqual(actual.Pages));
+        Assert.True(_expected.Characters.SequenceEqual(actual.Characters));
+        Assert.True(_expected.Kernings.SequenceEqual(actual.Kernings));
+    }
+
     [Fact]
     public void Read_Text_Test()
     {

--- a/tests/MonoGame.Extended.Tests/BitmapFonts/files/bmfont/test-font-xml-utf8-bom.fnt
+++ b/tests/MonoGame.Extended.Tests/BitmapFonts/files/bmfont/test-font-xml-utf8-bom.fnt
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0"?>
+<font>
+  <info face="Cute Dino" size="32" bold="0" italic="0" charset="" unicode="1" stretchH="50" smooth="1" aa="1" padding="1,2,3,4" spacing="6,5" outline="2"/>
+  <common lineHeight="16" base="12" scaleW="256" scaleH="256" pages="1" packed="0" alphaChnl="1" redChnl="0" greenChnl="0" blueChnl="0"/>
+  <pages>
+    <page id="0" file="test-font_0.png" />
+  </pages>
+  <chars count="2">
+    <char id="70" x="34" y="0" width="27" height="20" xoffset="-5" yoffset="-3" xadvance="17" page="0" chnl="15" />
+    <char id="74" x="0" y="0" width="28" height="20" xoffset="-6" yoffset="-3" xadvance="18" page="0" chnl="15" />
+  </chars>
+  <kernings count="1">
+    <kerning first="70" second="74" amount="-1" />
+  </kernings>
+</font>


### PR DESCRIPTION
## Description

As shown in #1073, it's possible for a scenario to occur where someone edits a Bitmap Font (BMFont) file using a third party library that then saves it back with the UTF-8 Byte Order Mark (BOM) preamble.  When this happens, the signature check of the file fails causing an exception to to be thrown.

To resolve this, a check for the preamble is made, and if found, skips it.

## Related Issues/Tickets

* Closes #1073

## Changes Made

* Added unit test to ensure BOM check is performed.
* Checks for UTF-8 Byte Order Mark (BOM) Preamble at the start of stream when reading a BMFont file.   


## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
