### PR TITLE
Setup project so that preview releases can be made

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,29 +1,44 @@
 ################################################################################
 ### Build MonoGame.Extended (Release)
-### Clones a specified release tag or the `develop` branch and performs a build,
-### test, then pack of the Monogame.Extended source code. Once the build job is
-### finished, the deploy job will upload the nupkg files created to the specified
-### package source (GitHub or NuGet).
+### Performs a build, test, then pack of the Monogame.Extended source code
+### from a specified branch or release tag. Once the build job is finished,
+### the deploy job will upload the nupkg files to NuGet.
 ###
 ###     - Can be triggered manually with workflow_dispatch
-###     - Allows specifying a release tag or defaults to develop branch
-###     - Allows choosing between GitHub Packages or NuGet as deployment target
+###     - Allows specifying a branch (defaults to develop)
+###     - Allows specifying a release tag (overrides branch if provided)
+###     - Supports both stable and preview builds
 ################################################################################
 name: "Create Release"
 
 on:
   workflow_dispatch:
     inputs:
-      source-feed:
-        description: 'Which source feed to publish to?'
+      branch:
+        description: 'Branch to build from (e.g., develop, v5.3.2-preview-1). Ignored if release-tag is provided.'
+        required: false
+        type: string
+        default: 'develop'
+      release-tag:
+        description: 'Release tag to build from (e.g., v5.3.1). Overrides branch if provided.'
+        required: false
+        type: string
+        default: ''
+      build-type:
+        description: 'Build type (Stable or Preview)'
         required: true
         type: choice
         options:
-          - GitHub
-          - NuGet
-        default: 'GitHub'
-      release-tag:
-        description: 'Release tag to build from (e.g., v1.0.0). Leave empty to use develop branch.'
+          - Stable
+          - Preview
+        default: 'Stable'
+      preview-label:
+        description: 'Preview label (e.g., preview.1, alpha.1). Only used for Preview builds.'
+        required: false
+        type: string
+        default: 'preview.1'
+      monogame-version:
+        description: 'MonoGame version to target. Leave empty to use defaults (3.8.4 for Stable, 3.8.5.2001-preview for Preview).'
         required: false
         type: string
         default: ''
@@ -37,7 +52,7 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release-tag || 'develop' }}
+          ref: ${{ inputs.release-tag != '' && inputs.release-tag || inputs.branch }}
 
       - name: Setup Dotnet
         uses: actions/setup-dotnet@v4
@@ -49,18 +64,77 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xvfb
 
-      - name: Build MonoGame.Extended
-        run: dotnet build MonoGame.Extended.sln --nologo --verbosity minimal --configuration Release
-
-      - name: Test MonoGame.Extended
+      - name: Build MonoGame.Extended (Stable)
+        if: ${{ inputs.build-type == 'Stable' }}
         run: |
-          xvfb-run -a -s "-screen 0 1024x768x24" dotnet test MonoGame.Extended.sln --nologo --verbosity minimal --configuration Release
+          BUILD_ARGS="--nologo --verbosity minimal --configuration Release"
+          if [ -n "${{ inputs.monogame-version }}" ]; then
+            BUILD_ARGS="$BUILD_ARGS -p:MonoGameVersion=${{ inputs.monogame-version }}"
+          fi
+          dotnet build MonoGame.Extended.sln $BUILD_ARGS
 
-      - name: Pack MonoGame.Extended
-        run: dotnet pack MonoGame.Extended.sln --nologo --verbosity minimal --configuration Release
+      - name: Build MonoGame.Extended (Preview)
+        if: ${{ inputs.build-type == 'Preview' }}
+        run: |
+          BUILD_ARGS="--nologo --verbosity minimal --configuration Release -p:IsPreviewBuild=true -p:PreviewLabel=${{ inputs.preview-label }}"
+          if [ -n "${{ inputs.monogame-version }}" ]; then
+            BUILD_ARGS="$BUILD_ARGS /p:MonoGameVersion=${{ inputs.monogame-version }}"
+          fi
+          dotnet build MonoGame.Extended.sln $BUILD_ARGS
 
-      - name: Pack Kni.Extended
-        run: dotnet pack KNI.Extended.sln --nologo --verbosity minimal --configuration Release
+      - name: Test MonoGame.Extended (Stable)
+        if: ${{ inputs.build-type == 'Stable' }}
+        run: |
+          TEST_ARGS="--nologo --verbosity minimal --configuration Release"
+          if [ -n "${{ inputs.monogame-version }}" ]; then
+            TEST_ARGS="$TEST_ARGS -p:MonoGameVersion=${{ inputs.monogame-version }}"
+          fi
+          xvfb-run -a -s "-screen 0 1024x768x24" dotnet test MonoGame.Extended.sln $TEST_ARGS
+
+      - name: Test MonoGame.Extended (Preview)
+        if: ${{ inputs.build-type == 'Preview' }}
+        run: |
+          TEST_ARGS="--nologo --verbosity minimal --configuration Release -p:IsPreviewBuild=true -p:PreviewLabel=${{ inputs.preview-label }}"
+          if [ -n "${{ inputs.monogame-version }}" ]; then
+            TEST_ARGS="$TEST_ARGS /p:MonoGameVersion=${{ inputs.monogame-version }}"
+          fi
+          xvfb-run -a -s "-screen 0 1024x768x24" dotnet test MonoGame.Extended.sln $TEST_ARGS
+
+      - name: Pack MonoGame.Extended (Stable)
+        if: ${{ inputs.build-type == 'Stable' }}
+        run: |
+          PACK_ARGS="--nologo --verbosity minimal --configuration Release"
+          if [ -n "${{ inputs.monogame-version }}" ]; then
+            PACK_ARGS="$PACK_ARGS -p:MonoGameVersion=${{ inputs.monogame-version }}"
+          fi
+          dotnet pack MonoGame.Extended.sln $PACK_ARGS
+
+      - name: Pack MonoGame.Extended (Preview)
+        if: ${{ inputs.build-type == 'Preview' }}
+        run: |
+          PACK_ARGS="--nologo --verbosity minimal --configuration Release -p:IsPreviewBuild=true -p:PreviewLabel=${{ inputs.preview-label }}"
+          if [ -n "${{ inputs.monogame-version }}" ]; then
+            PACK_ARGS="$PACK_ARGS /p:MonoGameVersion=${{ inputs.monogame-version }}"
+          fi
+          dotnet pack MonoGame.Extended.sln $PACK_ARGS
+
+      - name: Pack Kni.Extended (Stable)
+        if: ${{ inputs.build-type == 'Stable' }}
+        run: |
+          PACK_ARGS="--nologo --verbosity minimal --configuration Release"
+          if [ -n "${{ inputs.monogame-version }}" ]; then
+            PACK_ARGS="$PACK_ARGS -p:MonoGameVersion=${{ inputs.monogame-version }}"
+          fi
+          dotnet pack KNI.Extended.sln $PACK_ARGS
+
+      - name: Pack Kni.Extended (Preview)
+        if: ${{ inputs.build-type == 'Preview' }}
+        run: |
+          PACK_ARGS="--nologo --verbosity minimal --configuration Release -p:IsPreviewBuild=true -p:PreviewLabel=${{ inputs.preview-label }}"
+          if [ -n "${{ inputs.monogame-version }}" ]; then
+            PACK_ARGS="$PACK_ARGS /p:MonoGameVersion=${{ inputs.monogame-version }}"
+          fi
+          dotnet pack KNI.Extended.sln $PACK_ARGS
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -73,7 +147,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build ]
     permissions:
-      packages: write
       contents: write
 
     steps:
@@ -83,12 +156,11 @@ jobs:
           name: build-artifacts
           path: ./.artifacts
 
-      - name: "Push Packages"
+      - name: "Push Packages to NuGet"
         env:
-          SOURCE_URL: ${{ inputs.source-feed == 'GitHub' && 'https://nuget.pkg.github.com/craftworkgames/index.json' || inputs.source-feed == 'NuGet' && 'https://api.nuget.org/v3/index.json' }}
-          API_KEY: ${{ inputs.source-feed == 'GitHub' && secrets.GITHUB_TOKEN || inputs.source-feed == 'NuGet' && secrets.NUGET_ACCESS_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.NUGET_ACCESS_TOKEN }}
         run: |
           PACKAGES=(".artifacts/*.nupkg")
           for PACKAGE in "${PACKAGES[@]}"; do
-            dotnet nuget push "$PACKAGE" --source "$SOURCE_URL" --skip-duplicate --api-key "$API_KEY"
+            dotnet nuget push "$PACKAGE" --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key "$NUGET_API_KEY"
           done

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -1,7 +1,8 @@
 ################################################################################
 ### Pull Request Test
 ### Executes tests to ensure that the pull request being submitted is valid.
-###     - Only runs on pull requests made to the `develop` branch
+###     - Runs on pull requests to develop, main, and preview branches
+###     - Automatically detects preview branches and tests with appropriate MonoGame version
 ###     - Only runs if the pull request was opened or synchronized
 ################################################################################
 name: Pull Request Test
@@ -11,6 +12,7 @@ on:
     branches:
       - develop
       - main
+      - 'v*-preview.*'
     types:
       - opened
       - synchronize
@@ -33,6 +35,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xvfb
 
-      - name: Test MonoGame.Extended
+      - name: Detect Build Type
+        id: detect
+        run: |
+          TARGET_BRANCH="${{ github.base_ref }}"
+          echo "Target branch: $TARGET_BRANCH"
+
+          # Check if target branch is a preview branch using simple wildcard matching
+          if [[ "$TARGET_BRANCH" == v*-preview.* ]]; then
+            echo "is_preview=true" >> $GITHUB_OUTPUT
+            echo "Detected preview branch - will use preview MonoGame version"
+          else
+            echo "is_preview=false" >> $GITHUB_OUTPUT
+            echo "Detected stable branch - will use stable MonoGame version"
+          fi
+
+      - name: Test MonoGame.Extended (Stable)
+        if: steps.detect.outputs.is_preview == 'false'
         run: |
           xvfb-run -a -s "-screen 0 1024x768x24" dotnet test MonoGame.Extended.sln --nologo --verbosity minimal --configuration Release
+
+      - name: Test MonoGame.Extended (Preview)
+        if: steps.detect.outputs.is_preview == 'true'
+        run: |
+          xvfb-run -a -s "-screen 0 1024x768x24" dotnet test MonoGame.Extended.sln --nologo --verbosity minimal --configuration Release -p:IsPreviewBuild=true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,14 +6,33 @@
         <SolutionDirectory>$(MSBuildThisFileDirectory)</SolutionDirectory>
     </PropertyGroup>
 
+    <!-- Version Configuration -->
     <PropertyGroup>
-       <Version>5.3.1</Version>
-   </PropertyGroup>
+        <!-- Base version for stable releases -->
+        <VersionPrefix>5.3.1</VersionPrefix>
+
+        <!--
+            IsPreviewBuild: Set to 'true' for preview builds targeting MonoGame 3.8.5
+            Can be overridden via command line: dotnet build /p:IsPreviewBuild=true
+        -->
+        <IsPreviewBuild Condition="'$(IsPreviewBuild)' == ''">false</IsPreviewBuild>
+
+        <!--
+            PreviewLabel: The preview label to append (e.g., "preview.1", "alpha.1")
+            Only used when IsPreviewBuild=true
+        -->
+        <PreviewLabel Condition="'$(PreviewLabel)' == ''">preview.1</PreviewLabel>
+
+        <!-- Build the final version string -->
+        <VersionSuffix Condition="'$(IsPreviewBuild)' == 'true'">$(PreviewLabel)</VersionSuffix>
+        <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
+        <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
+    </PropertyGroup>
 
     <PropertyGroup>
-        <Authors>craftworkgames and contributors</Authors>
-        <PackageProjectUrl>https://github.com/craftworkgames/MonoGame.Extended</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/craftworkgames/MonoGame.Extended</RepositoryUrl>
+        <Authors>MonoGame Extended and contributors</Authors>
+        <PackageProjectUrl>https://github.com/MonoGame-Extended/MonoGame-Extended</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/MonGame-Extended/MonoGame-Extended</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryBranch>develop</RepositoryBranch>
         <NeutralLanguage>en</NeutralLanguage>
@@ -28,17 +47,5 @@
         <None Include="../../README.md" Pack="true" PackagePath="" />
         <None Include="../../CHANGELOG.md" Pack="false" />
     </ItemGroup>
-
-    <!-- Setup Code Analysis using the .editorconfig file -->
-    <!-- <PropertyGroup>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-        <AnalysisLevel>latest</AnalysisLevel>
-        <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-        <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
-        <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
-        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-        <WarningsAsErrors>nullable</WarningsAsErrors>
-    </PropertyGroup> -->
 
 </Project>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -11,17 +11,38 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
-   <ItemGroup Condition="!$(DefineConstants.Contains('FNA')) AND !$(DefineConstants.Contains('KNI'))">
-       <PackageReference Include="MonoGame.Framework.DesktopGL"
-                          Version="3.8.4"
+    <!--
+        MonoGame Version Selection
+        - Stable build (IsPreviewBuild=false): use MonoGame 3.8.4
+        - Preview Build (IsPreviewBuild=true): Use MonoGame 3.8.5-preview.#
+
+        MonogameVersion can be overridden via command line:
+        dotnet build /p:MonoGameVersion=3.8.5-preview.3
+    -->
+    <PropertyGroup>
+        <MonogameStableVersion>3.8.4.1</MonogameStableVersion>
+        <MonoGamePreviewVersion Condition="'$(MonoGamePreviewVersion)' == ''">3.8.5-preview.3</MonoGamePreviewVersion>
+
+        <!-- Select version based on build type -->
+        <MonoGameVersion Condition="'$(MonoGameVersion)' == '' AND '$(IsPreviewBuild)' == 'true'">$(MonoGamePreviewVersion)</MonoGameVersion>
+        <MonoGameVersion Condition="'$(MonoGameVersion)' == '' AND '$(IsPreviewBuild)' != 'true'">$(MonoGameStableVersion)</MonoGameVersion>
+    </PropertyGroup>
+
+    <!-- MonoGame Framework References (Standard) -->
+    <ItemGroup
+        Condition="!$(DefineConstants.Contains('FNA')) AND !$(DefineConstants.Contains('KNI'))">
+        <PackageReference Include="MonoGame.Framework.DesktopGL"
+                          Version="$(MonoGameVersion)"
                           PrivateAssets="All" />
     </ItemGroup>
 
-   <ItemGroup Condition="$(DefineConstants.Contains('FNA'))">
+    <!-- FNA Framework References -->
+    <ItemGroup Condition="$(DefineConstants.Contains('FNA'))">
         <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\FNA\FNA.NetStandard.csproj" />
-   </ItemGroup>
+    </ItemGroup>
 
-  <ItemGroup Condition="$(DefineConstants.Contains('KNI'))">
+    <!-- KNI Framework References -->
+    <ItemGroup Condition="$(DefineConstants.Contains('KNI'))">
         <PackageReference Include="nkast.Xna.Framework"
                           Version="4.0.9001" />
         <PackageReference Include="nkast.Xna.Framework.Content"
@@ -34,6 +55,6 @@
                           Version="4.0.9001" />
         <PackageReference Include="nkast.Xna.Framework.Game"
                           Version="4.0.9001" />
-   </ItemGroup>
+    </ItemGroup>
 
 </Project>

--- a/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
+++ b/source/MonoGame.Extended.Content.Pipeline/MonoGame.Extended.Content.Pipeline.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Autofac" Version="5.2.0" />
 
     <PackageReference Include="MonoGame.Framework.Content.Pipeline"
-                      Version="3.8.4"
+                      Version="$(MonoGameVersion)"
                       PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Updates projects so that we can do preview releases along side MonoGame preview releases

## Related Issues/Tickets

- #1089 

## Changes Made

- Updated the Directory.Build.props file to calculate the version to use
- Added new flags for `IsPreviewBuild`, `PreivewLabel`, and `MonoGameVersion` to MSBuild properties
- Updated the create_release workflow to support preview builds

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
