### PR TITLE
Fix/issue 1094 collisions in layers not working

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version Configuration -->
     <PropertyGroup>
         <!-- Base version for stable releases -->
-        <VersionPrefix>5.3.2</VersionPrefix>
+        <VersionPrefix>5.3.3</VersionPrefix>
 
         <!--
             IsPreviewBuild: Set to 'true' for preview builds targeting MonoGame 3.8.5

--- a/source/MonoGame.Extended/Collisions/CollisionComponent.cs
+++ b/source/MonoGame.Extended/Collisions/CollisionComponent.cs
@@ -144,7 +144,10 @@ namespace MonoGame.Extended.Collisions
                 throw new DuplicateNameException(name);
 
             if (name != DEFAULT_LAYER_NAME)
+            {
+                AddCollisionBetweenLayer(layer, layer);
                 AddCollisionBetweenLayer(_layers[DEFAULT_LAYER_NAME], layer);
+            }
         }
 
         /// <summary>

--- a/tests/MonoGame.Extended.Tests/Collisions/CollisionComponentTests.cs
+++ b/tests/MonoGame.Extended.Tests/Collisions/CollisionComponentTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Xna.Framework;
+using MonoGame.Extended.Collisions.QuadTree;
 using Xunit;
 
 namespace MonoGame.Extended.Collisions.Tests
@@ -388,14 +389,57 @@ namespace MonoGame.Extended.Collisions.Tests
                 Assert.Throws<UndefinedLayerException>(act);
             }
 
+            [Fact]
+            public void Actors_In_Same_Named_Layer_Collide()
+            {
+                var namedLayer = new Layer(new QuadTreeSpace(new RectangleF(Vector2.Zero, new Vector2(10, 10))));
+                _collisionComponent.Add("testLayer", namedLayer);
+
+                var bounds1 = new RectangleF(new Vector2(0, 0), new SizeF(1, 1));
+                var bounds2 = new RectangleF(new Vector2(0, 0), new SizeF(1, 1));
+                var actor1 = new CollisionIndicatingActor(bounds1, "testLayer");
+                var actor2 = new CollisionIndicatingActor(bounds2, "testLayer");
+                _collisionComponent.Insert(actor1);
+                _collisionComponent.Insert(actor2);
+
+                _collisionComponent.Update(_gameTime);
+
+                Assert.True(actor1.IsColliding);
+                Assert.True(actor2.IsColliding);
+            }
+
+            [Fact]
+            public void Actors_In_Named_Layer_Do_Not_Collide_With_Actors_In_Different_Named_Layer_By_Default()
+            {
+                var layerA = new Layer(new QuadTreeSpace(new RectangleF(Vector2.Zero, new Vector2(10, 10))));
+                var layerB = new Layer(new QuadTreeSpace(new RectangleF(Vector2.Zero, new Vector2(10, 10))));
+                _collisionComponent.Add("layerA", layerA);
+                _collisionComponent.Add("layerB", layerB);
+
+                var bounds1 = new RectangleF(new Vector2(0, 0), new SizeF(1, 1));
+                var bounds2 = new RectangleF(new Vector2(0, 0), new SizeF(1, 1));
+                var actor1 = new CollisionIndicatingActor(bounds1, "layerA");
+                var actor2 = new CollisionIndicatingActor(bounds2, "layerB");
+                _collisionComponent.Insert(actor1);
+                _collisionComponent.Insert(actor2);
+
+                _collisionComponent.Update(_gameTime);
+
+                Assert.False(actor1.IsColliding);
+                Assert.False(actor2.IsColliding);
+            }
+
             private class CollisionIndicatingActor : ICollisionActor
             {
                 private RectangleF _bounds;
 
-                public CollisionIndicatingActor(RectangleF bounds)
+                public CollisionIndicatingActor(RectangleF bounds, string layerName = null)
                 {
                     _bounds = bounds;
+                    LayerName = layerName;
                 }
+
+                public string LayerName { get; }
 
                 public IShapeF Bounds => _bounds;
 


### PR DESCRIPTION
## Description

When actors are inserted into a named (non-default) collision layer, they were never checked for collisions against other actors in the same layer. Only the `(default, namedLayer)` collision pair was registered when a layer was added via `Add()`, meaning actors in a named layer had no self-collision pair and silently never collided with each other. Actors in the default layer were unaffected because `SetDefaultLayer` correctly registers a `(default, default)` self-collision pair.

## Related Issues/Tickets

* Closes #1094

## Changes Made

* In `CollisionComponent.Add()`, register a `(layer, layer)` self-collision pair for non-default named layers, matching the behaviour already present for the default layer.
* Extended `CollisionIndicatingActor` in the test suite to accept an optional `layerName` parameter.
* Added two new tests to `CollisionComponentTests.Behaviours`:
  * `Actors_In_Same_Named_Layer_Collide`:  verifies actors in the same named layer receive collision events.
  * `Actors_In_Named_Layer_Do_Not_Collide_With_Actors_In_Different_Named_Layer_By_Default`:  verifies actors in separate named layers do not collide unless an explicit cross-layer pair is registered.
* Bumped patch version `5.3.2` → `5.3.3`.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
