### PR TITLE
Fix/kni tests

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -59,3 +59,7 @@ jobs:
         if: steps.detect.outputs.is_preview == 'true'
         run: |
           xvfb-run -a -s "-screen 0 1024x768x24" dotnet test MonoGame.Extended.sln --nologo --verbosity minimal --configuration Release -p:IsPreviewBuild=true
+
+      - name: Test KNI.Extended
+        run: |
+          dotnet test KNI.Extended.sln --nologo --verbosity minimal --configuration Release

--- a/tests/MonoGame.Extended.Tests/OrthographicCameraTests.cs
+++ b/tests/MonoGame.Extended.Tests/OrthographicCameraTests.cs
@@ -1,3 +1,4 @@
+#if !KNI && !FNA
 using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -1027,3 +1028,4 @@ public sealed class OrthographicCameraTests
     }
 
 }
+#endif

--- a/tests/MonoGame.Extended.Tests/Screens/ScreenManagerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Screens/ScreenManagerTests.cs
@@ -6,7 +6,6 @@ using MonoGame.Extended.Screens;
 
 namespace MonoGame.Extended.Tests.Screens;
 
-[Collection("GraphicsTest")]
 public sealed class ScreenManagerTests
 {
     #region ShowScreen Tests


### PR DESCRIPTION
## Description

Fixes 89 test failures that were silently passing in CI because the KNI solution was not being tested in the pull request workflow. Two distinct root causes were identified and resolved, and the CI workflow was updated to prevent regressions going forward.

## Related Issues/Tickets

* Related to #1109 

## Changes Made

**Test fixes (KNI build; `KNI.Extended.Tests`):**

* **`ScreenManagerTests.cs`**: Removed `[Collection("GraphicsTest")]`. These tests have no graphics dependency and were incorrectly placed in the graphics collection. 

* **`OrthographicCameraTests.cs`**: Wrapped the entire file with `#if !KNI && !FNA`. These tests require a live `GraphicsDevice` and cannot run under KNI or FNA without a platform specific runtime package that registers the game factory. 

**CI workflow (`.github/workflows/pull-request-test.yml`):**

* Added a `Test KNI.Extended` step that runs `dotnet test KNI.Extended.sln` on every PR. 

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
