### PR TITLE
Expose ActiveTweens on Tweener and deprecate AllocationCount (#966)

### DIFF
--- a/source/MonoGame.Extended/Tweening/Tweener.cs
+++ b/source/MonoGame.Extended/Tweening/Tweener.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 using Microsoft.Xna.Framework;
 
@@ -34,9 +35,28 @@ namespace MonoGame.Extended.Tweening
 
         /// <summary>
         /// Gets the total number of tween and member allocations made since this instance was created.
-        /// Useful for tracking and debugging allocation behavior.
         /// </summary>
+        /// <remarks>
+        /// This counter only increments and never decrements, making it unreliable for tracking how
+        /// many tweens are currently active. Use <see cref="ActiveTweens"/> and its <c>Length</c>
+        /// property instead.
+        /// </remarks>
+        [Obsolete("AllocationCount is a broken cumulative counter that never decrements. Use ActiveTweens.Length to get the number of currently active tweens. This property will be removed in the next major version.")]
         public long AllocationCount { get; private set; }
+
+        /// <summary>
+        /// Returns a read-only view of the currently active tweens as a <see cref="ReadOnlySpan{T}"/>.
+        /// This is a zero-allocation snapshot: it does not copy the list and cannot be used to modify
+        /// tween state. Use <c>ActiveTweens.Length</c> to check how many tweens are running, or
+        /// iterate with a <c>foreach</c> to inspect them.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// if (tweener.ActiveTweens.Length == 0)
+        ///     OnAllTweensComplete();
+        /// </code>
+        /// </example>
+        public ReadOnlySpan<Tween> ActiveTweens => CollectionsMarshal.AsSpan(_activeTweens);
 
         private readonly List<Tween> _activeTweens = new List<Tween>();
 
@@ -94,7 +114,9 @@ namespace MonoGame.Extended.Tweening
 
             activeTween?.Cancel();
 
+#pragma warning disable CS0618
             AllocationCount++;
+#pragma warning restore CS0618
             var tween = (TTween)Activator.CreateInstance(typeof(TTween),
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null,
                 new object[]{target, duration, delay, member, toValue}, null);
@@ -176,7 +198,9 @@ namespace MonoGame.Extended.Tweening
         private TweenMember<T> CreateMember<T>(object target, string memberName)
             where T : struct
         {
+#pragma warning disable CS0618
             AllocationCount++;
+#pragma warning restore CS0618
 
             var type = target.GetType();
             var property = type.GetTypeInfo().GetProperty(memberName);

--- a/tests/MonoGame.Extended.Tests/Tweening/TweenerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tweening/TweenerTests.cs
@@ -12,4 +12,57 @@ public class TweenerTests
         var obj = new ColorHandler();
         tweener.TweenTo(obj, x => x.Color, Color.Red, 2f);
     }
+
+    [Fact]
+    public void ActiveTweens_EmptyWhenNoTweensStarted()
+    {
+        var tweener = new Tweener();
+        Assert.Equal(0, tweener.ActiveTweens.Length);
+    }
+
+    [Fact]
+    public void ActiveTweens_ReflectsNumberOfRunningTweens()
+    {
+        var tweener = new Tweener();
+        var obj = new FloatHandler();
+
+        tweener.TweenTo(obj, x => x.Value, 10f, 2f);
+        Assert.Equal(1, tweener.ActiveTweens.Length);
+
+        tweener.TweenTo(obj, x => x.Other, 5f, 2f);
+        Assert.Equal(2, tweener.ActiveTweens.Length);
+    }
+
+    [Fact]
+    public void ActiveTweens_DecreasesAfterTweenCompletes()
+    {
+        var tweener = new Tweener();
+        var obj = new FloatHandler();
+
+        tweener.TweenTo(obj, x => x.Value, 10f, 1f);
+        Assert.Equal(1, tweener.ActiveTweens.Length);
+
+        // Advance past the duration so the tween is removed on Update.
+        tweener.Update(2f);
+        Assert.Equal(0, tweener.ActiveTweens.Length);
+    }
+
+    [Fact]
+    public void ActiveTweens_EmptyAfterCancelAll()
+    {
+        var tweener = new Tweener();
+        var obj = new FloatHandler();
+
+        tweener.TweenTo(obj, x => x.Value, 10f, 2f);
+        tweener.CancelAll();
+        tweener.Update(0f);
+
+        Assert.Equal(0, tweener.ActiveTweens.Length);
+    }
+}
+
+file class FloatHandler
+{
+    public float Value { get; set; }
+    public float Other { get; set; }
 }


### PR DESCRIPTION
## Description

`Tweener` held a private `_activeTweens` list with no way for callers to inspect running tweens or know when all tweens had finished. This adds a zero allocation `ActiveTweens` property and deprecates the misleading `AllocationCount` property.

## Related Issues/Tickets

- Closes #966

## Changes Made

- Added `public ReadOnlySpan<Tween> ActiveTweens` to `Tweener` using `CollectionsMarshal.AsSpan` — zero-allocation, read-only, no copy of the underlying list.
- Marked `AllocationCount` as `[Obsolete]` with a message directing callers to `ActiveTweens.Length`. The property is preserved to avoid a breaking change and will be removed in the next major version.
- Added `#pragma warning` suppression around the two internal `AllocationCount++` sites so the build stays warning-clean.
- Added 4 new tests covering: empty on init, correct count with multiple tweens, count decreasing after `Update` completes a tween, and empty after `CancelAll`.

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
