### PR TITLE
Add AOT/trimming support for Extended content type readers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version Configuration -->
     <PropertyGroup>
         <!-- Base version for stable releases -->
-        <VersionPrefix>5.3.3</VersionPrefix>
+        <VersionPrefix>5.4.0</VersionPrefix>
 
         <!--
             IsPreviewBuild: Set to 'true' for preview builds targeting MonoGame 3.8.5

--- a/source/MonoGame.Extended/Content/ContentReaders/BitmapFontContentReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/BitmapFontContentReader.cs
@@ -12,6 +12,19 @@ namespace MonoGame.Extended.Content.ContentReaders;
 
 public class BitmapFontContentReader : ContentTypeReader<BitmapFont>
 {
+    /// <summary>
+    /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
+    /// so it is resolved without reflection.
+    /// </summary>
+    /// <remarks>
+    /// Call this method once during application startup when publishing with
+    /// <c>PublishAot</c> or <c>PublishTrimmed</c>.
+    /// </remarks>
+    public static void Register() =>
+        ContentTypeReaderManager.AddTypeCreator(
+            typeof(BitmapFontContentReader).AssemblyQualifiedName,
+            () => new BitmapFontContentReader());
+
     protected override BitmapFont Read(ContentReader reader, BitmapFont existingInstance)
     {
         var textureCount = reader.ReadInt32();

--- a/source/MonoGame.Extended/Content/ContentReaders/JsonContentTypeReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/JsonContentTypeReader.cs
@@ -7,6 +7,22 @@ namespace MonoGame.Extended.Content.ContentReaders
 {
     public class JsonContentTypeReader<T> : ContentTypeReader<T>
     {
+        /// <summary>
+        /// Registers <see cref="JsonContentTypeReader{T}"/> for the type <typeparamref name="T"/> with the
+        /// <see cref="ContentTypeReaderManager"/> so it is resolved without reflection.
+        /// </summary>
+        /// <remarks>
+        /// Call this method once per concrete type during application startup when publishing with
+        /// <c>PublishAot</c> or <c>PublishTrimmed</c>. For example:
+        /// <code>
+        /// JsonContentTypeReader&lt;MyData&gt;.Register();
+        /// </code>
+        /// </remarks>
+        public static void Register() =>
+            ContentTypeReaderManager.AddTypeCreator(
+                typeof(JsonContentTypeReader<T>).AssemblyQualifiedName,
+                () => new JsonContentTypeReader<T>());
+
         protected override T Read(ContentReader reader, T existingInstance)
         {
             var json = reader.ReadString();

--- a/source/MonoGame.Extended/Content/ContentReaders/ParticleEffectContentReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/ParticleEffectContentReader.cs
@@ -7,6 +7,19 @@ namespace MonoGame.Extended.Content.ContentReaders;
 
 public sealed class ParticleEffectContentReader : ContentTypeReader<ParticleEffect>
 {
+    /// <summary>
+    /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
+    /// so it is resolved without reflection.
+    /// </summary>
+    /// <remarks>
+    /// Call this method once during application startup when publishing with
+    /// <c>PublishAot</c> or <c>PublishTrimmed</c>.
+    /// </remarks>
+    public static void Register() =>
+        ContentTypeReaderManager.AddTypeCreator(
+            typeof(ParticleEffectContentReader).AssemblyQualifiedName,
+            () => new ParticleEffectContentReader());
+
     protected override ParticleEffect Read(ContentReader input, ParticleEffect existingInstance)
     {
         string xmlContent = input.ReadString();

--- a/source/MonoGame.Extended/Content/ContentReaders/Texture2DAtlasReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/Texture2DAtlasReader.cs
@@ -11,6 +11,19 @@ namespace MonoGame.Extended.Content.ContentReaders
 {
     public class Texture2DAtlasReader : ContentTypeReader<Texture2DAtlas>
     {
+        /// <summary>
+        /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
+        /// so it is resolved without reflection.
+        /// </summary>
+        /// <remarks>
+        /// Call this method once during application startup when publishing with
+        /// <c>PublishAot</c> or <c>PublishTrimmed</c>.
+        /// </remarks>
+        public static void Register() =>
+            ContentTypeReaderManager.AddTypeCreator(
+                typeof(Texture2DAtlasReader).AssemblyQualifiedName,
+                () => new Texture2DAtlasReader());
+
         protected override Texture2DAtlas Read(ContentReader reader, Texture2DAtlas existingInstance)
         {
             var imageAssetName = reader.ReadString();

--- a/source/MonoGame.Extended/Tiled/TiledMapReader.cs
+++ b/source/MonoGame.Extended/Tiled/TiledMapReader.cs
@@ -10,6 +10,19 @@ namespace MonoGame.Extended.Tiled
 {
     public class TiledMapReader : ContentTypeReader<TiledMap>
     {
+        /// <summary>
+        /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
+        /// so it is resolved without reflection.
+        /// </summary>
+        /// <remarks>
+        /// Call this method once during application startup when publishing with
+        /// <c>PublishAot</c> or <c>PublishTrimmed</c>.
+        /// </remarks>
+        public static void Register() =>
+            ContentTypeReaderManager.AddTypeCreator(
+                typeof(TiledMapReader).AssemblyQualifiedName,
+                () => new TiledMapReader());
+
         protected override TiledMap Read(ContentReader reader, TiledMap existingInstance)
         {
             if (existingInstance != null)

--- a/source/MonoGame.Extended/Tiled/TiledMapTilesetReader.cs
+++ b/source/MonoGame.Extended/Tiled/TiledMapTilesetReader.cs
@@ -8,6 +8,20 @@ namespace MonoGame.Extended.Tiled
 {
 	public class TiledMapTilesetReader : ContentTypeReader<TiledMapTileset>
 	{
+		/// <summary>
+		/// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
+		/// so it is resolved without reflection.
+		/// </summary>
+		/// <remarks>
+		/// Call this method once during application startup when publishing with
+		/// <c>PublishAot</c> or <c>PublishTrimmed</c>.
+		/// </remarks>
+		public static void Register() =>
+			ContentTypeReaderManager.AddTypeCreator(
+				typeof(TiledMapTilesetReader).AssemblyQualifiedName,
+				() => new TiledMapTilesetReader());
+
+
 		protected override TiledMapTileset Read(ContentReader reader, TiledMapTileset existingInstance)
 		{
 			if (existingInstance != null)


### PR DESCRIPTION
## Description

Each MonoGame.Extended `ContentTypeReader` now exposes a static `Register()` method that pre-registers it with MonoGame's `ContentTypeReaderManager` using `AddTypeCreator()`. This avoids reflection-based type resolution, which crashes at runtime when publishing with `PublishAot` or `PublishTrimmed`.

## Related Issues/Tickets

- Closes #1083

## Changes Made

Added a static `Register()` method to each Extended content type reader:

- `Texture2DAtlasReader`
- `BitmapFontContentReader`
- `ParticleEffectContentReader`
- `TiledMapReader`
- `TiledMapTilesetReader`
- `JsonContentTypeReader<T>` (must be called per concrete type used)

Each reader self-registers using its own `AssemblyQualifiedName` as the key, which matches exactly what the XNB format stores. Registration is idempotent, calling `Register()` more than once is safe. Readers are registered individually rather than in bulk so that the trimmer can still eliminate any reader types the application does not use.

Users call `Register()` once per reader type during application startup, before loading any content:

```csharp
protected override void Initialize()
{
    // Call Register() only for the Extended content types you actually load.
    // This is only required when publishing with PublishAot or PublishTrimmed.
    Texture2DAtlasReader.Register();
    BitmapFontContentReader.Register();
    TiledMapReader.Register();
    TiledMapTilesetReader.Register(); // only needed if using external tilesets

    // JsonContentTypeReader<T> must be registered per concrete type
    JsonContentTypeReader<MyData>.Register();

    base.Initialize();
}
```


## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
