### PR TITLE
Add OnUpdate callback to Tween (#992)

### DIFF
--- a/source/MonoGame.Extended/Tweening/Tween.cs
+++ b/source/MonoGame.Extended/Tweening/Tween.cs
@@ -144,6 +144,7 @@ namespace MonoGame.Extended.Tweening
         private int _remainingRepeats;
         private Action<Tween> _onBegin;
         private Action<Tween> _onEnd;
+        private Action<Tween> _onUpdate;
 
         /// <summary>
         /// Sets the easing function applied to the animation progress each frame.
@@ -157,6 +158,8 @@ namespace MonoGame.Extended.Tweening
 
         /// <summary>
         /// Registers a callback to invoke when the animation begins its first cycle.
+        /// Cast the <see cref="Tween"/> argument to <see cref="Tween{T}"/> and read
+        /// <c>Member.Value</c> to retrieve the typed current value.
         /// </summary>
         /// <param name="action">The callback to invoke, receiving this tween as its argument.</param>
         /// <returns>This tween instance, for fluent chaining.</returns>
@@ -164,10 +167,22 @@ namespace MonoGame.Extended.Tweening
 
         /// <summary>
         /// Registers a callback to invoke when the animation completes each cycle.
+        /// Cast the <see cref="Tween"/> argument to <see cref="Tween{T}"/> and read
+        /// <c>Member.Value</c> to retrieve the typed current value.
         /// </summary>
         /// <param name="action">The callback to invoke, receiving this tween as its argument.</param>
         /// <returns>This tween instance, for fluent chaining.</returns>
         public Tween OnEnd(Action<Tween> action) { _onEnd = action; return this; }
+
+        /// <summary>
+        /// Registers a callback to invoke after each update step, once the interpolated value
+        /// has been applied to the target member.
+        /// Cast the <see cref="Tween"/> argument to <see cref="Tween{T}"/> and read
+        /// <c>Member.Value</c> to retrieve the typed current value.
+        /// </summary>
+        /// <param name="action">The callback to invoke, receiving this tween as its argument.</param>
+        /// <returns>This tween instance, for fluent chaining.</returns>
+        public Tween OnUpdate(Action<Tween> action) { _onUpdate = action; return this; }
 
         /// <summary>
         /// Pauses the animation. Has no effect if already paused.
@@ -324,6 +339,7 @@ namespace MonoGame.Extended.Tweening
             }
 
             Interpolate(n);
+            _onUpdate?.Invoke(this);
 
             if (IsComplete)
                 _onEnd?.Invoke(this);

--- a/tests/MonoGame.Extended.Tests/Tweening/TweenerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tweening/TweenerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Xunit;
 
@@ -45,6 +46,26 @@ public class TweenerTests
         // Advance past the duration so the tween is removed on Update.
         tweener.Update(2f);
         Assert.Equal(0, tweener.ActiveTweens.Length);
+    }
+
+    [Fact]
+    public void OnUpdate_FiresAfterEachUpdateWithInterpolatedValue()
+    {
+        var tweener = new Tweener();
+        var obj = new FloatHandler();
+        var callCount = 0;
+        var recordedValues = new List<float>();
+
+        tweener.TweenTo(obj, x => x.Value, 10f, 1f)
+            .OnUpdate(_ => { callCount++; recordedValues.Add(obj.Value); });
+
+        tweener.Update(0.5f);
+        Assert.Equal(1, callCount);
+        Assert.Equal(5f, recordedValues[0]);
+
+        tweener.Update(0.5f);
+        Assert.Equal(2, callCount);
+        Assert.Equal(10f, recordedValues[1]);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adds an `OnUpdate` callback to the `Tween` base class that fires after each update step, once the interpolated value has been applied to the target member. This enables a proxy/adapter pattern for cases where the tween target is not directly accessible by reference, most notably ECS struct components, which cannot be passed by ref to the tweener.

## Related Issues/Tickets

* Closes #992

## Changes Made

* Added `private Action<Tween> _onUpdate` field to `Tween`
* Added `public Tween OnUpdate(Action<Tween> action)` fluent method, consistent with the existing `OnBegin` / `OnEnd` API
* `_onUpdate` is invoked in `Update()` immediately after `Interpolate(n)`, before `OnEnd`
* Updated `OnBegin` and `OnEnd` XML docs to include the same cast hint (`Tween<T>.Member.Value`) already present on `OnUpdate`
* Added `OnUpdate_FiresAfterEachUpdateWithInterpolatedValue` test to `TweenerTests`

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
