### PR TITLE
Resolve particle double content path append

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 
     <!-- Version Configuration -->
     <PropertyGroup>
-        <Version>5.4.0</Version>
+        <Version>5.4.1</Version>
         <MonoGameVersion>3.8.4.1</MonoGameVersion>
         <KNIVersion>4.0.9001</KNIVersion>
     </PropertyGroup>

--- a/source/MonoGame.Extended/Content/ContentReaders/ParticleEffectContentReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/ParticleEffectContentReader.cs
@@ -28,6 +28,13 @@ public sealed class ParticleEffectContentReader : ContentTypeReader<ParticleEffe
 
         byte[] xmlBytes = Encoding.UTF8.GetBytes(xmlContent);
         using Stream stream = new MemoryStream(xmlBytes);
-        return ParticleEffectSerializer.Deserialize(stream, input.ContentManager);
+
+        // Resolve textures relative to the directory of this asset within the
+        // content tree, not the content root itself.  Without this, the serializer
+        // falls back to content.RootDirectory (e.g. "Content") as the base, which
+        // causes content.Load to prepend that prefix a second time and produce a
+        // doubled path such as "Content\Content\texture.xnb".
+        string assetDirectory = Path.GetDirectoryName(input.AssetName) ?? string.Empty;
+        return ParticleEffectSerializer.Deserialize(stream, input.ContentManager, assetDirectory);
     }
 }


### PR DESCRIPTION
## Description

Resolves issue where the Content path is appended twice when loading .ember particle files through the content pipeline.

## Related Issues/Tickets

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
