### PR TITLE
Add uniform random scale to ParticleVector2Parameter

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 
     <!-- Version Configuration -->
     <PropertyGroup>
-        <Version>5.4.1</Version>
+        <Version>5.5.0</Version>
         <MonoGameVersion>3.8.4.1</MonoGameVersion>
         <KNIVersion>4.0.9001</KNIVersion>
     </PropertyGroup>

--- a/source/MonoGame.Extended/Particles/Data/ParticleVector2Parameter.cs
+++ b/source/MonoGame.Extended/Particles/Data/ParticleVector2Parameter.cs
@@ -38,12 +38,24 @@ public struct ParticleVector2Parameter : IEquatable<ParticleVector2Parameter>
     public Vector2 RandomMax;
 
     /// <summary>
+    /// When <see langword="true"/> and <see cref="Kind"/> is <see cref="ParticleValueKind.Random"/>, a single random
+    /// value is sampled and applied to both X and Y, preserving the aspect ratio of each particle.
+    /// </summary>
+    /// <remarks>
+    /// The X components of <see cref="RandomMin"/> and <see cref="RandomMax"/> define the uniform range.
+    /// When <see langword="false"/>, X and Y are sampled independently.
+    /// </remarks>
+    public bool Uniform;
+
+    /// <summary>
     /// Gets the current value of this parameter based on its <see cref="Kind"/>
     /// </summary>
     /// <remarks>
     /// If <see cref="Kind"/> is <see cref="ParticleValueKind.Constant"/>, returns <see cref="Constant"/>.
-    /// If <see cref="Kind"/> is <see cref="ParticleValueKind.Random"/>, returns a random value between
-    /// <see cref="RandomMin"/> and <see cref="RandomMax"/>.
+    /// If <see cref="Kind"/> is <see cref="ParticleValueKind.Random"/> and <see cref="Uniform"/> is
+    /// <see langword="false"/>, returns a random value with X and Y sampled independently from their respective ranges.
+    /// If <see cref="Kind"/> is <see cref="ParticleValueKind.Random"/> and <see cref="Uniform"/> is
+    /// <see langword="true"/>, returns a random value with a single sample applied to both X and Y using the X range.
     /// </remarks>
     public Vector2 Value
     {
@@ -53,6 +65,12 @@ public struct ParticleVector2Parameter : IEquatable<ParticleVector2Parameter>
             if (Kind == ParticleValueKind.Constant)
             {
                 return Constant;
+            }
+
+            if (Uniform)
+            {
+                float s = FastRandom.Shared.NextSingle(RandomMin.X, RandomMax.X);
+                return new Vector2(s, s);
             }
 
             Vector2 v;

--- a/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectReader.cs
@@ -363,7 +363,8 @@ public sealed class ParticleEffectReader : IDisposable
         {
             Vector2 min = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMin));
             Vector2 max = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMax));
-            return new ParticleVector2Parameter(min, max);
+            bool uniform = reader.GetAttributeBool(nameof(ParticleVector2Parameter.Uniform), false);
+            return new ParticleVector2Parameter(min, max) { Uniform = uniform };
         }
 
         return new ParticleVector2Parameter(Vector2.Zero);

--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -302,7 +302,8 @@ public static class ParticleEffectSerializer
         {
             Vector2 min = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMin), default);
             Vector2 max = reader.GetAttributeVector2(nameof(ParticleVector2Parameter.RandomMax), default);
-            return new ParticleVector2Parameter(min, max);
+            bool uniform = reader.GetAttributeBool(nameof(ParticleVector2Parameter.Uniform), false);
+            return new ParticleVector2Parameter(min, max) { Uniform = uniform };
         }
 
         return new ParticleVector2Parameter(Vector2.Zero);
@@ -847,6 +848,11 @@ public static class ParticleEffectSerializer
         {
             writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMin), parameter.RandomMin);
             writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMax), parameter.RandomMax);
+
+            if (parameter.Uniform)
+            {
+                writer.WriteAttributeString(nameof(ParticleVector2Parameter.Uniform), "true");
+            }
         }
 
         writer.WriteEndElement();

--- a/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectWriter.cs
@@ -206,6 +206,11 @@ public class ParticleEffectWriter : IDisposable
         {
             _writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMin), parameter.RandomMin);
             _writer.WriteAttributeVector2(nameof(ParticleVector2Parameter.RandomMax), parameter.RandomMax);
+
+            if (parameter.Uniform)
+            {
+                _writer.WriteAttributeString(nameof(ParticleVector2Parameter.Uniform), "true");
+            }
         }
 
         _writer.WriteEndElement();


### PR DESCRIPTION
## Description

Adds a `Uniform` flag to `ParticleVector2Parameter` that, when set with `Kind = Random`, samples a single float and applies it to both X and Y axes. This guarantees per particle aspect ratio preservation when using random scale on a particle emitter. Without this flag, X and Y are sampled independently, meaning each particle can receive a non square scale even when the min/max range is symmetric.

## Related Issues/Tickets

- https://github.com/MonoGame-Extended/Ember/issues/26

## Changes Made

- `ParticleVector2Parameter`: added `public bool Uniform` field (default `false`); updated the `Value` getter to sample a single value from the X range and return `Vector2(s, s)` when `Uniform` is true and `Kind` is `Random`.
- `ParticleEffectSerializer`: reads the `Uniform` XML attribute with a default of `false`;  writes it only when `true`, preserving backward compatibility with existing `.ember` files.
- `ParticleEffectReader` / `ParticleEffectWriter`: same read/write changes for the content pipeline (`.xnb`) variants.

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
