### PR TITLE
Add Update(TimeSpan) overload to animation APIs

### DIFF
--- a/source/MonoGame.Extended/Animations/AnimationController.cs
+++ b/source/MonoGame.Extended/Animations/AnimationController.cs
@@ -189,7 +189,12 @@ public class AnimationController : IAnimationController
     /// <inheritdoc />
     public void Update(GameTime gameTime)
     {
-        TimeSpan elapsedTime = gameTime.ElapsedGameTime;
+        Update(gameTime.ElapsedGameTime);
+    }
+
+    /// <inheritdoc />
+    public void Update(TimeSpan elapsedTime)
+    {
         TimeSpan remainingTime = TimeSpan.Zero;
 
         if (!IsAnimating || IsPaused)

--- a/source/MonoGame.Extended/Animations/IAnimationController.cs
+++ b/source/MonoGame.Extended/Animations/IAnimationController.cs
@@ -141,6 +141,12 @@ public interface IAnimationController : IDisposable
     void Update(GameTime gameTime);
 
     /// <summary>
+    /// Updates the animation.
+    /// </summary>
+    /// <param name="elapsedTime">The elapsed time since the last update.</param>
+    void Update(TimeSpan elapsedTime);
+
+    /// <summary>
     /// Stops the animation.
     /// </summary>
     /// <returns>

--- a/source/MonoGame.Extended/Graphics/AnimatedSprite.cs
+++ b/source/MonoGame.Extended/Graphics/AnimatedSprite.cs
@@ -74,8 +74,14 @@ public class AnimatedSprite : Sprite
     /// <inheritdoc />
     public void Update(GameTime gameTime)
     {
+        Update(gameTime.ElapsedGameTime);
+    }
+
+    /// <inheritdoc />
+    public void Update(TimeSpan elapsedTime)
+    {
         int index = Controller.CurrentFrame;
-        Controller.Update(gameTime);
+        Controller.Update(elapsedTime);
 
         //  If the current frame changed during the update, change the texture region
         if (index != Controller.CurrentFrame)

--- a/tests/MonoGame.Extended.Tests/Animations/AnimationTests.cs
+++ b/tests/MonoGame.Extended.Tests/Animations/AnimationTests.cs
@@ -208,4 +208,45 @@ public class AnimationTests
 
         Assert.True(_animationController.IsDisposed);
     }
+
+    [Fact]
+    public void Update_WithTimeSpan_ShouldAdvanceFrame()
+    {
+        _animationController.Play();
+        _animationController.Update(TimeSpan.FromSeconds(1.1));
+
+        Assert.Equal(1, _animationController.CurrentFrame);
+    }
+
+    [Fact]
+    public void Update_WithGameTime_ShouldProduceSameResultAsTimeSpan()
+    {
+        var frames = new IAnimationFrame[]
+        {
+            new TestAnimationFrame { FrameIndex = 0, Duration = TimeSpan.FromSeconds(1) },
+            new TestAnimationFrame { FrameIndex = 1, Duration = TimeSpan.FromSeconds(1) }
+        };
+        var animation = new TestAnimation(frames)
+        {
+            FrameCount = frames.Length,
+            IsLooping = false,
+            IsReversed = false,
+            IsPingPong = false
+        };
+
+        var controller1 = new AnimationController(animation);
+        var controller2 = new AnimationController(animation);
+
+        controller1.Play();
+        controller2.Play();
+
+        var elapsed = TimeSpan.FromSeconds(0.5);
+        var gameTime = new GameTime(TimeSpan.Zero, elapsed);
+
+        controller1.Update(gameTime);
+        controller2.Update(elapsed);
+
+        Assert.Equal(controller1.CurrentFrame, controller2.CurrentFrame);
+        Assert.Equal(controller1.CurrentFrameTimeRemaining, controller2.CurrentFrameTimeRemaining);
+    }
 }


### PR DESCRIPTION
Removed the tight coupling of GameTime to the Sprite animation Update method while retaining the existing code paths.

Introduce Update(TimeSpan) to IAnimationController and implement it in AnimationController and AnimatedSprite. Refactor existing Update(GameTime) methods to delegate to the new overload so animations can be advanced directly with a TimeSpan (useful for testing and non-GameTime scenarios). Add unit tests to verify frame advancement with TimeSpan and that GameTime-based updates produce the same results as TimeSpan-based updates.

## Description

I ran into an issue where I want to do "hit stop" animation but realized that the existing Monogame Extended had a tight coupling on the GameTime. I am using a custom clock that can slow down or stop independent of GameTime but there was no existing easy way to pass that modified time into the MGEX animation system. 
My change is hopefully easy to comprehend and preserves the existing behavior while allowing custom time manipulation for sprite animation updates.

## Related Issues/Tickets

None that I know of.

## Changes Made

Exposed new overloaded Update() method on Sprite animations that remove the tight coupling to GameTime.


## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
