### PR TITLE
Cancelling changing the texture in Ember removes path and ember crashes if texture cannot be found when loaded

### DIFF
--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -193,7 +193,7 @@ public static class ParticleEffectSerializer
         Texture2D texture = content.Load<Texture2D>(path);
         if(string.IsNullOrEmpty(texture.Name))
         {
-            texture.Name = Path.GetFileName(path);
+            texture.Name = name;
         }
 
         Rectangle bounds = reader.GetAttributeRectangle(nameof(Texture2DRegion.Bounds), default);


### PR DESCRIPTION
## Description

Choosing the texture slot in Ember when a texture is already loaded wipes the path. If the user chooses cancel, the texture only shows name and extension. If the ember project is saved, the path is removed from the ember file. Opening the file later, crashes the program

## Related Issues/Tickets

closes #1131 

## Changes Made

One-line change in ParticleEffectSerializer.ReadTexture2DRegion: use name (the original relative path read from the XML attribute) instead of Path.GetFileName(path) when setting texture.Name.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [X] I have verified that there are no existing pull requests that would overlap with this pull request.
* [X] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [X] I have verified that this pull request adheres to this project's code of conduct.
* [X] I have written a descriptive title for this pull request.
* [X] I have provided appropriate test coverage were applicable.
