### PR TITLE
Revert back to using indexer to add kerning pairs

### DIFF
--- a/source/MonoGame.Extended.Content.Pipeline/BitmapFonts/BitmapFontProcessor.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/BitmapFonts/BitmapFontProcessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using MonoGame.Extended.Content.BitmapFonts;
@@ -13,6 +14,9 @@ namespace MonoGame.Extended.Content.Pipeline.BitmapFonts
             try
             {
                 BitmapFontFileContent bmfFile = importerResult.Data;
+
+                ValidateKernings(bmfFile, context);
+
                 var result = new BitmapFontProcessorResult(bmfFile);
 
                 foreach (var page in bmfFile.Pages)
@@ -29,5 +33,71 @@ namespace MonoGame.Extended.Content.Pipeline.BitmapFonts
                 throw;
             }
         }
+
+        private readonly record struct KerningPair(uint First, uint Second);
+        private readonly record struct KerningEntry(short Amount, int Index);
+        private readonly record struct DuplicateKerning(uint First, uint Second, short FirstAmount, short DuplicateAmount, int FirstIndex, int DuplicateIndex);
+
+        private void ValidateKernings(BitmapFontFileContent bmfFile, ContentProcessorContext context)
+        {
+            if(bmfFile.Kernings.Count == 0)
+            {
+                return;
+            }
+
+            Dictionary<KerningPair, KerningEntry> seenPairs = [];
+            List<DuplicateKerning> duplicates = [];
+
+            for(int i = 0; i < bmfFile.Kernings.Count; i++)
+            {
+                BitmapFontFileContent.KerningPairsBlock kerning = bmfFile.Kernings[i];
+                KerningPair pair = new KerningPair(kerning.First, kerning.Second);
+
+                if(seenPairs.TryGetValue(pair, out KerningEntry existing))
+                {
+                    duplicates.Add(new DuplicateKerning(pair.First, pair.Second, existing.Amount, kerning.Amount, existing.Index, i));
+                }
+                else
+                {
+                    seenPairs[pair] = new KerningEntry(kerning.Amount, i);
+                }
+            }
+
+            if(duplicates.Count > 0)
+            {
+                context.Logger.LogWarning(
+                    string.Empty,
+                    new ContentIdentity(bmfFile.Path),
+                    $"""
+                    BMFont file contains {duplicates.Count} duplicate kerning pair(s).
+                    This may cause runtime errors.  Each character pair should only have one kerning entry.
+                    Please regenerate or fix the font file
+                    """
+                );
+
+                foreach(var duplicate in duplicates)
+                {
+                    char firstChar = duplicate.First >= 32  && duplicate.First < 127
+                                     ? (char)duplicate.First
+                                     : '?';
+
+                    char secondChar = duplicate.Second >= 32 && duplicate.Second < 127
+                                      ? (char)duplicate.Second
+                                      : '?';
+
+                    context.Logger.LogWarning(
+                        string.Empty,
+                        new ContentIdentity(bmfFile.Path),
+                        $"""
+                          Duplicate kerning:  Character {duplicate.First} ('{firstChar}') -> {duplicate.Second} ('{secondChar}')
+                          First entry (index {duplicate.FirstIndex}): amount={duplicate.FirstAmount}
+                          Duplicate etnry (index {duplicate.DuplicateIndex}): amount={duplicate.DuplicateIndex}")
+
+                        """
+                    );
+                }
+            }
+        }
     }
+
 }

--- a/source/MonoGame.Extended/Content/ContentReaders/BitmapFontContentReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/BitmapFontContentReader.cs
@@ -59,7 +59,7 @@ public class BitmapFontContentReader : ContentTypeReader<BitmapFont>
 
             if (characters.TryGetValue((int)first, out var character))
             {
-                character.Kernings.Add((int)second, amount);
+                character.Kernings[(int)second] = amount;
             }
         }
 


### PR DESCRIPTION
Sometimes BMFont generation can create duplicate kerning pairs.  When this happens, the file is technically malformed, however previous behavior was to use the indexer of the dictionary to add the pairs, which just overwrite them.

Reverted back to using indexer and update the processor to detect duplicates and warn users now during build

## Related Issues/Tickets

* Closes #1076

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
