### PR TITLE
Add OnActivated and OnDeactivated lifecycle hooks to Screen (#1090)

### DIFF
--- a/source/MonoGame.Extended/Screens/Screen.cs
+++ b/source/MonoGame.Extended/Screens/Screen.cs
@@ -90,6 +90,28 @@ public abstract class Screen : IDisposable
     public virtual void UnloadContent() { }
 
     /// <summary>
+    /// Called every time this screen becomes the active (top) screen.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="Initialize"/>, this method is called every time the screen becomes active, including when
+    /// it is returned to after being cached in the screen stack.  Use this for logic that should run on every
+    /// activation, such as refreshing UI state or clearing transient data.
+    /// The base implementation does nothing.
+    /// </remarks>
+    public virtual void OnActivated() { }
+
+    /// <summary>
+    /// Called every time this screen is no longer the active (top) screen.
+    /// </summary>
+    /// <remarks>
+    /// This is called both when another screen is pushed on top of this screen and when this screen is closed or
+    /// removed from the screen stack.  Use this for logic that should run on every deactivation, such as pausing
+    /// audio or clearing UI state.
+    /// The base implementation does nothing.
+    /// </remarks>
+    public virtual void OnDeactivated() { }
+
+    /// <summary>
     /// Updates the screen's logic.
     /// </summary>
     /// <param name="gameTime">Provides a snapshot of timing values.</param>

--- a/source/MonoGame.Extended/Screens/ScreenManager.cs
+++ b/source/MonoGame.Extended/Screens/ScreenManager.cs
@@ -78,12 +78,14 @@ public class ScreenManager : SimpleDrawableGameComponent
         if (_activeScreen != null)
         {
             _activeScreen.IsActive = false;
+            _activeScreen.OnDeactivated();
         }
 
         screen.ScreenManager = this;
         screen.IsActive = true;
         screen.Initialize();
         screen.LoadContent();
+        screen.OnActivated();
 
         _screens.Push(screen);
         _activeScreen = screen;
@@ -128,6 +130,7 @@ public class ScreenManager : SimpleDrawableGameComponent
         }
 
         screen.IsActive = false;
+        screen.OnDeactivated();
         screen.UnloadContent();
         screen.Dispose();
 
@@ -136,6 +139,7 @@ public class ScreenManager : SimpleDrawableGameComponent
         if (_screens.TryPeek(out _activeScreen))
         {
             _activeScreen.IsActive = true;
+            _activeScreen.OnActivated();
         }
     }
 
@@ -226,7 +230,12 @@ public class ScreenManager : SimpleDrawableGameComponent
     {
         while (_screens.TryPop(out Screen screen))
         {
+            bool wasActive = screen.IsActive;
             screen.IsActive = false;
+            if (wasActive)
+            {
+                screen.OnDeactivated();
+            }
             screen.UnloadContent();
             screen.Dispose();
         }

--- a/tests/MonoGame.Extended.Tests/Screens/ScreenManagerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Screens/ScreenManagerTests.cs
@@ -385,10 +385,16 @@ public sealed class ScreenManagerTests
         manager.ShowScreen(screen2);
         manager.ShowScreen(screen3);
 
+        // Snapshot counts before clear — inactive screens already received
+        // OnDeactivated when a new screen was pushed on top of them.
+        int screen1CountBefore = screen1.DeactivatedCallCount;
+        int screen2CountBefore = screen2.DeactivatedCallCount;
+
         manager.ClearScreens();
 
-        Assert.Equal(0, screen1.DeactivatedCallCount);
-        Assert.Equal(0, screen2.DeactivatedCallCount);
+        // ClearScreens must not trigger additional OnDeactivated on already-inactive screens.
+        Assert.Equal(screen1CountBefore, screen1.DeactivatedCallCount);
+        Assert.Equal(screen2CountBefore, screen2.DeactivatedCallCount);
         Assert.Equal(1, screen3.DeactivatedCallCount);
     }
 

--- a/tests/MonoGame.Extended.Tests/Screens/ScreenManagerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Screens/ScreenManagerTests.cs
@@ -316,6 +316,84 @@ public sealed class ScreenManagerTests
 
     #endregion
 
+    #region OnActivated / OnDeactivated Tests
+
+    [Fact]
+    public void ShowScreen_FirstScreen_CallsOnActivated()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen = new TestScreen("Screen1");
+
+        manager.ShowScreen(screen);
+
+        Assert.Equal(1, screen.ActivatedCallCount);
+        Assert.Equal(0, screen.DeactivatedCallCount);
+    }
+
+    [Fact]
+    public void ShowScreen_SecondScreen_CallsOnDeactivatedOnFirstAndOnActivatedOnSecond()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+
+        Assert.Equal(1, screen1.ActivatedCallCount);
+        Assert.Equal(1, screen1.DeactivatedCallCount);
+        Assert.Equal(1, screen2.ActivatedCallCount);
+        Assert.Equal(0, screen2.DeactivatedCallCount);
+    }
+
+    [Fact]
+    public void CloseScreen_CallsOnDeactivatedOnClosedScreen_AndOnActivatedOnRevealed()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+
+        manager.CloseScreen();
+
+        Assert.Equal(1, screen2.DeactivatedCallCount);
+        Assert.Equal(2, screen1.ActivatedCallCount); // once on show, once on re-activation
+    }
+
+    [Fact]
+    public void CloseScreen_LastScreen_CallsOnDeactivatedButNotOnActivated()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen = new TestScreen("Screen1");
+        manager.ShowScreen(screen);
+
+        manager.CloseScreen();
+
+        Assert.Equal(1, screen.DeactivatedCallCount);
+        Assert.Equal(1, screen.ActivatedCallCount);
+    }
+
+    [Fact]
+    public void ClearScreens_CallsOnDeactivatedOnlyOnActiveScreen()
+    {
+        ScreenManager manager = new ScreenManager();
+        TestScreen screen1 = new TestScreen("Screen1");
+        TestScreen screen2 = new TestScreen("Screen2");
+        TestScreen screen3 = new TestScreen("Screen3");
+        manager.ShowScreen(screen1);
+        manager.ShowScreen(screen2);
+        manager.ShowScreen(screen3);
+
+        manager.ClearScreens();
+
+        Assert.Equal(0, screen1.DeactivatedCallCount);
+        Assert.Equal(0, screen2.DeactivatedCallCount);
+        Assert.Equal(1, screen3.DeactivatedCallCount);
+    }
+
+    #endregion
+
     #region Stack Ordering Tests
 
     [Fact]

--- a/tests/MonoGame.Extended.Tests/Screens/TestScreens.cs
+++ b/tests/MonoGame.Extended.Tests/Screens/TestScreens.cs
@@ -9,6 +9,8 @@ public class TestScreen : Screen
     public bool DisposeCalled { get; private set; }
     public int UpdateCallCount { get; private set; }
     public int DrawCallCount { get; private set; }
+    public int ActivatedCallCount { get; private set; }
+    public int DeactivatedCallCount { get; private set; }
     public GameTime LastUpdateGameTime { get; private set; }
     public GameTime LastDrawGameTime { get; private set; }
 
@@ -27,6 +29,16 @@ public class TestScreen : Screen
     {
         DisposeCalled = true;
         base.Dispose();
+    }
+
+    public override void OnActivated()
+    {
+        ActivatedCallCount++;
+    }
+
+    public override void OnDeactivated()
+    {
+        DeactivatedCallCount++;
     }
 
     public override void Update(GameTime gameTime)
@@ -48,6 +60,8 @@ public class TestScreen : Screen
         DisposeCalled = false;
         UpdateCallCount = 0;
         DrawCallCount = 0;
+        ActivatedCallCount = 0;
+        DeactivatedCallCount = 0;
         LastUpdateGameTime = null;
         LastDrawGameTime = null;
         OnUpdate = null;


### PR DESCRIPTION
## Description

Adds `OnActivated` and `OnDeactivated` virtual methods to the `Screen` base class so developers have a reliable hook for every activation/deactivation cycle, not just the first time a screen is shown.

`Initialize` only fires once when a screen is first pushed onto the stack. If a screen is cached and later returned to (e.g. after closing a screen pushed on top of it), there was no hook to react to that reactivation. `OnActivated` fills that gap.

## Related Issues/Tickets

* Closes #1090

## Changes Made

* Added `OnActivated()` virtual method to `Screen`: called every time the screen becomes the top/active screen, including re-activation after being cached.
* Added `OnDeactivated()` virtual method to `Screen`: called every time the screen stops being the top screen, whether pushed behind or closed.
* `ScreenManager.ShowScreen` calls `OnDeactivated` on the outgoing screen and `OnActivated` on the incoming screen (after `Initialize`/`LoadContent`).
* `ScreenManager.CloseScreen` calls `OnDeactivated` on the closing screen (before `UnloadContent`/`Dispose`) and `OnActivated` on the screen that becomes active again.
* `ScreenManager.ClearScreens` calls `OnDeactivated` only on the screen that was actually active at the time of the clear.

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
