### PR TITLE
Tweening and EasingFunction Maintenance

### DIFF
--- a/source/MonoGame.Extended/Tweening/ColorTween.cs
+++ b/source/MonoGame.Extended/Tweening/ColorTween.cs
@@ -2,12 +2,19 @@ using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended.Tweening;
 
+/// <summary>
+/// A tween that animates a <see cref="Color"/> value using <see cref="Color.Lerp"/> for interpolation.
+/// </summary>
 public class ColorTween: Tween<Color>
 {
     internal ColorTween(object target, float duration, float delay, TweenMember<Color> member, Color endValue) : base(target, duration, delay, member, endValue)
     {
     }
 
+    /// <summary>
+    /// Interpolates the member's color value between the start and end colors for the given progress.
+    /// </summary>
+    /// <param name="n">The interpolation progress in the range [0, 1], after easing has been applied.</param>
     protected override void Interpolate(float n)
     {
         Member.Value = Color.Lerp(_startValue, _endValue, n);

--- a/source/MonoGame.Extended/Tweening/EasingFunctions.cs
+++ b/source/MonoGame.Extended/Tweening/EasingFunctions.cs
@@ -1,40 +1,237 @@
-﻿using System;
+using System;
+
 using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended.Tweening
 {
+    /// <summary>
+    /// Provides a collection of standard easing functions for use with animation and tweening.
+    /// Each function accepts a normalized progress value in the range [0, 1] and returns a
+    /// transformed value representing a non-linear rate of change.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="Invert"/> and <see cref="Follow"/> to compose custom easing functions
+    /// from existing ones without writing additional math.
+    /// </remarks>
     public static class EasingFunctions
     {
+        /// <summary>
+        /// Returns a new easing function that is the inverse of the specified function,
+        /// mirroring the curve so that an "In" variant becomes an "Out" variant and vice versa.
+        /// </summary>
+        /// <param name="easer">The easing function to invert.</param>
+        /// <returns>
+        /// A new easing function that applies the inverse transformation of <paramref name="easer"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="easer"/> is <c>null</c>.
+        /// </exception>
+        /// <example>
+        /// Create a custom out variant from an existing in function:
+        /// <code>
+        /// Func&lt;float, float&gt; myOut = EasingFunctions.Invert(EasingFunctions.CubicIn);
+        /// </code>
+        /// </example>
+        public static Func<float, float> Invert(Func<float, float> easer)
+        {
+            ArgumentNullException.ThrowIfNull(easer);
+            return t => 1 - easer(1 - t);
+        }
+
+        /// <summary>
+        /// Returns a new easing function that applies <paramref name="first"/> for the first half
+        /// of the interpolation range and <paramref name="second"/> for the second half.
+        /// This is the standard technique for composing "InOut" variants from paired "In" and "Out" functions.
+        /// </summary>
+        /// <param name="first">The easing function applied when the progress is in [0, 0.5].</param>
+        /// <param name="second">The easing function applied when the progress is in (0.5, 1].</param>
+        /// <returns>
+        /// A new easing function that transitions from <paramref name="first"/> to <paramref name="second"/>
+        /// at the midpoint.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="first"/> or <paramref name="second"/> is <c>null</c>.
+        /// </exception>
+        /// <example>
+        /// Create a custom InOut variant from existing In and Out functions:
+        /// <code>
+        /// Func&lt;float, float&gt; myInOut = EasingFunctions.Follow(EasingFunctions.CubicIn, EasingFunctions.CubicOut);
+        /// </code>
+        /// </example>
+        public static Func<float, float> Follow(Func<float, float> first, Func<float, float> second)
+        {
+            ArgumentNullException.ThrowIfNull(first);
+            ArgumentNullException.ThrowIfNull(second);
+            return t => (t <= 0.5f) ? first(t * 2) / 2 : second(t * 2 - 1) / 2 + 0.5f;
+        }
+
+        /// <summary>
+        /// A linear easing function with a constant rate of change and no acceleration or deceleration.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The input <paramref name="value"/> unchanged.</returns>
         public static float Linear(float value) => value;
 
+        /// <summary>
+        /// A cubic easing function that starts slow and accelerates towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float CubicIn(float value) => Power.In(value, 3);
+
+        /// <summary>
+        /// A cubic easing function that starts fast and decelerates towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float CubicOut(float value) => Power.Out(value, 3);
+
+        /// <summary>
+        /// A cubic easing function that starts slow, accelerates through the middle, and decelerates at the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float CubicInOut(float value) => Power.InOut(value, 3);
 
+        /// <summary>
+        /// A quadratic easing function that starts slow and accelerates towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuadraticIn(float value) => Power.In(value, 2);
+
+        /// <summary>
+        /// A quadratic easing function that starts fast and decelerates towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuadraticOut(float value) => Power.Out(value, 2);
+
+        /// <summary>
+        /// A quadratic easing function that starts slow, accelerates through the middle, and decelerates at the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuadraticInOut(float value) => Power.InOut(value, 2);
 
+        /// <summary>
+        /// A quartic easing function that starts slow and accelerates towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuarticIn(float value) => Power.In(value, 4);
+
+        /// <summary>
+        /// A quartic easing function that starts fast and decelerates towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuarticOut(float value) => Power.Out(value, 4);
+
+        /// <summary>
+        /// A quartic easing function that starts slow, accelerates through the middle, and decelerates at the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuarticInOut(float value) => Power.InOut(value, 4);
 
+        /// <summary>
+        /// A quintic easing function that starts slow and accelerates towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuinticIn(float value) => Power.In(value, 5);
+
+        /// <summary>
+        /// A quintic easing function that starts fast and decelerates towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuinticOut(float value) => Power.Out(value, 5);
+
+        /// <summary>
+        /// A quintic easing function that starts slow, accelerates through the middle, and decelerates at the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float QuinticInOut(float value) => Power.InOut(value, 5);
 
+        /// <summary>
+        /// A sinusoidal easing function that starts slow and accelerates towards the end,
+        /// following the curve of a sine wave.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float SineIn(float value) => (float) Math.Sin(value*MathHelper.PiOver2 - MathHelper.PiOver2) + 1;
+
+        /// <summary>
+        /// A sinusoidal easing function that starts fast and decelerates towards the end,
+        /// following the curve of a sine wave.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float SineOut(float value) => (float) Math.Sin(value*MathHelper.PiOver2);
+
+        /// <summary>
+        /// A sinusoidal easing function that starts slow, accelerates through the middle, and
+        /// decelerates at the end, following the curve of a sine wave.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float SineInOut(float value) => (float) (Math.Sin(value*MathHelper.Pi - MathHelper.PiOver2) + 1)/2;
 
+        /// <summary>
+        /// An exponential easing function that starts very slow and accelerates sharply towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float ExponentialIn(float value) => (float) Math.Pow(2, 10*(value - 1));
+
+        /// <summary>
+        /// An exponential easing function that starts fast and decelerates sharply towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float ExponentialOut(float value) => Out(value, ExponentialIn);
+
+        /// <summary>
+        /// An exponential easing function that starts very slow, accelerates sharply through the middle,
+        /// and decelerates sharply at the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float ExponentialInOut(float value) => InOut(value, ExponentialIn);
 
+        /// <summary>
+        /// A circular easing function that starts slow and accelerates towards the end,
+        /// following the curve of a circle arc.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float CircleIn(float value) => (float) -(Math.Sqrt(1 - value * value) - 1);
+
+        /// <summary>
+        /// A circular easing function that starts fast and decelerates towards the end,
+        /// following the curve of a circle arc.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float CircleOut(float value) => (float) Math.Sqrt(1 - (value - 1) * (value - 1));
+
+        /// <summary>
+        /// A circular easing function that starts slow, accelerates through the middle, and decelerates
+        /// at the end, following the curve of a circle arc.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float CircleInOut(float value) => (float) (value <= .5 ? (Math.Sqrt(1 - value * value * 4) - 1) / -2 : (Math.Sqrt(1 - (value * 2 - 2) * (value * 2 - 2)) + 1) / 2);
 
+        /// <summary>
+        /// An elastic easing function that oscillates with a spring-like effect at the start
+        /// before settling into the forward motion.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float ElasticIn(float value)
         {
             const int oscillations = 1;
@@ -43,21 +240,69 @@ namespace MonoGame.Extended.Tweening
             return (float) (e*Math.Sin((MathHelper.PiOver2 + MathHelper.TwoPi*oscillations)*value));
         }
 
+        /// <summary>
+        /// An elastic easing function that overshoots and oscillates with a spring-like effect
+        /// at the end before settling into the final value.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float ElasticOut(float value) => Out(value, ElasticIn);
+
+        /// <summary>
+        /// An elastic easing function that oscillates with a spring-like effect at both
+        /// the start and end of the motion.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float ElasticInOut(float value) => InOut(value, ElasticIn);
 
+        /// <summary>
+        /// A back easing function that slightly overshoots backward at the start
+        /// before accelerating forward towards the end.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float BackIn(float value)
         {
             const float amplitude = 1f;
             return (float) (Math.Pow(value, 3) - value*amplitude*Math.Sin(value*MathHelper.Pi));
         }
 
+        /// <summary>
+        /// A back easing function that overshoots the target at the end
+        /// before pulling back to settle on the final value.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float BackOut(float value) => Out(value, BackIn);
+
+        /// <summary>
+        /// A back easing function that slightly overshoots at both the start and end of the motion.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float BackInOut(float value) => InOut(value, BackIn);
 
+        /// <summary>
+        /// A bounce easing function that simulates a bouncing effect at the end,
+        /// as though the value strikes a surface and bounces to rest.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float BounceOut(float value) => Out(value, BounceIn);
+
+        /// <summary>
+        /// A bounce easing function that simulates a bouncing effect at both the start and end of the motion.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float BounceInOut(float value) => InOut(value, BounceIn);
 
+        /// <summary>
+        /// A bounce easing function that simulates a bouncing effect at the start of the motion.
+        /// </summary>
+        /// <param name="value">The interpolation progress in the range [0, 1].</param>
+        /// <returns>The eased value.</returns>
         public static float BounceIn(float value)
         {
             const float bounceConst1 = 2.75f;
@@ -78,7 +323,6 @@ namespace MonoGame.Extended.Tweening
             return 1f - (float) (bounceConst2*Math.Pow(value - 2.625f/bounceConst1, 2) + .984375);
         }
 
-
         private static float Out(float value, Func<float, float> function)
         {
             return 1 - function(1 - value);
@@ -87,7 +331,9 @@ namespace MonoGame.Extended.Tweening
         private static float InOut(float value, Func<float, float> function)
         {
             if (value < 0.5f)
+            {
                 return 0.5f*function(value*2);
+            }
 
             return 1f - 0.5f*function(2 - value*2);
         }
@@ -110,7 +356,9 @@ namespace MonoGame.Extended.Tweening
                 s *= 2;
 
                 if (s < 1)
+                {
                     return In(s, power)/2;
+                }
 
                 var sign = power%2 == 0 ? -1 : 1;
                 return (float) (sign/2.0*(Math.Pow(s - 2, power) + sign*2));

--- a/source/MonoGame.Extended/Tweening/LinearOperations.cs
+++ b/source/MonoGame.Extended/Tweening/LinearOperations.cs
@@ -3,6 +3,16 @@ using System.Linq.Expressions;
 
 namespace MonoGame.Extended.Tweening;
 
+/// <summary>
+/// Provides compiled arithmetic delegates for a value type <typeparamref name="T"/>, enabling
+/// type-agnostic linear interpolation over any struct that supports addition, subtraction, and
+/// scalar multiplication operators. The delegates are compiled once via expression trees and
+/// cached as static members.
+/// </summary>
+/// <typeparam name="T">
+/// The value type to compile operations for. Must define <c>+</c>, <c>-</c>, and <c>*</c>
+/// operators, with <c>*</c> accepting a <see cref="float"/> scalar as the right-hand operand.
+/// </typeparam>
 public class LinearOperations<T>
 {
     static LinearOperations()
@@ -15,7 +25,18 @@ public class LinearOperations<T>
         Multiply = Expression.Lambda<Func<T, float, T>>(Expression.Multiply(a, c), a, c).Compile();
     }
 
+    /// <summary>
+    /// Gets a compiled delegate that adds two values of type <typeparamref name="T"/>.
+    /// </summary>
     public static Func<T, T, T> Add { get; }
+
+    /// <summary>
+    /// Gets a compiled delegate that subtracts the second value from the first for type <typeparamref name="T"/>.
+    /// </summary>
     public static Func<T, T, T> Subtract { get; }
+
+    /// <summary>
+    /// Gets a compiled delegate that multiplies a value of type <typeparamref name="T"/> by a <see cref="float"/> scalar.
+    /// </summary>
     public static Func<T, float, T> Multiply { get; }
 }

--- a/source/MonoGame.Extended/Tweening/LinearTween.cs
+++ b/source/MonoGame.Extended/Tweening/LinearTween.cs
@@ -1,5 +1,13 @@
 namespace MonoGame.Extended.Tweening;
 
+/// <summary>
+/// A tween that animates a value of type <typeparamref name="T"/> using linear interpolation
+/// via the arithmetic operations provided by <see cref="LinearOperations{T}"/>.
+/// </summary>
+/// <typeparam name="T">
+/// The value type to animate. Must support the addition, subtraction, and scalar multiplication
+/// operators required by <see cref="LinearOperations{T}"/>.
+/// </typeparam>
 public class LinearTween<T>: Tween<T>
     where T: struct
 {
@@ -9,12 +17,19 @@ public class LinearTween<T>: Tween<T>
     {
     }
 
+    /// <summary>
+    /// Captures the initial member value as the start value and computes the animation range.
+    /// </summary>
     protected override void Initialize()
     {
         base.Initialize();
         _range = LinearOperations<T>.Subtract(_endValue, _startValue);
     }
 
+    /// <summary>
+    /// Interpolates the member value between the start and end values for the given progress.
+    /// </summary>
+    /// <param name="n">The interpolation progress in the range [0, 1], after easing has been applied.</param>
     protected override void Interpolate(float n)
     {
         var value = LinearOperations<T>.Add(_startValue, LinearOperations<T>.Multiply(_range, n));

--- a/source/MonoGame.Extended/Tweening/Tween.cs
+++ b/source/MonoGame.Extended/Tweening/Tween.cs
@@ -1,8 +1,14 @@
-﻿using System;
+using System;
+
 using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended.Tweening
 {
+    /// <summary>
+    /// Abstract base for a typed tween that animates a value of type <typeparamref name="T"/>
+    /// on a target object's member.
+    /// </summary>
+    /// <typeparam name="T">The value type being animated.</typeparam>
     public abstract class Tween<T> : Tween
         where T : struct
     {
@@ -13,17 +19,38 @@ namespace MonoGame.Extended.Tweening
             _endValue = endValue;
         }
 
+        /// <summary>
+        /// Gets the <see cref="TweenMember{T}"/> representing the property or field being animated.
+        /// </summary>
         public TweenMember<T> Member { get; }
+
+        /// <summary>
+        /// Gets the name of the member being animated.
+        /// </summary>
         public override string MemberName => Member.Name;
 
+        /// <summary>
+        /// The value of the member at the start of the current animation cycle.
+        /// </summary>
         protected T _startValue;
+
+        /// <summary>
+        /// The target value to animate towards.
+        /// </summary>
         protected T _endValue;
 
+        /// <summary>
+        /// Captures the current member value as the start value of the animation.
+        /// </summary>
         protected override void Initialize()
         {
             _startValue = Member.Value;
         }
 
+        /// <summary>
+        /// Swaps the start and end values to reverse the animation direction.
+        /// Called at the start of each reversed repeat cycle when <see cref="Tween.IsAutoReverse"/> is enabled.
+        /// </summary>
         protected override void Swap()
         {
             _endValue = _startValue;
@@ -31,6 +58,10 @@ namespace MonoGame.Extended.Tweening
         }
     }
 
+    /// <summary>
+    /// Abstract base class managing timing, lifecycle, easing, callbacks, and
+    /// repeat behavior. Subclasses implement the actual value interpolation.
+    /// </summary>
     public abstract class Tween
     {
         internal Tween(object target, float duration, float delay)
@@ -43,17 +74,65 @@ namespace MonoGame.Extended.Tweening
             _remainingDelay = delay;
         }
 
+        /// <summary>
+        /// Gets the object whose member is being animated.
+        /// </summary>
         public object Target { get; }
+
+        /// <summary>
+        /// Gets the name of the member being animated.
+        /// </summary>
         public abstract string MemberName { get; }
+
+        /// <summary>
+        /// Gets the total duration of one complete animation cycle, in seconds.
+        /// </summary>
         public float Duration { get; }
+
+        /// <summary>
+        /// Gets the delay before the animation begins, in seconds.
+        /// </summary>
         public float Delay { get; }
+
+        /// <summary>
+        /// Gets or sets whether the tween is currently paused. When paused, <see cref="Update"/> has no effect.
+        /// </summary>
         public bool IsPaused { get; set; }
+
+        /// <summary>
+        /// Gets whether the tween is configured to repeat after completing a cycle.
+        /// </summary>
         public bool IsRepeating => _remainingRepeats != 0;
+
+        /// <summary>
+        /// Gets whether the tween is configured to repeat indefinitely.
+        /// </summary>
         public bool IsRepeatingForever => _remainingRepeats < 0;
+
+        /// <summary>
+        /// Gets whether the tween reverses direction on alternate repeat cycles.
+        /// </summary>
         public bool IsAutoReverse { get; private set; }
+
+        /// <summary>
+        /// Gets whether the tween is active and should continue receiving updates.
+        /// </summary>
         public bool IsAlive { get; private set; }
+
+        /// <summary>
+        /// Gets whether the tween has completed the current animation cycle.
+        /// </summary>
         public bool IsComplete { get; private set; }
+
+        /// <summary>
+        /// Gets the time remaining in the current animation cycle, in seconds.
+        /// </summary>
         public float TimeRemaining => Duration - _elapsedDuration;
+
+        /// <summary>
+        /// Gets the normalized progress of the current animation cycle, clamped to [0, 1].
+        /// This value is not affected by easing.
+        /// </summary>
         public float Completion => MathHelper.Clamp(_completion, 0, 1);
 
         private Func<float, float> _easingFunction;
@@ -66,12 +145,48 @@ namespace MonoGame.Extended.Tweening
         private Action<Tween> _onBegin;
         private Action<Tween> _onEnd;
 
+        /// <summary>
+        /// Sets the easing function applied to the animation progress each frame.
+        /// </summary>
+        /// <param name="easingFunction">
+        /// A function that transforms a linear [0, 1] progress value into a non-linear one.
+        /// Use members of <see cref="EasingFunctions"/> or supply a custom delegate.
+        /// </param>
+        /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween Easing(Func<float, float> easingFunction) { _easingFunction = easingFunction; return this; }
+
+        /// <summary>
+        /// Registers a callback to invoke when the animation begins its first cycle.
+        /// </summary>
+        /// <param name="action">The callback to invoke, receiving this tween as its argument.</param>
+        /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween OnBegin(Action<Tween> action) { _onBegin = action; return this; }
+
+        /// <summary>
+        /// Registers a callback to invoke when the animation completes each cycle.
+        /// </summary>
+        /// <param name="action">The callback to invoke, receiving this tween as its argument.</param>
+        /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween OnEnd(Action<Tween> action) { _onEnd = action; return this; }
+
+        /// <summary>
+        /// Pauses the animation. Has no effect if already paused.
+        /// </summary>
+        /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween Pause() { IsPaused = true; return this; }
+
+        /// <summary>
+        /// Resumes a paused animation. Has no effect if not paused.
+        /// </summary>
+        /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween Resume() { IsPaused = false; return this; }
 
+        /// <summary>
+        /// Configures the animation to repeat a fixed number of times after its first cycle.
+        /// </summary>
+        /// <param name="count">The number of additional cycles to play.</param>
+        /// <param name="repeatDelay">An optional delay between cycles, in seconds.</param>
+        /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween Repeat(int count, float repeatDelay = 0f)
         {
             _remainingRepeats = count;
@@ -79,6 +194,11 @@ namespace MonoGame.Extended.Tweening
             return this;
         }
 
+        /// <summary>
+        /// Configures the animation to repeat indefinitely.
+        /// </summary>
+        /// <param name="repeatDelay">An optional delay between cycles, in seconds.</param>
+        /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween RepeatForever(float repeatDelay = 0f)
         {
             _remainingRepeats = -1;
@@ -86,6 +206,11 @@ namespace MonoGame.Extended.Tweening
             return this;
         }
 
+        /// <summary>
+        /// Configures the animation to reverse direction on alternate repeat cycles, creating
+        /// a ping-pong effect. Implicitly sets the repeat count to at least 1 if not already repeating.
+        /// </summary>
+        /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween AutoReverse()
         {
             if (_remainingRepeats == 0)
@@ -95,16 +220,35 @@ namespace MonoGame.Extended.Tweening
             return this;
         }
 
+        /// <summary>
+        /// Called once before the first update to capture the initial animation state.
+        /// </summary>
         protected abstract void Initialize();
+
+        /// <summary>
+        /// Called each update to apply the interpolated value for the given progress.
+        /// </summary>
+        /// <param name="n">The interpolation progress in the range [0, 1], after easing has been applied.</param>
         protected abstract void Interpolate(float n);
+
+        /// <summary>
+        /// Called at the start of a reversed cycle to swap the start and end values.
+        /// </summary>
         protected abstract void Swap();
 
+        /// <summary>
+        /// Stops the animation immediately without applying the final value.
+        /// </summary>
         public void Cancel()
         {
             _remainingRepeats = 0;
             IsAlive = false;
         }
 
+        /// <summary>
+        /// Stops the animation and immediately applies the end value, invoking the
+        /// <see cref="OnEnd"/> callback if the tween was still alive.
+        /// </summary>
         public void CancelAndComplete()
         {
             if (IsAlive)
@@ -119,6 +263,11 @@ namespace MonoGame.Extended.Tweening
             Cancel();
         }
 
+        /// <summary>
+        /// Advances the animation by the given elapsed time and applies the interpolated value.
+        /// Animations that complete and are not configured to repeat are automatically deactivated.
+        /// </summary>
+        /// <param name="elapsedSeconds">The time elapsed since the last update, in seconds.</param>
         public void Update(float elapsedSeconds)
         {
             if(IsPaused || !IsAlive)

--- a/source/MonoGame.Extended/Tweening/TweenFieldMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenFieldMember.cs
@@ -6,11 +6,21 @@ using Microsoft.VisualBasic;
 
 namespace MonoGame.Extended.Tweening
 {
+    /// <summary>
+    /// Provides access to a public field on a target object using expression-tree compiled
+    /// delegates for efficient get and set operations.
+    /// </summary>
+    /// <typeparam name="T">The value type of the field being accessed.</typeparam>
     public sealed class TweenFieldMember<T> : TweenMember<T>
         where T : struct
     {
         private readonly FieldInfo _fieldInfo;
 
+        /// <summary>
+        /// Initializes a new instance targeting the specified field on the given object.
+        /// </summary>
+        /// <param name="target">The object that owns the field.</param>
+        /// <param name="fieldInfo">Reflection metadata for the field to access.</param>
         public TweenFieldMember(object target, FieldInfo fieldInfo)
             : base(target, CompileGetMethod(fieldInfo), CompileSetMethod(fieldInfo))
         {
@@ -40,7 +50,14 @@ namespace MonoGame.Extended.Tweening
             return Expression.Lambda<Action<object, T>>(assignation, targetParam, valueParam).Compile();
         }
 
+        /// <summary>
+        /// Gets the declared type of the field.
+        /// </summary>
         public override Type Type => _fieldInfo.FieldType;
+
+        /// <summary>
+        /// Gets the name of the field.
+        /// </summary>
         public override string Name => _fieldInfo.Name;
     }
 }

--- a/source/MonoGame.Extended/Tweening/TweenMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenMember.cs
@@ -3,21 +3,50 @@ using System.Linq.Expressions;
 
 namespace MonoGame.Extended.Tweening
 {
+    /// <summary>
+    /// Abstract base representing a property or field on a target object that a tween can animate.
+    /// </summary>
     public abstract class TweenMember
     {
+        /// <summary>
+        /// Initializes a new instance targeting the specified object.
+        /// </summary>
+        /// <param name="target">The object whose member will be animated.</param>
         protected TweenMember(object target)
         {
             Target = target;
         }
 
+        /// <summary>
+        /// Gets the target object whose member is being animated.
+        /// </summary>
         public object Target { get; }
+
+        /// <summary>
+        /// Gets the declared type of the member being animated.
+        /// </summary>
         public abstract Type Type { get; }
+
+        /// <summary>
+        /// Gets the name of the member being animated.
+        /// </summary>
         public abstract string Name { get; }
     }
 
+    /// <summary>
+    /// Abstract base for typed member access, using compiled get and set delegates to read and
+    /// write a value of type <typeparamref name="T"/> on the target object.
+    /// </summary>
+    /// <typeparam name="T">The value type of the member being animated.</typeparam>
     public abstract class TweenMember<T> : TweenMember
         where T : struct
     {
+        /// <summary>
+        /// Initializes a new instance with the given target object and compiled accessor delegates.
+        /// </summary>
+        /// <param name="target">The object whose member will be animated.</param>
+        /// <param name="getMethod">A compiled delegate that reads the member value from the target.</param>
+        /// <param name="setMethod">A compiled delegate that writes a value to the member on the target.</param>
         protected TweenMember(object target, Func<object, T> getMethod, Action<object, T> setMethod)
             : base(target)
         {
@@ -28,6 +57,9 @@ namespace MonoGame.Extended.Tweening
         private readonly Func<object, T> _getMethod;
         private readonly Action<object, T> _setMethod;
 
+        /// <summary>
+        /// Gets or sets the current value of the member on the target object.
+        /// </summary>
         public T Value
         {
             get { return _getMethod(Target); }

--- a/source/MonoGame.Extended/Tweening/TweenPropertyMember.cs
+++ b/source/MonoGame.Extended/Tweening/TweenPropertyMember.cs
@@ -5,18 +5,35 @@ using System.Reflection;
 
 namespace MonoGame.Extended.Tweening
 {
+    /// <summary>
+    /// Provides access to a property on a target object using expression-tree compiled
+    /// delegates for efficient get and set operations.
+    /// </summary>
+    /// <typeparam name="T">The value type of the property being accessed.</typeparam>
     public sealed class TweenPropertyMember<T> : TweenMember<T>
         where T : struct
     {
         private readonly PropertyInfo _propertyInfo;
 
+        /// <summary>
+        /// Initializes a new instance targeting the specified property on the given object.
+        /// </summary>
+        /// <param name="target">The object that owns the property.</param>
+        /// <param name="propertyInfo">Reflection metadata for the property to access.</param>
         public TweenPropertyMember(object target, PropertyInfo propertyInfo)
             : base(target, CompileGetMethod(propertyInfo), CompileSetMethod(propertyInfo))
         {
             _propertyInfo = propertyInfo;
         }
 
+        /// <summary>
+        /// Gets the declared type of the property.
+        /// </summary>
         public override Type Type => _propertyInfo.PropertyType;
+
+        /// <summary>
+        /// Gets the name of the property.
+        /// </summary>
         public override string Name => _propertyInfo.Name;
 
         //TODO: Try to further optimize this. For example, it needs to do all this reflection compilation shenanigan every time.

--- a/source/MonoGame.Extended/Tweening/Tweener.cs
+++ b/source/MonoGame.Extended/Tweening/Tweener.cs
@@ -1,18 +1,30 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+
 using Microsoft.Xna.Framework;
 
 namespace MonoGame.Extended.Tweening
 {
+    /// <summary>
+    /// Manages a collection of active tween animations and drives their updates each frame.
+    /// Create animations using <see cref="TweenTo{TTarget,TMember}(TTarget,Expression{Func{TTarget,TMember}},TMember,float,float)"/>,
+    /// then call <see cref="Update"/> once per frame. Completed animations are removed automatically.
+    /// </summary>
     public class Tweener : IDisposable
     {
+        /// <summary>
+        /// Initializes a new instance with no active animations.
+        /// </summary>
         public Tweener()
         {
         }
 
+        /// <summary>
+        /// Cancels all active animations, clears internal state, and releases resources.
+        /// </summary>
         public void Dispose()
         {
             CancelAll();
@@ -20,10 +32,28 @@ namespace MonoGame.Extended.Tweening
             _memberCache.Clear();
         }
 
+        /// <summary>
+        /// Gets the total number of tween and member allocations made since this instance was created.
+        /// Useful for tracking and debugging allocation behavior.
+        /// </summary>
         public long AllocationCount { get; private set; }
 
         private readonly List<Tween> _activeTweens = new List<Tween>();
 
+        /// <summary>
+        /// Creates and starts an animation that interpolates the specified member of
+        /// <paramref name="target"/> from its current value to <paramref name="toValue"/> over
+        /// <paramref name="duration"/> seconds. If an animation is already running on the same
+        /// member it is cancelled before the new one begins.
+        /// </summary>
+        /// <typeparam name="TTarget">The type of the target object.</typeparam>
+        /// <typeparam name="TMember">The value type of the member being animated.</typeparam>
+        /// <param name="target">The object whose member will be animated.</param>
+        /// <param name="expression">A member-access expression identifying the property or field to animate.</param>
+        /// <param name="toValue">The target value to animate towards.</param>
+        /// <param name="duration">The duration of the animation in seconds.</param>
+        /// <param name="delay">An optional delay before the animation begins, in seconds.</param>
+        /// <returns>The created <see cref="Tween{TMember}"/> for fluent configuration.</returns>
         public Tween<TMember> TweenTo<TTarget, TMember>(TTarget target, Expression<Func<TTarget, TMember>> expression, TMember toValue, float duration, float delay = 0f)
             where TTarget : class
             where TMember : struct
@@ -38,6 +68,20 @@ namespace MonoGame.Extended.Tweening
 
         }
 
+        /// <summary>
+        /// Creates and starts a tween of a specific <typeparamref name="TTween"/> type that
+        /// interpolates the specified member of <paramref name="target"/> from its current value
+        /// to <paramref name="toValue"/> over <paramref name="duration"/> seconds.
+        /// </summary>
+        /// <typeparam name="TTarget">The type of the target object.</typeparam>
+        /// <typeparam name="TMember">The value type of the member being animated.</typeparam>
+        /// <typeparam name="TTween">The concrete <see cref="Tween{TMember}"/> type to create.</typeparam>
+        /// <param name="target">The object whose member will be animated.</param>
+        /// <param name="expression">A member-access expression identifying the property or field to animate.</param>
+        /// <param name="toValue">The target value to animate towards.</param>
+        /// <param name="duration">The duration of the animation in seconds.</param>
+        /// <param name="delay">An optional delay before the animation begins, in seconds.</param>
+        /// <returns>The created <typeparamref name="TTween"/> instance for fluent configuration.</returns>
         public Tween<TMember> TweenTo<TTarget, TMember, TTween>(TTarget target, Expression<Func<TTarget, TMember>> expression, TMember toValue, float duration, float delay = 0f)
             where TTarget : class
             where TMember : struct
@@ -58,6 +102,11 @@ namespace MonoGame.Extended.Tweening
             return tween;
         }
 
+        /// <summary>
+        /// Advances all active animations by <paramref name="elapsedSeconds"/> and removes
+        /// any that have completed.
+        /// </summary>
+        /// <param name="elapsedSeconds">The time elapsed since the last update, in seconds.</param>
         public void Update(float elapsedSeconds)
         {
             for (var i = _activeTweens.Count - 1; i >= 0; i--)
@@ -71,17 +120,30 @@ namespace MonoGame.Extended.Tweening
             }
         }
 
+        /// <summary>
+        /// Finds and returns an active animation targeting the specified member on the given object,
+        /// or <c>null</c> if no matching animation exists.
+        /// </summary>
+        /// <param name="target">The object to search for.</param>
+        /// <param name="memberName">The name of the member to search for.</param>
+        /// <returns>The matching <see cref="Tween"/>, or <c>null</c> if not found.</returns>
         public Tween FindTween(object target, string memberName)
         {
             return _activeTweens.FirstOrDefault(t => t.Target == target && t.MemberName == memberName);
         }
 
+        /// <summary>
+        /// Cancels all active animations immediately without applying their final values.
+        /// </summary>
         public void CancelAll()
         {
             foreach (var tween in _activeTweens)
                 tween.Cancel();
         }
 
+        /// <summary>
+        /// Cancels all active animations, applying the final value of each before stopping.
+        /// </summary>
         public void CancelAndCompleteAll()
         {
             foreach (var tween in _activeTweens)


### PR DESCRIPTION
## Description

* Adds `Invert` and `Follow` combinator methods to `EasingFunctions`, allowing users to compose custom easing functions from existing ones without writing the underlying math. Also documents the full public API of the tweening system.

## Related Issues/Tickets

* Closes #562 

## Changes Made

* Added `EasingFunctions.Invert(Func<float, float>)`:  returns a new easing function that mirrors the curve of the given function, converting an "In" variant into an "Out" variant and vice versa.
* Added `EasingFunctions.Follow(Func<float, float>, Func<float, float>)`:  returns a new easing function that applies the first function for the first half of the interpolation range and the second for the second half, enabling composition of "InOut" variants from any paired functions.
* Added XML documentation to all public API members across the tweening system: `EasingFunctions`, `Tween`, `Tween<T>`, `Tweener`, `ColorTween`, `LinearTween<T>`, `LinearOperations<T>`, `TweenMember`, `TweenMember<T>`, `TweenFieldMember<T>`, and `TweenPropertyMember<T>`.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
