### PR TITLE
Add no-ops for `ContentTypeReaderManager.AddTypeCreator` for KNI and FNA since these are exclusively MonoGame additions

### DIFF
--- a/source/MonoGame.Extended/Content/ContentReaders/BitmapFontContentReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/BitmapFontContentReader.cs
@@ -12,6 +12,7 @@ namespace MonoGame.Extended.Content.ContentReaders;
 
 public class BitmapFontContentReader : ContentTypeReader<BitmapFont>
 {
+#if !FNA && !KNI
     /// <summary>
     /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
     /// so it is resolved without reflection.
@@ -24,6 +25,7 @@ public class BitmapFontContentReader : ContentTypeReader<BitmapFont>
         ContentTypeReaderManager.AddTypeCreator(
             typeof(BitmapFontContentReader).AssemblyQualifiedName,
             () => new BitmapFontContentReader());
+#endif
 
     protected override BitmapFont Read(ContentReader reader, BitmapFont existingInstance)
     {

--- a/source/MonoGame.Extended/Content/ContentReaders/JsonContentTypeReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/JsonContentTypeReader.cs
@@ -7,6 +7,7 @@ namespace MonoGame.Extended.Content.ContentReaders
 {
     public class JsonContentTypeReader<T> : ContentTypeReader<T>
     {
+#if !FNA && !KNI
         /// <summary>
         /// Registers <see cref="JsonContentTypeReader{T}"/> for the type <typeparamref name="T"/> with the
         /// <see cref="ContentTypeReaderManager"/> so it is resolved without reflection.
@@ -22,6 +23,7 @@ namespace MonoGame.Extended.Content.ContentReaders
             ContentTypeReaderManager.AddTypeCreator(
                 typeof(JsonContentTypeReader<T>).AssemblyQualifiedName,
                 () => new JsonContentTypeReader<T>());
+#endif
 
         protected override T Read(ContentReader reader, T existingInstance)
         {

--- a/source/MonoGame.Extended/Content/ContentReaders/ParticleEffectContentReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/ParticleEffectContentReader.cs
@@ -7,6 +7,7 @@ namespace MonoGame.Extended.Content.ContentReaders;
 
 public sealed class ParticleEffectContentReader : ContentTypeReader<ParticleEffect>
 {
+#if !FNA && !KNI
     /// <summary>
     /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
     /// so it is resolved without reflection.
@@ -19,6 +20,7 @@ public sealed class ParticleEffectContentReader : ContentTypeReader<ParticleEffe
         ContentTypeReaderManager.AddTypeCreator(
             typeof(ParticleEffectContentReader).AssemblyQualifiedName,
             () => new ParticleEffectContentReader());
+#endif
 
     protected override ParticleEffect Read(ContentReader input, ParticleEffect existingInstance)
     {

--- a/source/MonoGame.Extended/Content/ContentReaders/Texture2DAtlasReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/Texture2DAtlasReader.cs
@@ -11,6 +11,7 @@ namespace MonoGame.Extended.Content.ContentReaders
 {
     public class Texture2DAtlasReader : ContentTypeReader<Texture2DAtlas>
     {
+#if !FNA && !KNI
         /// <summary>
         /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
         /// so it is resolved without reflection.
@@ -23,6 +24,7 @@ namespace MonoGame.Extended.Content.ContentReaders
             ContentTypeReaderManager.AddTypeCreator(
                 typeof(Texture2DAtlasReader).AssemblyQualifiedName,
                 () => new Texture2DAtlasReader());
+#endif
 
         protected override Texture2DAtlas Read(ContentReader reader, Texture2DAtlas existingInstance)
         {

--- a/source/MonoGame.Extended/Tiled/TiledMapReader.cs
+++ b/source/MonoGame.Extended/Tiled/TiledMapReader.cs
@@ -10,6 +10,7 @@ namespace MonoGame.Extended.Tiled
 {
     public class TiledMapReader : ContentTypeReader<TiledMap>
     {
+#if !FNA && !KNI
         /// <summary>
         /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
         /// so it is resolved without reflection.
@@ -22,6 +23,7 @@ namespace MonoGame.Extended.Tiled
             ContentTypeReaderManager.AddTypeCreator(
                 typeof(TiledMapReader).AssemblyQualifiedName,
                 () => new TiledMapReader());
+#endif
 
         protected override TiledMap Read(ContentReader reader, TiledMap existingInstance)
         {

--- a/source/MonoGame.Extended/Tiled/TiledMapTilesetReader.cs
+++ b/source/MonoGame.Extended/Tiled/TiledMapTilesetReader.cs
@@ -1,13 +1,14 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.Content;
-using System;
 
 namespace MonoGame.Extended.Tiled
 {
 	public class TiledMapTilesetReader : ContentTypeReader<TiledMapTileset>
 	{
+#if !FNA && !KNI
 		/// <summary>
 		/// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
 		/// so it is resolved without reflection.
@@ -20,6 +21,7 @@ namespace MonoGame.Extended.Tiled
 			ContentTypeReaderManager.AddTypeCreator(
 				typeof(TiledMapTilesetReader).AssemblyQualifiedName,
 				() => new TiledMapTilesetReader());
+#endif
 
 
 		protected override TiledMapTileset Read(ContentReader reader, TiledMapTileset existingInstance)


### PR DESCRIPTION
## Description

Fixes build errors in the FNA and KNI solutions caused by the AOT/trimming support added in #1109. `ContentTypeReaderManager.AddTypeCreator` is a MonoGame specific API that does not exist in FNA or KNI, so the `Register()` methods added to the content type readers were causing compilation failures in those builds.

## Related Issues/Tickets

* Related to #1109 

## Changes Made

Wrapped the `Register()` static method in each of the six affected content type readers with `#if !FNA && !KNI` preprocessor directives so the method is excluded entirely from FNA and KNI builds:

* `BitmapFontContentReader.cs`
* `JsonContentTypeReader.cs`
* `ParticleEffectContentReader.cs`
* `Texture2DAtlasReader.cs`
* `TiledMapReader.cs`
* `TiledMapTilesetReader.cs`

The MonoGame build is unaffected. FNA and KNI users who require AOT/trimming support can use standard .NET `TrimmerRootDescriptor` XML to preserve the reader types they use.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
