### PR TITLE
Add support for "Collection of Images" from Tiled

### DIFF
--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Tiled/TilemapTilesetImporter.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Tiled/TilemapTilesetImporter.cs
@@ -56,8 +56,7 @@ public sealed class TilemapTilesetImporter : ContentImporter<TilemapTilesetConte
     {
         if (tileset.Image == null)
         {
-            // Image collection tilesets define per-tile images rather than a shared atlas.
-            // Per-tile images are registered during processing once individual tile data is available.
+            RegisterCollectionTileImageDependencies(tileset, sourceDirectory, filePath, context);
             return;
         }
 
@@ -74,5 +73,28 @@ public sealed class TilemapTilesetImporter : ContentImporter<TilemapTilesetConte
 
         // Store the absolute path so ConvertTilesetData picks it up directly.
         tileset.Image.Source = absoluteImagePath;
+    }
+
+    private static void RegisterCollectionTileImageDependencies(TiledTilesetXml tileset, string sourceDirectory, string filePath, ContentImporterContext context)
+    {
+        if (tileset.Tiles == null)
+        {
+            return;
+        }
+
+        foreach (TiledTileXml tile in tileset.Tiles)
+        {
+            if (tile.Image == null || string.IsNullOrWhiteSpace(tile.Image.Source))
+            {
+                continue;
+            }
+
+            string absoluteTileImagePath = Path.GetFullPath(Path.Combine(sourceDirectory, tile.Image.Source));
+            ContentLogger.Log($"Adding dependency '{absoluteTileImagePath}'");
+            context.AddDependency(absoluteTileImagePath);
+
+            // Store the absolute path so ConvertTileEntries picks it up directly.
+            tile.Image.Source = absoluteTileImagePath;
+        }
     }
 }

--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Tiled/TilemapTilesetProcessor.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Tiled/TilemapTilesetProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+using MonoGame.Extended.Tilemaps;
 
 namespace MonoGame.Extended.Content.Pipeline.Tilemaps.Tiled;
 
@@ -25,6 +26,15 @@ public sealed class TilemapTilesetProcessor : ContentProcessor<TilemapTilesetCon
         {
             ContentLogger.Log($"Building texture '{contentItem.Data.TexturePath}'");
             contentItem.BuildExternalReference<Texture2DContent>(context, contentItem.Data.TexturePath);
+        }
+
+        foreach (TilemapTileEntryData tile in contentItem.Data.Tiles)
+        {
+            if (!string.IsNullOrWhiteSpace(tile.ImagePath))
+            {
+                ContentLogger.Log($"Building tile image '{tile.ImagePath}'");
+                contentItem.BuildExternalReference<Texture2DContent>(context, tile.ImagePath);
+            }
         }
 
         ContentLogger.Log($"Processed tileset '{contentItem.Data.Name}'");

--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Tiled/TilemapTilesetWriter.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Tiled/TilemapTilesetWriter.cs
@@ -43,7 +43,7 @@ public sealed class TilemapTilesetWriter : ContentTypeWriter<TilemapTilesetConte
         writer.Write(tileset.DrawOffsetY);
 
         TilemapWriteHelper.WriteProperties(writer, tileset.Properties);
-        TilemapWriteHelper.WriteTileEntries(writer, tileset.Tiles);
+        TilemapWriteHelper.WriteTileEntries(writer, tileset.Tiles, references);
     }
 
     /// <inheritdoc/>

--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/TilemapWriteHelper.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/TilemapWriteHelper.cs
@@ -258,7 +258,7 @@ internal static class TilemapWriteHelper
         }
     }
 
-    internal static void WriteTileEntries(ContentWriter writer, IReadOnlyList<TilemapTileEntryData> tiles)
+    internal static void WriteTileEntries(ContentWriter writer, IReadOnlyList<TilemapTileEntryData> tiles, IExternalReferenceRepository refs)
     {
         if (tiles == null || tiles.Count == 0)
         {
@@ -270,11 +270,11 @@ internal static class TilemapWriteHelper
 
         foreach (TilemapTileEntryData tile in tiles)
         {
-            WriteTileEntry(writer, tile);
+            WriteTileEntry(writer, tile, refs);
         }
     }
 
-    private static void WriteTileEntry(ContentWriter writer, TilemapTileEntryData tile)
+    private static void WriteTileEntry(ContentWriter writer, TilemapTileEntryData tile, IExternalReferenceRepository refs)
     {
         writer.Write(tile.LocalId);
         writer.Write(tile.Class ?? string.Empty);
@@ -282,6 +282,16 @@ internal static class TilemapWriteHelper
         WriteProperties(writer, tile.Properties);
         WriteAnimation(writer, tile.Animation);
         WriteCollisionObjects(writer, tile.CollisionObjects);
+
+        bool hasTileImage = !string.IsNullOrEmpty(tile.ImagePath);
+        writer.Write(hasTileImage);
+
+        if (hasTileImage)
+        {
+            ExternalReference<Texture2DContent> tileTexRef =
+                refs.GetExternalReference<Texture2DContent>(tile.ImagePath);
+            writer.WriteExternalReference(tileTexRef);
+        }
     }
 
     private static void WriteAnimation(ContentWriter writer, TilemapAnimationData animation)

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
@@ -125,6 +125,13 @@ namespace MonoGame.Extended.Tilemaps.Content
                 tileData.CollisionObjects.Add(obj);
             }
 
+            bool hasTileImage = reader.ReadBoolean();
+
+            if (hasTileImage)
+            {
+                tileData.CustomImage = reader.ReadExternalReference<Texture2D>();
+            }
+
             return tileData;
         }
 

--- a/source/MonoGame.Extended/Tilemaps/Rendering/TilemapRenderer.cs
+++ b/source/MonoGame.Extended/Tilemaps/Rendering/TilemapRenderer.cs
@@ -39,7 +39,7 @@ public sealed class TilemapRenderer : IDisposable
 
     private readonly Dictionary<string, LayerGroup> _layerGroups;
     private readonly Dictionary<TilemapLayer, string> _layerToGroup;
-    private readonly Dictionary<TilemapTileLayer, LayerModel> _layerModels;
+    private readonly Dictionary<TilemapTileLayer, List<LayerModel>> _layerModels;
     private readonly Dictionary<TilemapImageLayer, LayerModel> _imageLayerModels;
     private readonly Dictionary<TilemapImageLayer, RepeatImageLayerModel> _repeatImageLayerModels;
     private readonly Dictionary<TilemapObjectLayer, List<LayerModel>> _objectLayerModels;
@@ -200,7 +200,7 @@ public sealed class TilemapRenderer : IDisposable
 
         _layerGroups = new Dictionary<string, LayerGroup>();
         _layerToGroup = new Dictionary<TilemapLayer, string>();
-        _layerModels = new Dictionary<TilemapTileLayer, LayerModel>();
+        _layerModels = new Dictionary<TilemapTileLayer, List<LayerModel>>();
         _imageLayerModels = new Dictionary<TilemapImageLayer, LayerModel>();
         _repeatImageLayerModels = new Dictionary<TilemapImageLayer, RepeatImageLayerModel>();
         _objectLayerModels = new Dictionary<TilemapObjectLayer, List<LayerModel>>();
@@ -237,9 +237,12 @@ public sealed class TilemapRenderer : IDisposable
     {
         ThrowIfDisposed();
 
-        foreach (LayerModel model in _layerModels.Values)
+        foreach (List<LayerModel> models in _layerModels.Values)
         {
-            model.Dispose();
+            foreach (LayerModel model in models)
+            {
+                model.Dispose();
+            }
         }
         _layerModels.Clear();
 
@@ -889,10 +892,10 @@ public sealed class TilemapRenderer : IDisposable
         {
             if (layer is TilemapTileLayer tileLayer)
             {
-                LayerModel model = BuildLayerModel(tileLayer);
-                if (model != null)
+                List<LayerModel> models = BuildLayerModels(tileLayer);
+                if (models.Count > 0)
                 {
-                    _layerModels[tileLayer] = model;
+                    _layerModels[tileLayer] = models;
                 }
             }
             else if (layer is TilemapImageLayer imageLayer)
@@ -1013,32 +1016,18 @@ public sealed class TilemapRenderer : IDisposable
                 continue;
             }
 
-            TilemapTileData tileData = tileObj.Tile.GetTileData(_tilemap.Tilesets);
+            int localId = tileObj.Tile.GetLocalId(_tilemap.Tilesets, out TilemapTileset tileset);
 
-            Texture2D texture;
-            Rectangle sourceRect;
-
-            if (tileData?.CustomImage != null)
+            if (tileset == null)
             {
-                texture = tileData.CustomImage;
-                sourceRect = new Rectangle(0, 0, texture.Width, texture.Height);
+                continue;
             }
-            else
+
+            tileset.GetRenderSource(localId, out Texture2D texture, out Rectangle sourceRect);
+
+            if (texture == null)
             {
-                int localId = tileObj.Tile.GetLocalId(_tilemap.Tilesets, out TilemapTileset tileset);
-
-                if (tileset?.Texture == null)
-                {
-                    continue;
-                }
-
-                if (tileData?.Animation != null)
-                {
-                    localId = tileData.Animation.CurrentFrame.TileId;
-                }
-
-                texture = tileset.Texture;
-                sourceRect = tileset.GetTileRegion(localId);
+                continue;
             }
 
             if (currentTexture != null && currentTexture != texture)
@@ -1098,11 +1087,11 @@ public sealed class TilemapRenderer : IDisposable
         indices.Add(vertexOffset + 2);
     }
 
-    private LayerModel BuildLayerModel(TilemapTileLayer tileLayer)
+    private List<LayerModel> BuildLayerModels(TilemapTileLayer tileLayer)
     {
-        List<VertexPositionColorTexture> vertices = new List<VertexPositionColorTexture>();
-        List<int> indices = new List<int>();
-        Texture2D currentTexture = null;
+        List<TileBatch> batches = new List<TileBatch>();
+        Color layerColor = new Color(1f, 1f, 1f, tileLayer.Opacity);
+        Vector2 layerParallax = tileLayer.ParallaxFactor;
 
         foreach (TilemapTileEntry entry in tileLayer.GetTiles())
         {
@@ -1113,32 +1102,45 @@ public sealed class TilemapRenderer : IDisposable
                 continue;
             }
 
-            if (currentTexture == null)
+            tileset.GetRenderSource(localId, out Texture2D texture, out Rectangle sourceRect);
+
+            if (texture == null)
             {
-                currentTexture = tileset.Texture;
+                continue;
             }
 
-            Rectangle sourceRect = tileset.GetTileRegion(localId);
             Point worldPos = _tilemap.TileToWorldPosition(entry.X, entry.Y);
-            Vector2 position = new Vector2(worldPos.X, worldPos.Y) + tileLayer.Offset;
-            position += tileset.TileOffset;
-            // Tiled bottom-aligns oversized tiles: shift up by the amount the sprite exceeds the grid cell.
-            position.Y -= Math.Max(0, tileset.TileHeight - tileLayer.TileHeight);
+            Vector2 position = new Vector2(worldPos.X, worldPos.Y) + tileLayer.Offset + tileset.TileOffset;
+            // Tiled bottom-aligns all tiles: shifts oversized tiles up and undersized tiles down.
+            position.Y += tileLayer.TileHeight - sourceRect.Height;
 
-            // Bake layer opacity into vertex color so grouped and ungrouped paths use the same mechanism.
-            Color tileColor = new Color(1f, 1f, 1f, tileLayer.Opacity);
-            TilemapRendererShared.AddTileQuad(vertices, indices, position, tileset.TileWidth, tileset.TileHeight,
-                        sourceRect, entry.Tile.FlipFlags, tileset.Texture, tileColor);
+            TileBatch last = batches.Count > 0 ? batches[batches.Count - 1] : null;
+            if (last == null || last.Texture != texture || last.ParallaxFactor != layerParallax)
+            {
+                last = new TileBatch(texture, layerParallax, new List<VertexPositionColorTexture>(), new List<int>());
+                batches.Add(last);
+            }
+
+            TilemapRendererShared.AddTileQuad(last.Vertices, last.Indices, position,
+                sourceRect.Width, sourceRect.Height,
+                sourceRect, entry.Tile.FlipFlags, texture, layerColor);
         }
 
-        if (vertices.Count == 0)
+        List<LayerModel> result = new List<LayerModel>();
+
+        foreach (TileBatch batch in batches)
         {
-            return null;
+            if (batch.Vertices.Count == 0)
+            {
+                continue;
+            }
+
+            LayerModel model = TilemapRendererShared.CreateLayerModel(_graphicsDevice, batch.Vertices.ToArray(), batch.Indices.ToArray(), batch.Texture);
+            model.ParallaxFactor = layerParallax;
+            result.Add(model);
         }
 
-        LayerModel model = TilemapRendererShared.CreateLayerModel(_graphicsDevice, vertices.ToArray(), indices.ToArray(), currentTexture);
-        model.ParallaxFactor = tileLayer.ParallaxFactor;
-        return model;
+        return result;
     }
 
     private void ApplyParallaxWorld(Vector2 parallaxFactor)
@@ -1214,13 +1216,17 @@ public sealed class TilemapRenderer : IDisposable
 
         if (layer is TilemapTileLayer tileLayer)
         {
-            // Find the corresponding layer model by layer identity, not by index.
+            // Find the corresponding layer models by layer identity, not by index.
             // Index-based lookup breaks when non-tile layers are interleaved with tile layers
             // because _layerModels only contains entries for layers that produced at least one tile.
-            if (_layerModels.TryGetValue(tileLayer, out LayerModel tileModel))
+            if (_layerModels.TryGetValue(tileLayer, out List<LayerModel> tileModels))
             {
                 ApplyParallaxWorld(tileLayer.ParallaxFactor);
-                DrawLayerModel(tileModel);
+
+                foreach (LayerModel tileModel in tileModels)
+                {
+                    DrawLayerModel(tileModel);
+                }
             }
 
             return;
@@ -1298,18 +1304,17 @@ public sealed class TilemapRenderer : IDisposable
                     continue;
                 }
 
-                TilemapTileData tileData = tileset.GetTileData(localId);
-                if (tileData?.Animation != null)
+                tileset.GetRenderSource(localId, out Texture2D texture, out Rectangle sourceRect);
+
+                if (texture == null)
                 {
-                    localId = tileData.Animation.CurrentFrame.TileId;
+                    continue;
                 }
 
-                Texture2D texture = tileset.Texture;
-                Rectangle sourceRect = tileset.GetTileRegion(localId);
                 Point worldPos = _tilemap.TileToWorldPosition(entry.X, entry.Y);
                 Vector2 position = new Vector2(worldPos.X, worldPos.Y) + tileLayer.Offset + tileset.TileOffset;
-                // Tiled bottom-aligns oversized tiles: shift up by the amount the sprite exceeds the grid cell.
-                position.Y -= Math.Max(0, tileset.TileHeight - tileLayer.TileHeight);
+                // Tiled bottom-aligns all tiles: shifts oversized tiles up and undersized tiles down.
+                position.Y += tileLayer.TileHeight - sourceRect.Height;
 
                 TileBatch last = orderedBatches.Count > 0 ? orderedBatches[orderedBatches.Count - 1] : null;
                 if (last == null || last.Texture != texture || last.ParallaxFactor != layerParallax)
@@ -1319,7 +1324,7 @@ public sealed class TilemapRenderer : IDisposable
                 }
 
                 TilemapRendererShared.AddTileQuad(last.Vertices, last.Indices, position,
-                    tileset.TileWidth, tileset.TileHeight,
+                    sourceRect.Width, sourceRect.Height,
                     sourceRect, entry.Tile.FlipFlags, texture, layerColor);
             }
         }
@@ -1373,19 +1378,18 @@ public sealed class TilemapRenderer : IDisposable
                     continue;
                 }
 
-                TilemapTileData tileData = tileset.GetTileData(localId);
-                if (tileData?.Animation != null)
+                tileset.GetRenderSource(localId, out Texture2D texture, out Rectangle sourceRect);
+
+                if (texture == null)
                 {
-                    localId = tileData.Animation.CurrentFrame.TileId;
+                    continue;
                 }
 
-                Texture2D texture = tileset.Texture;
-                Rectangle sourceRect = tileset.GetTileRegion(localId);
                 Point worldPos = _tilemap.TileToWorldPosition(entry.X, entry.Y);
                 Vector2 position = new Vector2(worldPos.X, worldPos.Y) + tileLayer.Offset + tileset.TileOffset;
 
-                // Tiled bottom-aligns oversized tiles: shift up by the amount the sprite exceeds the grid cell.
-                position.Y -= Math.Max(0, tileset.TileHeight - tileLayer.TileHeight);
+                // Tiled bottom-aligns all tiles: shifts oversized tiles up and undersized tiles down.
+                position.Y += tileLayer.TileHeight - sourceRect.Height;
 
                 TileBatch last = batches.Count > 0 ? batches[batches.Count - 1] : null;
                 if (last == null || last.Texture != texture || last.ParallaxFactor != layerParallax)
@@ -1395,7 +1399,7 @@ public sealed class TilemapRenderer : IDisposable
                 }
 
                 TilemapRendererShared.AddTileQuad(last.Vertices, last.Indices, position,
-                    tileset.TileWidth, tileset.TileHeight,
+                    sourceRect.Width, sourceRect.Height,
                     sourceRect, entry.Tile.FlipFlags, texture, layerColor);
             }
         }

--- a/source/MonoGame.Extended/Tilemaps/Rendering/TilemapSpriteBatchRenderer.cs
+++ b/source/MonoGame.Extended/Tilemaps/Rendering/TilemapSpriteBatchRenderer.cs
@@ -441,32 +441,18 @@ public sealed class TilemapSpriteBatchRenderer
                 continue;
             }
 
-            TilemapTileData tileData = tileObj.Tile.GetTileData(_tilemap.Tilesets);
+            int localId = tileObj.Tile.GetLocalId(_tilemap.Tilesets, out TilemapTileset tileset);
 
-            Texture2D texture;
-            Rectangle sourceRect;
-
-            if (tileData?.CustomImage != null)
+            if (tileset == null)
             {
-                texture = tileData.CustomImage;
-                sourceRect = new Rectangle(0, 0, texture.Width, texture.Height);
+                continue;
             }
-            else
+
+            tileset.GetRenderSource(localId, out Texture2D texture, out Rectangle sourceRect);
+
+            if (texture == null)
             {
-                int localId = tileObj.Tile.GetLocalId(_tilemap.Tilesets, out TilemapTileset tileset);
-
-                if (tileset?.Texture == null)
-                {
-                    continue;
-                }
-
-                if (tileData?.Animation != null)
-                {
-                    localId = tileData.Animation.CurrentFrame.TileId;
-                }
-
-                texture = tileset.Texture;
-                sourceRect = tileset.GetTileRegion(localId);
+                continue;
             }
 
             Vector2 scale = new Vector2(
@@ -552,22 +538,21 @@ public sealed class TilemapSpriteBatchRenderer
                 continue;
             }
 
-            // If this tile has an animation, use the current frame's tile ID for the source rect.
-            TilemapTileData tileData = tileset.GetTileData(localId);
-            if (tileData?.Animation != null)
+            tileset.GetRenderSource(localId, out Texture2D tileTexture, out Rectangle sourceRect);
+
+            if (tileTexture == null)
             {
-                localId = tileData.Animation.CurrentFrame.TileId;
+                continue;
             }
 
-            Rectangle sourceRect = tileset.GetTileRegion(localId);
             Point worldPos = _tilemap.TileToWorldPosition(entry.X, entry.Y);
             Vector2 drawPosition = new Vector2(worldPos.X, worldPos.Y) + tileLayer.Offset + tileset.TileOffset;
 
-            // Tiled bottom-aligns oversized tiles: shift up by the amount the sprite exceeds the grid cell.
-            drawPosition.Y -= Math.Max(0, tileset.TileHeight - tileLayer.TileHeight);
+            // Tiled bottom-aligns all tiles: shifts oversized tiles up and undersized tiles down.
+            drawPosition.Y += tileLayer.TileHeight - sourceRect.Height;
 
-            DrawTile(spriteBatch, tileset.Texture, drawPosition, sourceRect,
-                entry.Tile.FlipFlags, tileset.TileWidth, tileset.TileHeight, layerColor);
+            DrawTile(spriteBatch, tileTexture, drawPosition, sourceRect,
+                entry.Tile.FlipFlags, sourceRect.Width, sourceRect.Height, layerColor);
         }
     }
 

--- a/source/MonoGame.Extended/Tilemaps/Rendering/TilemapWorldRenderer.cs
+++ b/source/MonoGame.Extended/Tilemaps/Rendering/TilemapWorldRenderer.cs
@@ -187,24 +187,31 @@ public sealed class TilemapWorldRenderer : IDisposable
                         continue;
                     }
 
-                    TileBatchKey key = new TileBatchKey(depth, tileset.Texture, tileLayer.ParallaxFactor);
+                    int localId = entry.Tile.GlobalId - tileset.FirstGlobalId;
+                    tileset.GetRenderSource(localId, out Texture2D tileTexture, out Rectangle sourceRect);
+
+                    if (tileTexture == null)
+                    {
+                        continue;
+                    }
+
+                    TileBatchKey key = new TileBatchKey(depth, tileTexture, tileLayer.ParallaxFactor);
                     if (!groups.TryGetValue(key, out TileAccumulator group))
                     {
                         group = new TileAccumulator();
                         groups[key] = group;
                     }
 
-                    int localId = entry.Tile.GlobalId - tileset.FirstGlobalId;
-                    Rectangle sourceRect = tileset.GetTileRegion(localId);
                     Point tilePos = tilemap.TileToWorldPosition(entry.X, entry.Y);
                     Vector2 position = new Vector2(tilePos.X, tilePos.Y) + worldPos + tileLayer.Offset + tileset.TileOffset;
-                    position.Y -= Math.Max(0, tileset.TileHeight - tileLayer.TileHeight);
+                    // Tiled bottom-aligns all tiles: shifts oversized tiles up and undersized tiles down.
+                    position.Y += tileLayer.TileHeight - sourceRect.Height;
 
                     Color tileColor = new Color(1f, 1f, 1f, tileLayer.Opacity);
                     TilemapRendererShared.AddTileQuad(
                         group.Vertices, group.Indices,
-                        position, tileset.TileWidth, tileset.TileHeight,
-                        sourceRect, entry.Tile.FlipFlags, tileset.Texture, tileColor);
+                        position, sourceRect.Width, sourceRect.Height,
+                        sourceRect, entry.Tile.FlipFlags, tileTexture, tileColor);
                 }
             }
         }

--- a/source/MonoGame.Extended/Tilemaps/Rendering/TilemapWorldSpriteBatchRenderer.cs
+++ b/source/MonoGame.Extended/Tilemaps/Rendering/TilemapWorldSpriteBatchRenderer.cs
@@ -143,15 +143,22 @@ public sealed class TilemapWorldSpriteBatchRenderer
                         }
                     }
 
-                    Rectangle sourceRect = tileset.GetTileRegion(localId);
+                    tileset.GetRenderSource(localId, out Texture2D tileTexture, out Rectangle sourceRect);
+
+                    if (tileTexture == null)
+                    {
+                        continue;
+                    }
+
                     Point tilePos = tilemap.TileToWorldPosition(entry.X, entry.Y);
                     Vector2 drawPosition = new Vector2(tilePos.X, tilePos.Y) + worldPos + tileLayer.Offset + tileset.TileOffset;
-                    drawPosition.Y -= Math.Max(0, tileset.TileHeight - tileLayer.TileHeight);
+                    // Tiled bottom-aligns all tiles: shifts oversized tiles up and undersized tiles down.
+                    drawPosition.Y += tileLayer.TileHeight - sourceRect.Height;
 
                     roomBatch.Tiles.Add(new WorldTileSprite(
-                        tileset.Texture, sourceRect, animatedData, tileset,
+                        tileTexture, sourceRect, animatedData, tileset,
                         drawPosition, entry.Tile.FlipFlags,
-                        tileset.TileWidth, tileset.TileHeight, layerColor));
+                        sourceRect.Width, sourceRect.Height, layerColor));
                 }
             }
         }
@@ -287,12 +294,26 @@ public sealed class TilemapWorldSpriteBatchRenderer
                         continue;
                     }
 
-                    Rectangle src = tile.AnimatedTileData?.Animation != null
-                        ? tile.Tileset.GetTileRegion(tile.AnimatedTileData.Animation.CurrentFrame.TileId)
-                        : tile.SourceRect;
+                    Texture2D drawTexture;
+                    Rectangle src;
 
-                    DrawTile(spriteBatch, tile.Texture, pos, src,
-                             tile.FlipFlags, tile.TileWidth, tile.TileHeight, tile.Color);
+                    if (tile.AnimatedTileData?.Animation != null)
+                    {
+                        tile.Tileset.GetRenderSource(tile.AnimatedTileData.LocalId, out drawTexture, out src);
+
+                        if (drawTexture == null)
+                        {
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        drawTexture = tile.Texture;
+                        src = tile.SourceRect;
+                    }
+
+                    DrawTile(spriteBatch, drawTexture, pos, src,
+                             tile.FlipFlags, src.Width, src.Height, tile.Color);
                 }
             }
 

--- a/source/MonoGame.Extended/Tilemaps/Tiled/Converters/TiledTilemapDataConverter.cs
+++ b/source/MonoGame.Extended/Tilemaps/Tiled/Converters/TiledTilemapDataConverter.cs
@@ -101,12 +101,6 @@ public static class TiledTilemapDataConverter
             {
                 TiledTilesetXml tilesetXml = tilesetRef.TilesetData ?? tilesetRef;
 
-                if (tilesetXml.Image == null || string.IsNullOrWhiteSpace(tilesetXml.Image.Source))
-                {
-                    // Image collection tilesets are not supported.
-                    continue;
-                }
-
                 entry.IsExternal = false;
                 entry.InlineData = ConvertTilesetData(tilesetXml);
             }
@@ -148,6 +142,7 @@ public static class TiledTilemapDataConverter
             entry.LocalId = tile.Id;
             entry.Class = tile.Class ?? tile.Type ?? string.Empty;
             entry.Probability = tile.Probability <= 0f ? 1.0f : tile.Probability;
+            entry.ImagePath = tile.Image?.Source ?? string.Empty;
 
             ConvertProperties(tile.Properties, entry.Properties);
 

--- a/source/MonoGame.Extended/Tilemaps/TilemapData.cs
+++ b/source/MonoGame.Extended/Tilemaps/TilemapData.cs
@@ -242,6 +242,15 @@ public sealed class TilemapTileEntryData
     /// Gets the collision objects defined for this tile.
     /// </summary>
     public List<TilemapObjectData> CollisionObjects { get; } = new List<TilemapObjectData>();
+
+    /// <summary>
+    /// Gets or sets the path to the image for this tile.
+    /// </summary>
+    /// <remarks>
+    /// Only populated for image collection tilesets where each tile has its own source image.
+    /// Empty for standard atlas-based tilesets.
+    /// </remarks>
+    public string ImagePath { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/source/MonoGame.Extended/Tilemaps/TilemapFactory.cs
+++ b/source/MonoGame.Extended/Tilemaps/TilemapFactory.cs
@@ -102,16 +102,19 @@ public static class TilemapFactory
     private static TilemapTileset BuildTileset(TilemapTilesetEntry entry, GraphicsDevice graphicsDevice, string baseDirectory)
     {
         TilemapTilesetData tilesetData = entry.InlineData;
-        Texture2D texture;
+        Texture2D texture = null;
 
-        try
+        if (!string.IsNullOrEmpty(tilesetData.TexturePath))
         {
-            texture = LoadTexture(tilesetData.TexturePath, graphicsDevice, baseDirectory);
-        }
-        catch (TilemapParseException ex)
-        {
-            throw new TilemapParseException(
-                $"Failed to load texture for tileset '{tilesetData.Name}': {ex.Message}", ex);
+            try
+            {
+                texture = LoadTexture(tilesetData.TexturePath, graphicsDevice, baseDirectory);
+            }
+            catch (TilemapParseException ex)
+            {
+                throw new TilemapParseException(
+                    $"Failed to load texture for tileset '{tilesetData.Name}': {ex.Message}", ex);
+            }
         }
 
         TilemapTileset tileset = new TilemapTileset(
@@ -132,20 +135,33 @@ public static class TilemapFactory
 
         foreach (TilemapTileEntryData tileEntry in tilesetData.Tiles)
         {
-            TilemapTileData tileData = BuildTileData(tileEntry);
+            TilemapTileData tileData = BuildTileData(tileEntry, graphicsDevice, baseDirectory);
             tileset.AddTileData(tileData);
         }
 
         return tileset;
     }
 
-    private static TilemapTileData BuildTileData(TilemapTileEntryData entryData)
+    private static TilemapTileData BuildTileData(TilemapTileEntryData entryData, GraphicsDevice graphicsDevice, string baseDirectory)
     {
         TilemapTileData tileData = new TilemapTileData(entryData.LocalId);
         tileData.Class = entryData.Class ?? string.Empty;
         tileData.Probability = entryData.Probability;
 
         ApplyProperties(entryData.Properties, tileData.Properties);
+
+        if (!string.IsNullOrEmpty(entryData.ImagePath))
+        {
+            try
+            {
+                tileData.CustomImage = LoadTexture(entryData.ImagePath, graphicsDevice, baseDirectory);
+            }
+            catch (TilemapParseException ex)
+            {
+                throw new TilemapParseException(
+                    $"Failed to load image for tile {entryData.LocalId}: {ex.Message}", ex);
+            }
+        }
 
         if (entryData.Animation != null && entryData.Animation.Frames.Count > 0)
         {

--- a/source/MonoGame.Extended/Tilemaps/TilemapTileset.cs
+++ b/source/MonoGame.Extended/Tilemaps/TilemapTileset.cs
@@ -143,6 +143,40 @@ public class TilemapTileset
     public IReadOnlyList<TilemapTileData> GetAnimatedTiles() => _animatedTileData;
 
     /// <summary>
+    /// Resolves the texture and source rectangle to use when rendering a tile.
+    /// </summary>
+    /// <param name="localId">The local tile ID within this tileset.</param>
+    /// <param name="texture">The texture to draw from.</param>
+    /// <param name="sourceRect">The source rectangle within the texture.</param>
+    /// <remarks>
+    /// For image collection tilesets each tile has its own image; the resolved texture will
+    /// differ per tile and the source rectangle will cover the full image. For atlas-based
+    /// tilesets the shared atlas texture and a sub-rectangle are returned. Current animation
+    /// frame advancement is also applied automatically.
+    /// </remarks>
+    public void GetRenderSource(int localId, out Texture2D texture, out Rectangle sourceRect)
+    {
+        TilemapTileData data = GetTileData(localId);
+        int renderLocalId = localId;
+
+        if (data?.Animation != null)
+        {
+            renderLocalId = data.Animation.CurrentFrame.TileId;
+            data = GetTileData(renderLocalId);
+        }
+
+        if (data?.CustomImage != null)
+        {
+            texture = data.CustomImage;
+            sourceRect = new Rectangle(0, 0, texture.Width, texture.Height);
+            return;
+        }
+
+        texture = Texture;
+        sourceRect = GetTileRegion(renderLocalId);
+    }
+
+    /// <summary>
     /// Gets the source rectangle for a tile within the texture atlas.
     /// </summary>
     /// <param name="localId">The local tile ID within this tileset.</param>


### PR DESCRIPTION
## Description

Adds support for Tiled tilesets (tsx) that are made using a "Collection of Images"

## Related Issues/Tickets

- Closes #1133 
## Changes Made

* Added support for Tiled tilesets created as a "Collection of Images" so they can be imported and used the same way as existing tilesets.
* Updated the content pipeline and tile data handling to carry per-tile image information through loading and content build steps.
* Updated runtime tile loading and rendering so tiles that use their own individual images are drawn correctly, including sizing/positioning and animated tile handling.
* Removed the previous behavior where these tilesets were effectively skipped/unsupported, while keeping existing atlas-based tilesets working as before.


## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
