### PR TITLE
Fix alpha rendering issue in PrimtiveDrawing and PrimitiveBatch

### DIFF
--- a/source/MonoGame.Extended/Graphics/Batcher.cs
+++ b/source/MonoGame.Extended/Graphics/Batcher.cs
@@ -11,6 +11,7 @@ namespace MonoGame.Extended.Graphics
     /// </summary>
     /// <typeparam name="TDrawCallInfo">The type of the information for a draw call.</typeparam>
     /// <seealso cref="IDisposable" />
+    [Obsolete("Batcher is part of an incomplete implementation that was never finished. It will be removed in a future major release.")]
     public abstract class Batcher<TDrawCallInfo> : IDisposable
         where TDrawCallInfo : struct, IBatchDrawCallInfo<TDrawCallInfo>, IComparable<TDrawCallInfo>
     {

--- a/source/MonoGame.Extended/Graphics/Batcher2D.cs
+++ b/source/MonoGame.Extended/Graphics/Batcher2D.cs
@@ -17,6 +17,7 @@ namespace MonoGame.Extended.Graphics
     ///     frequently between frames such as sprites and shapes.
     /// </summary>
     /// <seealso cref="IDisposable" />
+    [Obsolete("Batcher2D is an incomplete implementation that was never finished. Use SpriteBatch with MonoGame.Extended's extension methods instead. It will be removed in a future major release.")]
     public sealed class Batcher2D : Batcher<Batcher2D.DrawCallInfo>
     {
 

--- a/source/MonoGame.Extended/Graphics/Geometry/GeometryBuilder.cs
+++ b/source/MonoGame.Extended/Graphics/Geometry/GeometryBuilder.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.Graphics.Geometry
 {
+    [Obsolete("GeometryBuilder is part of an incomplete implementation that was never finished. It will be removed in a future major release.")]
     public abstract class GeometryBuilder<TVertexType, TIndexType>
         where TVertexType : struct, IVertexType
         where TIndexType : struct

--- a/source/MonoGame.Extended/Graphics/Geometry/GeometryBuilder2D.cs
+++ b/source/MonoGame.Extended/Graphics/Geometry/GeometryBuilder2D.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.Graphics.Geometry
 {
+    [Obsolete("GeometryBuilder2D is part of an incomplete implementation that was never finished. It will be removed in a future major release.")]
     public class GeometryBuilder2D : GeometryBuilder<VertexPositionColorTexture, ushort>
     {
         public GeometryBuilder2D(int maximumVerticesCount, int maximumIndicesCount)

--- a/source/MonoGame.Extended/Graphics/IBatchDrawCallInfo.cs
+++ b/source/MonoGame.Extended/Graphics/IBatchDrawCallInfo.cs
@@ -5,6 +5,7 @@ namespace MonoGame.Extended.Graphics
     /// <summary>
     ///     Defines the for a deferred draw call when batching.
     /// </summary>
+    [Obsolete("IBatchDrawCallInfo is part of an incomplete implementation that was never finished. It will be removed in a future major release.")]
     public interface IBatchDrawCallInfo<TDrawCallInfo> where TDrawCallInfo : IBatchDrawCallInfo<TDrawCallInfo>
     {
         /// <summary>

--- a/source/MonoGame.Extended/Graphics/IBatchDrawCallInfo.cs
+++ b/source/MonoGame.Extended/Graphics/IBatchDrawCallInfo.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.Graphics

--- a/source/MonoGame.Extended/Math/ShapeExtensions.cs
+++ b/source/MonoGame.Extended/Math/ShapeExtensions.cs
@@ -320,6 +320,67 @@ namespace MonoGame.Extended
             DrawPolygon(spriteBatch, center, CreateEllipse(radius.X, radius.Y, sides), color, thickness, layerDepth);
         }
 
+        /// <summary>
+        /// Draws an arc outline.
+        /// </summary>
+        /// <param name="spriteBatch">The destination drawing surface.</param>
+        /// <param name="center">The center point of the arc.</param>
+        /// <param name="radius">The radius of the arc.</param>
+        /// <param name="startAngle">The starting angle in radians.</param>
+        /// <param name="sweepAngle">
+        /// The sweep angle in radians. Positive values sweep counter-clockwise.
+        /// Use <c>MathHelper.TwoPi</c> to draw a full circle.
+        /// </param>
+        /// <param name="sides">The number of line segments used to approximate the arc.</param>
+        /// <param name="color">The color of the arc.</param>
+        /// <param name="thickness">The thickness of the lines used.</param>
+        /// <param name="layerDepth">The depth of the layer of this shape.</param>
+        public static void DrawArc(this SpriteBatch spriteBatch, Vector2 center, float radius, float startAngle, float sweepAngle, int sides, Color color, float thickness = 1f, float layerDepth = 0)
+        {
+            Texture2D texture = GetTexture(spriteBatch);
+            Vector2[] arc = CreateArc(radius, sides, startAngle, sweepAngle);
+
+            for (int i = 0; i < arc.Length - 1; i++)
+            {
+                DrawPolygonEdge(spriteBatch, texture, center + arc[i], center + arc[i + 1], color, thickness, layerDepth);
+            }
+        }
+
+        /// <summary>
+        /// Draws an arc outline.
+        /// </summary>
+        /// <param name="spriteBatch">The destination drawing surface.</param>
+        /// <param name="x">The center X of the arc.</param>
+        /// <param name="y">The center Y of the arc.</param>
+        /// <param name="radius">The radius of the arc.</param>
+        /// <param name="startAngle">The starting angle in radians.</param>
+        /// <param name="sweepAngle">
+        /// The sweep angle in radians. Positive values sweep counter-clockwise.
+        /// Use <c>MathHelper.TwoPi</c> to draw a full circle.
+        /// </param>
+        /// <param name="sides">The number of line segments used to approximate the arc.</param>
+        /// <param name="color">The color of the arc.</param>
+        /// <param name="thickness">The thickness of the lines used.</param>
+        /// <param name="layerDepth">The depth of the layer of this shape.</param>
+        public static void DrawArc(this SpriteBatch spriteBatch, float x, float y, float radius, float startAngle, float sweepAngle, int sides, Color color, float thickness = 1f, float layerDepth = 0)
+        {
+            DrawArc(spriteBatch, new Vector2(x, y), radius, startAngle, sweepAngle, sides, color, thickness, layerDepth);
+        }
+
+        private static Vector2[] CreateArc(float radius, int sides, float startAngle, float sweepAngle)
+        {
+            Vector2[] points = new Vector2[sides + 1];
+            float step = sweepAngle / sides;
+            float theta = startAngle;
+
+            for (int i = 0; i <= sides; i++, theta += step)
+            {
+                points[i] = new Vector2((float)(radius * Math.Cos(theta)), (float)(radius * Math.Sin(theta)));
+            }
+
+            return points;
+        }
+
         private static Vector2[] CreateCircle(double radius, int sides)
         {
             const double max = 2.0 * Math.PI;

--- a/source/MonoGame.Extended/Math/ShapeExtensions.cs
+++ b/source/MonoGame.Extended/Math/ShapeExtensions.cs
@@ -7,8 +7,30 @@ using MonoGame.Extended.Shapes;
 namespace MonoGame.Extended
 {
     /// <summary>
-    ///     Sprite batch extensions for drawing primitive shapes
+    /// Provides <see cref="SpriteBatch"/> extension methods for drawing primitive shape outlines.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These methods are intended for <b>prototyping and debug visualization only</b>. They rely on
+    /// <see cref="SpriteBatch"/> and a 1×1 white pixel texture to approximate shapes, which has the following
+    /// known limitations:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///     Outline joints (corners) physically overlap. With semi-transparent colors this causes visible
+    ///     double-blending artifacts at each joint.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Filled shape drawing is not supported here. For filled shapes with correct alpha blending use
+    ///     <see cref="MonoGame.Extended.VectorDraw.PrimitiveDrawing"/> with a
+    ///     <see cref="MonoGame.Extended.VectorDraw.PrimitiveBatch"/>.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    /// </remarks>
     public static class ShapeExtensions
     {
         private static Texture2D _whitePixelTexture;

--- a/source/MonoGame.Extended/VectorDraw/PrimitiveBatch.cs
+++ b/source/MonoGame.Extended/VectorDraw/PrimitiveBatch.cs
@@ -29,6 +29,7 @@ namespace MonoGame.Extended.VectorDraw
         private readonly GraphicsDevice _device;
         private readonly VertexPositionColor[] _lineVertices;
         private readonly VertexPositionColor[] _triangleVertices;
+        private BlendState _previousBlendState;
         private bool _hasBegun;
         private bool _isDisposed;
         private int _lineVertsCount;
@@ -85,15 +86,23 @@ namespace MonoGame.Extended.VectorDraw
         /// </summary>
         /// <param name="projection">The projection matrix.</param>
         /// <param name="view">The view matrix.</param>
+        /// <param name="blendState">
+        /// The <see cref="BlendState"/> to use while drawing. Defaults to
+        /// <see cref="BlendState.NonPremultiplied"/>, which correctly blends vertex colors specified
+        /// as straight (non-premultiplied) alpha. Pass <see langword="null"/> to use the default.
+        /// </param>
         /// <exception cref="InvalidOperationException">
         /// <see cref="End"/> must be called before <see cref="Begin"/> can be called again.
         /// </exception>
-        public void Begin(ref Matrix projection, ref Matrix view)
+        public void Begin(ref Matrix projection, ref Matrix view, BlendState blendState = null)
         {
             if (_hasBegun)
             {
                 throw new InvalidOperationException("End must be called before Begin can be called again.");
             }
+
+            _previousBlendState = _device.BlendState;
+            _device.BlendState = blendState ?? BlendState.NonPremultiplied;
 
             _basicEffect.Projection = projection;
             _basicEffect.View = view;
@@ -165,6 +174,7 @@ namespace MonoGame.Extended.VectorDraw
 
             FlushTriangles();
             FlushLines();
+            _device.BlendState = _previousBlendState;
             _hasBegun = false;
         }
 

--- a/source/MonoGame.Extended/VectorDraw/PrimitiveBatch.cs
+++ b/source/MonoGame.Extended/VectorDraw/PrimitiveBatch.cs
@@ -1,115 +1,138 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
+// Copyright (c) Craftwork Games. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+// Adapted from Velcro Physics (formerly known as Farseer Physics).
+// Used with permission: https://github.com/craftworkgames/MonoGame.Extended/issues/574
+
 using System;
-using System.Collections.Generic;
-using System.Text;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.VectorDraw
 {
-    //Taken from Velcro Physics
-    //Used with permission: https://github.com/craftworkgames/MonoGame.Extended/issues/574
-
+    /// <summary>
+    /// A low-level primitive batch that renders colored lines and filled triangles directly to the GPU using
+    /// <see cref="BasicEffect"/> with vertex colors.
+    /// </summary>
+    /// <remarks>
+    /// Call <see cref="Begin"/> before adding vertices and <see cref="End"/> to flush all pending geometry to the GPU.
+    /// This class is the underlying renderer used by <see cref="PrimitiveDrawing"/>. For drawing shapes via
+    /// <see cref="SpriteBatch"/> for debug or prototype purposes, see <c>ShapeExtensions</c>.
+    /// </remarks>
     public class PrimitiveBatch : IDisposable
     {
-        private const int DefaultBufferSize = 500;
+        private const int DEFAULT_BUFFER_SIZE = 500;
 
-        // a basic effect, which contains the shaders that we will use to draw our
-        // primitives.
         private readonly BasicEffect _basicEffect;
-
-        // the device that we will issue draw calls to.
         private readonly GraphicsDevice _device;
-
         private readonly VertexPositionColor[] _lineVertices;
         private readonly VertexPositionColor[] _triangleVertices;
-
-        // hasBegun is flipped to true once Begin is called, and is used to make
-        // sure users don't call End before Begin is called.
         private bool _hasBegun;
-
         private bool _isDisposed;
         private int _lineVertsCount;
         private int _triangleVertsCount;
 
-        public PrimitiveBatch(GraphicsDevice graphicsDevice, int bufferSize = DefaultBufferSize)
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrimitiveBatch"/>.
+        /// </summary>
+        /// <param name="graphicsDevice">The graphics device used to issue draw calls.</param>
+        /// <param name="bufferSize">
+        /// The maximum number of vertices buffered before an automatic flush occurs. Defaults to 500.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice"/> is <see langword="null"/>.</exception>
+        public PrimitiveBatch(GraphicsDevice graphicsDevice, int bufferSize = DEFAULT_BUFFER_SIZE)
         {
-            if (graphicsDevice == null)
-                throw new ArgumentNullException(nameof(graphicsDevice));
+            ArgumentNullException.ThrowIfNull(graphicsDevice);
 
             _device = graphicsDevice;
-
             _triangleVertices = new VertexPositionColor[bufferSize - bufferSize % 3];
             _lineVertices = new VertexPositionColor[bufferSize - bufferSize % 2];
 
-            // set up a new basic effect, and enable vertex colors.
             _basicEffect = new BasicEffect(graphicsDevice);
             _basicEffect.VertexColorEnabled = true;
         }
 
-        #region IDisposable Members
-
+        /// <inheritdoc/>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        #endregion
-
+        /// <summary>
+        /// Sets the projection matrix applied during rendering.
+        /// </summary>
+        /// <param name="projection">The projection matrix to apply.</param>
         public void SetProjection(ref Matrix projection)
         {
             _basicEffect.Projection = projection;
         }
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing && !_isDisposed)
-            {
-                if (_basicEffect != null)
-                    _basicEffect.Dispose();
-
-                _isDisposed = true;
-            }
-        }
-
         /// <summary>
-        /// Begin is called to tell the PrimitiveBatch what kind of primitives will be
-        /// drawn, and to prepare the graphics card to render those primitives.
+        /// Returns <see langword="true"/> if <see cref="Begin"/> has been called and <see cref="End"/> has not yet
+        /// been called; otherwise <see langword="false"/>.
         /// </summary>
-        /// <param name="projection">The projection.</param>
-        /// <param name="view">The view.</param>
-        public void Begin(ref Matrix projection, ref Matrix view)
-        {
-            if (_hasBegun)
-                throw new InvalidOperationException("End must be called before Begin can be called again.");
-
-            //tell our basic effect to begin.
-            _basicEffect.Projection = projection;
-            _basicEffect.View = view;
-            _basicEffect.CurrentTechnique.Passes[0].Apply();
-
-            // flip the error checking boolean. It's now ok to call AddVertex, Flush,
-            // and End.
-            _hasBegun = true;
-        }
-
         public bool IsReady()
         {
             return _hasBegun;
         }
 
+        /// <summary>
+        /// Begins a new batch, setting the view and projection matrices for this frame.
+        /// Must be called before any <see cref="AddVertex"/> calls.
+        /// </summary>
+        /// <param name="projection">The projection matrix.</param>
+        /// <param name="view">The view matrix.</param>
+        /// <exception cref="InvalidOperationException">
+        /// <see cref="End"/> must be called before <see cref="Begin"/> can be called again.
+        /// </exception>
+        public void Begin(ref Matrix projection, ref Matrix view)
+        {
+            if (_hasBegun)
+            {
+                throw new InvalidOperationException("End must be called before Begin can be called again.");
+            }
+
+            _basicEffect.Projection = projection;
+            _basicEffect.View = view;
+            _basicEffect.CurrentTechnique.Passes[0].Apply();
+            _hasBegun = true;
+        }
+
+        /// <summary>
+        /// Adds a single vertex to the current batch.
+        /// </summary>
+        /// <param name="vertex">The 2D position of the vertex.</param>
+        /// <param name="color">The color of the vertex.</param>
+        /// <param name="primitiveType">
+        /// The primitive type this vertex belongs to. Only <see cref="PrimitiveType.TriangleList"/> and
+        /// <see cref="PrimitiveType.LineList"/> are supported.
+        /// </param>
+        /// <exception cref="InvalidOperationException"><see cref="Begin"/> must be called before adding vertices.</exception>
+        /// <exception cref="NotSupportedException">
+        /// <paramref name="primitiveType"/> is <see cref="PrimitiveType.LineStrip"/> or
+        /// <see cref="PrimitiveType.TriangleStrip"/>.
+        /// </exception>
         public void AddVertex(Vector2 vertex, Color color, PrimitiveType primitiveType)
         {
             if (!_hasBegun)
+            {
                 throw new InvalidOperationException("Begin must be called before AddVertex can be called.");
+            }
 
             if (primitiveType == PrimitiveType.LineStrip || primitiveType == PrimitiveType.TriangleStrip)
+            {
                 throw new NotSupportedException("The specified primitiveType is not supported by PrimitiveBatch.");
+            }
 
             if (primitiveType == PrimitiveType.TriangleList)
             {
                 if (_triangleVertsCount >= _triangleVertices.Length)
+                {
                     FlushTriangles();
+                }
 
                 _triangleVertices[_triangleVertsCount].Position = new Vector3(vertex, -0.1f);
                 _triangleVertices[_triangleVertsCount].Color = color;
@@ -119,7 +142,9 @@ namespace MonoGame.Extended.VectorDraw
             if (primitiveType == PrimitiveType.LineList)
             {
                 if (_lineVertsCount >= _lineVertices.Length)
+                {
                     FlushLines();
+                }
 
                 _lineVertices[_lineVertsCount].Position = new Vector3(vertex, 0f);
                 _lineVertices[_lineVertsCount].Color = color;
@@ -128,10 +153,9 @@ namespace MonoGame.Extended.VectorDraw
         }
 
         /// <summary>
-        /// End is called once all the primitives have been drawn using AddVertex.
-        /// it will call Flush to actually submit the draw call to the graphics card, and
-        /// then tell the basic effect to end.
+        /// Flushes all pending geometry to the GPU and ends the current batch.
         /// </summary>
+        /// <exception cref="InvalidOperationException"><see cref="Begin"/> must be called before <see cref="End"/>.</exception>
         public void End()
         {
             if (!_hasBegun)
@@ -139,11 +163,29 @@ namespace MonoGame.Extended.VectorDraw
                 throw new InvalidOperationException("Begin must be called before End can be called.");
             }
 
-            // Draw whatever the user wanted us to draw
             FlushTriangles();
             FlushLines();
-
             _hasBegun = false;
+        }
+
+        /// <summary>
+        /// Releases all managed and unmanaged resources used by this <see cref="PrimitiveBatch"/>.
+        /// </summary>
+        /// <param name="disposing">
+        /// <see langword="true"/> to release managed resources; <see langword="false"/> to release only unmanaged
+        /// resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing && !_isDisposed)
+            {
+                if (_basicEffect != null)
+                {
+                    _basicEffect.Dispose();
+                }
+
+                _isDisposed = true;
+            }
         }
 
         private void FlushTriangles()
@@ -152,11 +194,10 @@ namespace MonoGame.Extended.VectorDraw
             {
                 throw new InvalidOperationException("Begin must be called before Flush can be called.");
             }
+
             if (_triangleVertsCount >= 3)
             {
                 int primitiveCount = _triangleVertsCount / 3;
-
-                // submit the draw call to the graphics card
                 _device.SamplerStates[0] = SamplerState.AnisotropicClamp;
                 _device.DrawUserPrimitives(PrimitiveType.TriangleList, _triangleVertices, 0, primitiveCount);
                 _triangleVertsCount -= primitiveCount * 3;
@@ -169,11 +210,10 @@ namespace MonoGame.Extended.VectorDraw
             {
                 throw new InvalidOperationException("Begin must be called before Flush can be called.");
             }
+
             if (_lineVertsCount >= 2)
             {
                 int primitiveCount = _lineVertsCount / 2;
-
-                // submit the draw call to the graphics card
                 _device.SamplerStates[0] = SamplerState.AnisotropicClamp;
                 _device.DrawUserPrimitives(PrimitiveType.LineList, _lineVertices, 0, primitiveCount);
                 _lineVertsCount -= primitiveCount * 2;

--- a/source/MonoGame.Extended/VectorDraw/PrimitiveDrawing.cs
+++ b/source/MonoGame.Extended/VectorDraw/PrimitiveDrawing.cs
@@ -1,51 +1,88 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using MonoGame.Extended.Triangulation;
+// Copyright (c) Craftwork Games. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+// Adapted from Velcro Physics (formerly known as Farseer Physics).
+// Used with permission: https://github.com/craftworkgames/MonoGame.Extended/issues/574
+
 using System;
-using System.Collections.Generic;
-using System.Text;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using MonoGame.Extended.Triangulation;
 
 namespace MonoGame.Extended.VectorDraw
 {
+    /// <summary>
+    /// Provides methods for drawing primitive shapes using a <see cref="PrimitiveBatch"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class renders filled shapes and outlines directly via the GPU, producing correct alpha-blended
+    /// results even with semi-transparent colors. For quick outline-only drawing via <see cref="SpriteBatch"/>
+    /// during prototyping or debugging, see <c>ShapeExtensions</c>.
+    /// </para>
+    /// <para>
+    /// Call <see cref="PrimitiveBatch.Begin"/> on the associated <see cref="PrimitiveBatch"/> before issuing any
+    /// draw calls, and <see cref="PrimitiveBatch.End"/> when finished to flush geometry to the GPU.
+    /// </para>
+    /// </remarks>
     public class PrimitiveDrawing
     {
-        //Drawing
-        private PrimitiveBatch _primitiveBatch;
-
-        private SpriteBatch _batch;
-        private SpriteFont _font;
-        private GraphicsDevice _device;
-        private readonly Vector2[] _tempVertices = new Vector2[1000]; //TODO: something else...
-
-        //private Matrix _localProjection;
-        //private Matrix _localView;
-
-        //TODO: do we need to split this based on platform?
+        /// <summary>
+        /// The default number of segments used when approximating circles and ellipses.
+        /// </summary>
 #if XBOX || WINDOWS_PHONE
         public const int CircleSegments = 16;
 #else
         public const int CircleSegments = 32;
 #endif
 
+        private readonly PrimitiveBatch _primitiveBatch;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrimitiveDrawing"/>.
+        /// </summary>
+        /// <param name="primitiveBatch">The <see cref="PrimitiveBatch"/> used to issue draw calls.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="primitiveBatch"/> is <see langword="null"/>.</exception>
         public PrimitiveDrawing(PrimitiveBatch primitiveBatch)
         {
+            ArgumentNullException.ThrowIfNull(primitiveBatch);
             _primitiveBatch = primitiveBatch;
         }
 
+        /// <summary>
+        /// Draws a single point at the specified position.
+        /// </summary>
+        /// <param name="center">The position of the point.</param>
+        /// <param name="color">The color of the point.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawPoint(Vector2 center, Color color)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
-            //Add two points or the PrimitiveBatch acts up
             _primitiveBatch.AddVertex(center, color, PrimitiveType.LineList);
             _primitiveBatch.AddVertex(center, color, PrimitiveType.LineList);
         }
 
+        /// <summary>
+        /// Draws a rectangle outline.
+        /// </summary>
+        /// <param name="location">The top-left position of the rectangle in world space.</param>
+        /// <param name="width">The width of the rectangle.</param>
+        /// <param name="height">The height of the rectangle.</param>
+        /// <param name="color">The color of the outline.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawRectangle(Vector2 location, float width, float height, Color color)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
             Vector2[] rectVerts = new Vector2[4]
             {
@@ -55,14 +92,23 @@ namespace MonoGame.Extended.VectorDraw
                 new Vector2(0, height)
             };
 
-            //Location is offset here
             DrawPolygon(location, rectVerts, color);
         }
 
+        /// <summary>
+        /// Draws a solid (filled) rectangle.
+        /// </summary>
+        /// <param name="location">The top-left position of the rectangle in world space.</param>
+        /// <param name="width">The width of the rectangle.</param>
+        /// <param name="height">The height of the rectangle.</param>
+        /// <param name="color">The fill color.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawSolidRectangle(Vector2 location, float width, float height, Color color)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
             Vector2[] rectVerts = new Vector2[4]
             {
@@ -75,12 +121,21 @@ namespace MonoGame.Extended.VectorDraw
             DrawSolidPolygon(location, rectVerts, color);
         }
 
-            public void DrawCircle(Vector2 center, float radius, Color color)
+        /// <summary>
+        /// Draws a circle outline using <see cref="CircleSegments"/> segments.
+        /// </summary>
+        /// <param name="center">The center of the circle.</param>
+        /// <param name="radius">The radius of the circle.</param>
+        /// <param name="color">The color of the outline.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
+        public void DrawCircle(Vector2 center, float radius, Color color)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
-            const double increment = Math.PI * 2.0 / CircleSegments;
+            double increment = Math.PI * 2.0 / CircleSegments;
             double theta = 0.0;
 
             for (int i = 0; i < CircleSegments; i++)
@@ -95,39 +150,35 @@ namespace MonoGame.Extended.VectorDraw
             }
         }
 
+        /// <summary>
+        /// Draws a solid (filled) circle with an outline using <see cref="CircleSegments"/> segments.
+        /// The fill and outline use the same color.
+        /// </summary>
+        /// <param name="center">The center of the circle.</param>
+        /// <param name="radius">The radius of the circle.</param>
+        /// <param name="color">The color used for both the fill and the outline.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawSolidCircle(Vector2 center, float radius, Color color)
         {
-            if (!_primitiveBatch.IsReady())
-                throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
-
-            const double increment = Math.PI * 2.0 / CircleSegments;
-            double theta = 0.0;
-
-            Color colorFill = color * 0.5f;
-
-            Vector2 v0 = center + radius * new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta));
-            theta += increment;
-
-            for (int i = 1; i < CircleSegments - 1; i++)
-            {
-                Vector2 v1 = center + radius * new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta));
-                Vector2 v2 = center + radius * new Vector2((float)Math.Cos(theta + increment), (float)Math.Sin(theta + increment));
-
-                _primitiveBatch.AddVertex(v0, colorFill, PrimitiveType.TriangleList);
-                _primitiveBatch.AddVertex(v1, colorFill, PrimitiveType.TriangleList);
-                _primitiveBatch.AddVertex(v2, colorFill, PrimitiveType.TriangleList);
-
-                theta += increment;
-            }
-
-            DrawCircle(center, radius, color);            
+            DrawSolidCircle(center, radius, color, color);
         }
-        public void DrawSolidCircle(Vector2 center, float radius, Color color, Color fillcolor)
+
+        /// <summary>
+        /// Draws a solid (filled) circle with an outline using <see cref="CircleSegments"/> segments.
+        /// </summary>
+        /// <param name="center">The center of the circle.</param>
+        /// <param name="radius">The radius of the circle.</param>
+        /// <param name="color">The color of the outline.</param>
+        /// <param name="fillColor">The color of the fill.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
+        public void DrawSolidCircle(Vector2 center, float radius, Color color, Color fillColor)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
-            const double increment = Math.PI * 2.0 / CircleSegments;
+            double increment = Math.PI * 2.0 / CircleSegments;
             double theta = 0.0;
 
             Vector2 v0 = center + radius * new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta));
@@ -138,9 +189,9 @@ namespace MonoGame.Extended.VectorDraw
                 Vector2 v1 = center + radius * new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta));
                 Vector2 v2 = center + radius * new Vector2((float)Math.Cos(theta + increment), (float)Math.Sin(theta + increment));
 
-                _primitiveBatch.AddVertex(v0, fillcolor, PrimitiveType.TriangleList);
-                _primitiveBatch.AddVertex(v1, fillcolor, PrimitiveType.TriangleList);
-                _primitiveBatch.AddVertex(v2, fillcolor, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(v0, fillColor, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(v1, fillColor, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(v2, fillColor, PrimitiveType.TriangleList);
 
                 theta += increment;
             }
@@ -148,40 +199,167 @@ namespace MonoGame.Extended.VectorDraw
             DrawCircle(center, radius, color);
         }
 
+        /// <summary>
+        /// Draws an arc outline.
+        /// </summary>
+        /// <param name="center">The center point of the arc.</param>
+        /// <param name="radius">The radius of the arc.</param>
+        /// <param name="startAngle">The starting angle in radians.</param>
+        /// <param name="sweepAngle">
+        /// The sweep angle in radians. Positive values sweep counter-clockwise.
+        /// Use <c>MathHelper.TwoPi</c> to draw a full circle.
+        /// </param>
+        /// <param name="sides">The number of line segments used to approximate the arc.</param>
+        /// <param name="color">The color of the arc.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
+        public void DrawArc(Vector2 center, float radius, float startAngle, float sweepAngle, int sides, Color color)
+        {
+            if (!_primitiveBatch.IsReady())
+            {
+                throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
+
+            float step = sweepAngle / sides;
+            float theta = startAngle;
+
+            for (int i = 0; i < sides; i++)
+            {
+                Vector2 v1 = center + radius * new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta));
+                Vector2 v2 = center + radius * new Vector2((float)Math.Cos(theta + step), (float)Math.Sin(theta + step));
+
+                _primitiveBatch.AddVertex(v1, color, PrimitiveType.LineList);
+                _primitiveBatch.AddVertex(v2, color, PrimitiveType.LineList);
+
+                theta += step;
+            }
+        }
+
+        /// <summary>
+        /// Draws a solid (filled) arc (pie slice) with an outline. The fill and outline use the same color.
+        /// </summary>
+        /// <param name="center">The center point of the arc.</param>
+        /// <param name="radius">The radius of the arc.</param>
+        /// <param name="startAngle">The starting angle in radians.</param>
+        /// <param name="sweepAngle">
+        /// The sweep angle in radians. Positive values sweep counter-clockwise.
+        /// Use <c>MathHelper.TwoPi</c> for a full circle.
+        /// </param>
+        /// <param name="sides">The number of triangle segments used to fill the arc.</param>
+        /// <param name="color">The color used for both the fill and the outline.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
+        public void DrawSolidArc(Vector2 center, float radius, float startAngle, float sweepAngle, int sides, Color color)
+        {
+            DrawSolidArc(center, radius, startAngle, sweepAngle, sides, color, color);
+        }
+
+        /// <summary>
+        /// Draws a solid (filled) arc (pie slice) with an outline.
+        /// </summary>
+        /// <param name="center">The center point of the arc.</param>
+        /// <param name="radius">The radius of the arc.</param>
+        /// <param name="startAngle">The starting angle in radians.</param>
+        /// <param name="sweepAngle">
+        /// The sweep angle in radians. Positive values sweep counter-clockwise.
+        /// Use <c>MathHelper.TwoPi</c> for a full circle.
+        /// </param>
+        /// <param name="sides">The number of triangle segments used to fill the arc.</param>
+        /// <param name="color">The color of the outline.</param>
+        /// <param name="fillColor">The color of the fill.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
+        public void DrawSolidArc(Vector2 center, float radius, float startAngle, float sweepAngle, int sides, Color color, Color fillColor)
+        {
+            if (!_primitiveBatch.IsReady())
+            {
+                throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
+
+            float step = sweepAngle / sides;
+            float theta = startAngle;
+
+            for (int i = 0; i < sides; i++)
+            {
+                Vector2 v1 = center + radius * new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta));
+                Vector2 v2 = center + radius * new Vector2((float)Math.Cos(theta + step), (float)Math.Sin(theta + step));
+
+                _primitiveBatch.AddVertex(center, fillColor, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(v1, fillColor, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(v2, fillColor, PrimitiveType.TriangleList);
+
+                theta += step;
+            }
+
+            DrawArc(center, radius, startAngle, sweepAngle, sides, color);
+        }
+
+        /// <summary>
+        /// Draws a line segment between two points.
+        /// </summary>
+        /// <param name="start">The start point.</param>
+        /// <param name="end">The end point.</param>
+        /// <param name="color">The color of the line.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawSegment(Vector2 start, Vector2 end, Color color)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
             _primitiveBatch.AddVertex(start, color, PrimitiveType.LineList);
             _primitiveBatch.AddVertex(end, color, PrimitiveType.LineList);
         }
 
+        /// <summary>
+        /// Draws a polygon outline.
+        /// </summary>
+        /// <param name="position">The world offset applied to all vertices.</param>
+        /// <param name="vertices">The polygon vertices in local space.</param>
+        /// <param name="color">The color of the outline.</param>
+        /// <param name="closed">
+        /// When <see langword="true"/>, an edge is drawn between the last and first vertex to close the polygon.
+        /// Defaults to <see langword="true"/>.
+        /// </param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawPolygon(Vector2 position, Vector2[] vertices, Color color, bool closed = true)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
             int count = vertices.Length;
 
             for (int i = 0; i < count - 1; i++)
             {
-                //translate the vertices according to the position passed
                 _primitiveBatch.AddVertex(new Vector2(vertices[i].X + position.X, vertices[i].Y + position.Y), color, PrimitiveType.LineList);
                 _primitiveBatch.AddVertex(new Vector2(vertices[i + 1].X + position.X, vertices[i + 1].Y + position.Y), color, PrimitiveType.LineList);
             }
+
             if (closed)
             {
-                //TODO: verify closed is working as expected
                 _primitiveBatch.AddVertex(new Vector2(vertices[count - 1].X + position.X, vertices[count - 1].Y + position.Y), color, PrimitiveType.LineList);
                 _primitiveBatch.AddVertex(new Vector2(vertices[0].X + position.X, vertices[0].Y + position.Y), color, PrimitiveType.LineList);
             }
         }
 
+        /// <summary>
+        /// Draws a solid (filled) polygon with an optional outline.
+        /// </summary>
+        /// <param name="position">The world offset applied to all vertices.</param>
+        /// <param name="vertices">The polygon vertices in local space.</param>
+        /// <param name="color">
+        /// The fill color. When <paramref name="outline"/> is <see langword="true"/>, also used for the outline.
+        /// </param>
+        /// <param name="outline">
+        /// When <see langword="true"/>, an outline is drawn over the filled polygon. Defaults to <see langword="true"/>.
+        /// </param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawSolidPolygon(Vector2 position, Vector2[] vertices, Color color, bool outline = true)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
             int count = vertices.Length;
 
@@ -191,37 +369,60 @@ namespace MonoGame.Extended.VectorDraw
                 return;
             }
 
-            Color colorFill = color * (outline ? 0.5f : 1.0f);
-
             Vector2[] outVertices;
             int[] outIndices;
             Triangulator.Triangulate(vertices, WindingOrder.CounterClockwise, out outVertices, out outIndices);
 
-            for(int i = 0; i < outIndices.Length - 2; i += 3)
+            for (int i = 0; i < outIndices.Length - 2; i += 3)
             {
-                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i]].X + position.X, outVertices[outIndices[i]].Y + position.Y), colorFill, PrimitiveType.TriangleList);
-                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i + 1]].X + position.X, outVertices[outIndices[i + 1]].Y + position.Y), colorFill, PrimitiveType.TriangleList);
-                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i + 2]].X + position.X, outVertices[outIndices[i + 2]].Y + position.Y), colorFill, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i]].X + position.X, outVertices[outIndices[i]].Y + position.Y), color, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i + 1]].X + position.X, outVertices[outIndices[i + 1]].Y + position.Y), color, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i + 2]].X + position.X, outVertices[outIndices[i + 2]].Y + position.Y), color, PrimitiveType.TriangleList);
             }
 
             if (outline)
+            {
                 DrawPolygon(position, vertices, color);
+            }
         }
 
+        /// <summary>
+        /// Draws an ellipse outline.
+        /// </summary>
+        /// <param name="center">The center of the ellipse.</param>
+        /// <param name="radius">The horizontal (X) and vertical (Y) radii of the ellipse.</param>
+        /// <param name="sides">The number of line segments used to approximate the ellipse.</param>
+        /// <param name="color">The color of the outline.</param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawEllipse(Vector2 center, Vector2 radius, int sides, Color color)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
+            }
 
             DrawPolygon(center, CreateEllipse(radius.X, radius.Y, sides), color);
         }
 
+        /// <summary>
+        /// Draws a solid (filled) ellipse with an optional outline.
+        /// </summary>
+        /// <param name="center">The center of the ellipse.</param>
+        /// <param name="radius">The horizontal (X) and vertical (Y) radii of the ellipse.</param>
+        /// <param name="sides">The number of segments used to approximate the ellipse.</param>
+        /// <param name="color">
+        /// The fill color. When <paramref name="outline"/> is <see langword="true"/>, also used for the outline.
+        /// </param>
+        /// <param name="outline">
+        /// When <see langword="true"/>, an outline is drawn over the filled ellipse. Defaults to <see langword="true"/>.
+        /// </param>
+        /// <exception cref="InvalidOperationException"><see cref="PrimitiveBatch.Begin"/> must be called first.</exception>
         public void DrawSolidEllipse(Vector2 center, Vector2 radius, int sides, Color color, bool outline = true)
         {
             if (!_primitiveBatch.IsReady())
+            {
                 throw new InvalidOperationException("BeginCustomDraw must be called before drawing anything.");
-
-            Color colorFill = color * (outline ? 0.5f : 1.0f);
+            }
 
             Vector2[] vertices = CreateEllipse(radius.X, radius.Y, sides);
 
@@ -231,24 +432,28 @@ namespace MonoGame.Extended.VectorDraw
 
             for (int i = 0; i < outIndices.Length - 2; i += 3)
             {
-                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i]].X + center.X, outVertices[outIndices[i]].Y + center.Y), colorFill, PrimitiveType.TriangleList);
-                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i + 1]].X + center.X, outVertices[outIndices[i + 1]].Y + center.Y), colorFill, PrimitiveType.TriangleList);
-                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i + 2]].X + center.X, outVertices[outIndices[i + 2]].Y + center.Y), colorFill, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i]].X + center.X, outVertices[outIndices[i]].Y + center.Y), color, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i + 1]].X + center.X, outVertices[outIndices[i + 1]].Y + center.Y), color, PrimitiveType.TriangleList);
+                _primitiveBatch.AddVertex(new Vector2(outVertices[outIndices[i + 2]].X + center.X, outVertices[outIndices[i + 2]].Y + center.Y), color, PrimitiveType.TriangleList);
+            }
+
+            if (outline)
+            {
+                DrawPolygon(center, vertices, color);
             }
         }
 
         private static Vector2[] CreateEllipse(float rx, float ry, int sides)
         {
-            var vertices = new Vector2[sides];
+            Vector2[] vertices = new Vector2[sides];
+            double t = 0.0;
+            double dt = 2.0 * Math.PI / sides;
 
-            var t = 0.0;
-            var dt = 2.0 * Math.PI / sides;
-            for (var i = 0; i < sides; i++, t += dt)
+            for (int i = 0; i < sides; i++, t += dt)
             {
-                var x = (float)(rx * Math.Cos(t));
-                var y = (float)(ry * Math.Sin(t));
-                vertices[i] = new Vector2(x, y);
+                vertices[i] = new Vector2((float)(rx * Math.Cos(t)), (float)(ry * Math.Sin(t)));
             }
+
             return vertices;
         }
     }


### PR DESCRIPTION
## Description

Fixes two bugs in `PrimitiveDrawing`/`PrimitiveBatch` that caused incorrect alpha rendering for filled shapes, adds arc drawing to both the GPU and SpriteBatch shape APIs, and deprecates the incomplete `Batcher2D` cluster.

<img width="802" height="632" alt="image" src="https://github.com/user-attachments/assets/c0af3810-f898-4cfe-9c16-0f47b861f935" />


## Related Issues/Tickets

- Closes #574

## Changes Made

**Bug fixes**

- `PrimitiveBatch.Begin()` now sets `BlendState.NonPremultiplied` by default  and restores the previous blend state on `End()`. Previously no `BlendState`  was set, causing the GPU to fall back to `BlendState.Opaque` after  `GraphicsDevice.Clear()`, which discarded alpha entirely and exposed  triangle fan geometry as visible seams in filled shapes.
- Removed the hardcoded `color * 0.5f` multiplication from `DrawSolidCircle`,  `DrawSolidPolygon`, and `DrawSolidEllipse` in `PrimitiveDrawing`. The fill  color passed by the caller is now used as-is.

**New API in `PrimitiveDrawing` (VectorDraw)**

- `DrawArc(center, radius, startAngle, sweepAngle, sides, color)`: outline arc
- `DrawSolidArc(center, radius, startAngle, sweepAngle, sides, color)`:" filled  pie-slice arc using a single color for both fill and outline
- `DrawSolidArc(center, radius, startAngle, sweepAngle, sides, outlineColor, fillColor)`: overload with separate fill and outline colors

**New API in `ShapeExtensions` (SpriteBatch)**

- `DrawArc(center, radius, startAngle, sweepAngle, sides, color, thickness, layerDepth)` : outline-only arc consistent with `DrawCircle`/`DrawEllipse`. Subject to the  same joint-overlap limitations as the rest of `ShapeExtensions`.

**Deprecations**

The following types were part of an incomplete `Batcher2D` implementation that was never finished. They have been marked `[Obsolete]` pending removal in a future major release. Use `SpriteBatch` with MonoGame.Extended's extension
methods instead.

- `Batcher<TDrawCallInfo>`
- `Batcher2D`
- `IBatchDrawCallInfo<T>`
- `GeometryBuilder`
- `GeometryBuilder2D`

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
