### PR TITLE
Fix Texture2DAtlas.Name returning relative texture path instead of content asset name

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version Configuration -->
     <PropertyGroup>
         <!-- Base version for stable releases -->
-        <VersionPrefix>5.3.1</VersionPrefix>
+        <VersionPrefix>5.3.2</VersionPrefix>
 
         <!--
             IsPreviewBuild: Set to 'true' for preview builds targeting MonoGame 3.8.5

--- a/source/MonoGame.Extended/Content/ContentReaders/Texture2DAtlasReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/Texture2DAtlasReader.cs
@@ -15,7 +15,7 @@ namespace MonoGame.Extended.Content.ContentReaders
         {
             var imageAssetName = reader.ReadString();
             var texture = reader.ContentManager.Load<Texture2D>(reader.GetRelativeAssetName(imageAssetName));
-            var atlas = new Texture2DAtlas(imageAssetName, texture);
+            var atlas = new Texture2DAtlas(reader.AssetName, texture);
 
             var regionCount = reader.ReadInt32();
 


### PR DESCRIPTION
## Description

* `Texture2DAtlas.Name` was returning the relative texture path embedded in the TexturePacker JSON (e.g. `../textures/sprites_0`) instead of the content asset name used to load the atlas (e.g. `data/sprites_0`). The reader was reusing the `imageAssetName` string, which exists solely to resolve and load the backing texture as the atlas name. This PR fixes the reader to use `reader.AssetName` instead.

## Related Issues/Tickets

* Closes #1103

## Changes Made

* In `Texture2DAtlasReader.Read`, changed the `Texture2DAtlas` constructor call to pass `reader.AssetName` as the atlas name rather than `imageAssetName`. The `imageAssetName` value is still used unchanged on the preceding line to load the texture via `GetRelativeAssetName`.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
