### PR TITLE
Allow negative character id

### DIFF
--- a/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileContent.cs
+++ b/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileContent.cs
@@ -57,7 +57,7 @@ public sealed class BitmapFontFileContent
     {
         public const int StructSize = 20;
 
-        [FieldOffset(0)] public uint ID;
+        [FieldOffset(0)] public int ID;
         [FieldOffset(4)] public ushort X;
         [FieldOffset(6)] public ushort Y;
         [FieldOffset(8)] public ushort Width;

--- a/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileReader.cs
+++ b/source/MonoGame.Extended/Content/BitmapFonts/BitmapFontFileReader.cs
@@ -279,7 +279,7 @@ public static class BitmapFontFileReader
         {
             var character = new BitmapFontFileContent.CharacterBlock
             {
-                ID = node.GetUInt32Attribute("id"),
+                ID = node.GetInt32Attribute("id"),
                 X = node.GetUInt16Attribute("x"),
                 Y = node.GetUInt16Attribute("y"),
                 Width = node.GetUInt16Attribute("width"),
@@ -509,7 +509,7 @@ public static class BitmapFontFileReader
             switch (split[0])
             {
                 case "id":
-                    character.ID = Convert.ToUInt32(split[1], CultureInfo.InvariantCulture);
+                    character.ID = Convert.ToInt32(split[1], CultureInfo.InvariantCulture);
                     break;
                 case "x":
                     character.X = Convert.ToUInt16(split[1], CultureInfo.InvariantCulture);


### PR DESCRIPTION
Negative character id's have a legitimate use case in font systems to represent an invalid character or missing glyph fallback.

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
