### PR TITLE
Replace BitVector32 with custom ComponentBits to lift 32 component restriction

### DIFF
--- a/source/MonoGame.Extended/ECS/Aspect.cs
+++ b/source/MonoGame.Extended/ECS/Aspect.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Specialized;
 
 namespace MonoGame.Extended.ECS
 {
@@ -7,14 +6,14 @@ namespace MonoGame.Extended.ECS
     {
         internal Aspect()
         {
-            AllSet = new BitVector32();
-            ExclusionSet = new BitVector32();
-            OneSet = new BitVector32();
+            AllSet = new ComponentBits();
+            ExclusionSet = new ComponentBits();
+            OneSet = new ComponentBits();
         }
 
-        public BitVector32 AllSet;
-        public BitVector32 ExclusionSet;
-        public BitVector32 OneSet;
+        public ComponentBits AllSet;
+        public ComponentBits ExclusionSet;
+        public ComponentBits OneSet;
 
         public static AspectBuilder All(params Type[] types)
         {
@@ -31,16 +30,22 @@ namespace MonoGame.Extended.ECS
             return new AspectBuilder().Exclude(types);
         }
 
-        public bool IsInterested(BitVector32 componentBits)
+        public bool IsInterested(ComponentBits componentBits)
         {
-            if (AllSet.Data != 0 && (componentBits.Data & AllSet.Data) != AllSet.Data)
+            if (!AllSet.IsEmpty && !componentBits.HasAll(AllSet))
+            {
                 return false;
+            }
 
-            if (ExclusionSet.Data != 0 && (componentBits.Data & ExclusionSet.Data) != 0)
+            if (!ExclusionSet.IsEmpty && componentBits.HasAny(ExclusionSet))
+            {
                 return false;
+            }
 
-            if (OneSet.Data != 0 && (componentBits.Data & OneSet.Data) == 0)
+            if (!OneSet.IsEmpty && !componentBits.HasAny(OneSet))
+            {
                 return false;
+            }
 
             return true;
         }

--- a/source/MonoGame.Extended/ECS/AspectBuilder.cs
+++ b/source/MonoGame.Extended/ECS/AspectBuilder.cs
@@ -51,12 +51,12 @@ namespace MonoGame.Extended.ECS
         }
 
         // ReSharper disable once ParameterTypeCanBeEnumerable.Local
-        private static void Associate(ComponentManager componentManager, Bag<Type> types, ref BitVector32 bits)
+        private static void Associate(ComponentManager componentManager, Bag<Type> types, ref ComponentBits bits)
         {
             foreach (var type in types)
             {
                 var id = componentManager.GetComponentTypeId(type);
-                bits[1 << id] = true;
+                bits[id] = true;
             }
         }
     }

--- a/source/MonoGame.Extended/ECS/ComponentBits.cs
+++ b/source/MonoGame.Extended/ECS/ComponentBits.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace MonoGame.Extended.ECS;
+
+/// <summary>
+/// Represents a bit field for tracking which component types are associated with an entity.
+/// </summary>
+/// <remarks>
+/// This structure supports up to 256 different component types (4 segments × 64 bits each), where each bit position
+/// corresponds to a specific component type.
+/// </remarks>
+[StructLayout(LayoutKind.Sequential)]
+public struct ComponentBits : IEquatable<ComponentBits>
+{
+    private const int BITS_PER_SEGMENT = 64;
+    private const int SEGMENT_COUNT = 4;
+    private const int MAX_BITS = BITS_PER_SEGMENT * SEGMENT_COUNT;
+
+    private ulong _bits0;
+    private ulong _bits1;
+    private ulong _bits2;
+    private ulong _bits3;
+
+    /// <summary>
+    /// Gets or sets a bit at the specified index, representing whether a specific component type is present.
+    /// </summary>
+    /// <param name="bitIndex">The zero-based index of the bit to get or set. Must be between 0 and 255.</param>
+    /// <returns>
+    /// <see langword="true"/> if the bit at the specified index is set; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="bitIndex"/> is less than 0 or greater than or equal to 256.
+    /// </exception>
+    public unsafe bool this[int bitIndex]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(bitIndex, 0);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(bitIndex, MAX_BITS);
+
+            int segmentIndex = bitIndex / BITS_PER_SEGMENT;
+            int bitPosition = bitIndex % BITS_PER_SEGMENT;
+            ulong mask = 1UL << bitPosition;
+
+            fixed (ulong* bits = &_bits0)
+            {
+                return (bits[segmentIndex] & mask) != 0;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(bitIndex, 0);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(bitIndex, MAX_BITS);
+
+            int segmentIndex = bitIndex / BITS_PER_SEGMENT;
+            int bitPosition = bitIndex % BITS_PER_SEGMENT;
+            ulong mask = 1UL << bitPosition;
+
+            fixed (ulong* bits = &_bits0)
+            {
+                if (value)
+                {
+                    bits[segmentIndex] |= mask;
+                }
+                else
+                {
+                    bits[segmentIndex] &= ~mask;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether no component types are present.
+    /// </summary>
+    /// <returns><see langword="true"/> if no component types are set; otherwise, <see langword="false"/>.</returns>
+    public readonly bool IsEmpty
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _bits0 == 0 && _bits1 == 0 && _bits2 == 0 && _bits3 == 0;
+    }
+
+    /// <summary>
+    /// Determines if all the component types in the required set are present in this component set.
+    /// </summary>
+    /// <param name="required">The component types that must all be present.</param>
+    /// <returns>
+    /// <see langword="true"/> if this component set has all the required component types;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly bool HasAll(ComponentBits required)
+    {
+        return (_bits0 & required._bits0) == required._bits0 &&
+               (_bits1 & required._bits1) == required._bits1 &&
+               (_bits2 & required._bits2) == required._bits2 &&
+               (_bits3 & required._bits3) == required._bits3;
+    }
+
+    /// <summary>
+    /// Determines if this component set contains at least one of the specified component types.
+    /// </summary>
+    /// <param name="options">The component types to check for.</param>
+    /// <returns>
+    /// <see langword="true"/> if this component set has at least one of the specified component types;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly bool HasAny(ComponentBits options)
+    {
+        return ((_bits0 & options._bits0) |
+                (_bits1 & options._bits1) |
+                (_bits2 & options._bits2) |
+                (_bits3 & options._bits3)) != 0;
+    }
+
+    /// <summary>
+    /// Determines if this component set contains none of the specified component types.
+    /// </summary>
+    /// <param name="excluded">The component types that must not be present.</param>
+    /// <returns>
+    /// <see langword="true"/> if this component set has none of the specified component types;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly bool HasNone(ComponentBits excluded)
+    {
+        return ((_bits0 & excluded._bits0) |
+                (_bits1 & excluded._bits1) |
+                (_bits2 & excluded._bits2) |
+                (_bits3 & excluded._bits3)) == 0;
+    }
+
+    /// <summary>
+    /// Removes all component types from this component set.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Clear() => _bits0 = _bits1 = _bits2 = _bits3 = 0;
+
+    /// <summary>
+    /// Marks all possible component types as present in this component set.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetAll() => _bits0 = _bits1 = _bits2 = _bits3 = ulong.MaxValue;
+
+    /// <inheritdoc />
+    public override readonly bool Equals([NotNullWhen(true)] object obj) => obj is ComponentBits other && Equals(other);
+
+    /// <inheritdoc />
+    public readonly bool Equals(ComponentBits other)
+    {
+        return _bits0 == other._bits0 &&
+               _bits1 == other._bits1 &&
+               _bits2 == other._bits2 &&
+               _bits3 == other._bits3;
+    }
+
+    /// <inheritdoc />
+    public override readonly int GetHashCode() => HashCode.Combine(_bits0, _bits1, _bits2, _bits3);
+
+    /// <inheritdoc />
+    public static bool operator ==(ComponentBits left, ComponentBits right) => left.Equals(right);
+
+    /// <inheritdoc />
+    public static bool operator !=(ComponentBits left, ComponentBits right) => !left.Equals(right);
+
+    /// <inheritdoc />
+    public static ComponentBits operator |(ComponentBits left, ComponentBits right)
+    {
+        return new ComponentBits()
+        {
+            _bits0 = left._bits0 | right._bits0,
+            _bits1 = left._bits1 | right._bits1,
+            _bits2 = left._bits2 | right._bits2,
+            _bits3 = left._bits3 | right._bits3
+        };
+    }
+
+    /// <inheritdoc />
+    public static ComponentBits operator &(ComponentBits left, ComponentBits right)
+    {
+        return new ComponentBits()
+        {
+            _bits0 = left._bits0 & right._bits0,
+            _bits1 = left._bits1 & right._bits1,
+            _bits2 = left._bits2 & right._bits2,
+            _bits3 = left._bits3 & right._bits3
+        };
+    }
+
+    /// <inheritdoc />
+    public static ComponentBits operator ~(ComponentBits other)
+    {
+        return new ComponentBits()
+        {
+            _bits0 = ~other._bits0,
+            _bits1 = ~other._bits1,
+            _bits2 = ~other._bits2,
+            _bits3 = ~other._bits3
+        };
+    }
+}

--- a/source/MonoGame.Extended/ECS/ComponentBits.cs
+++ b/source/MonoGame.Extended/ECS/ComponentBits.cs
@@ -42,14 +42,16 @@ public struct ComponentBits : IEquatable<ComponentBits>
             ArgumentOutOfRangeException.ThrowIfLessThan(bitIndex, 0);
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(bitIndex, MAX_BITS);
 
-            int segmentIndex = bitIndex / BITS_PER_SEGMENT;
-            int bitPosition = bitIndex % BITS_PER_SEGMENT;
+            // bitIndex / BITS_PER_SEGMENT;
+            int segmentIndex = bitIndex >> 6;
+
+            // bitIndex % BITS_PER_SEGMENT;
+            int bitPosition = bitIndex & 63;
+
             ulong mask = 1UL << bitPosition;
 
-            fixed (ulong* bits = &_bits0)
-            {
-                return (bits[segmentIndex] & mask) != 0;
-            }
+            ref ulong segment = ref Unsafe.Add(ref _bits0, segmentIndex);
+            return (segment & mask) != 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -58,20 +60,22 @@ public struct ComponentBits : IEquatable<ComponentBits>
             ArgumentOutOfRangeException.ThrowIfLessThan(bitIndex, 0);
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(bitIndex, MAX_BITS);
 
-            int segmentIndex = bitIndex / BITS_PER_SEGMENT;
-            int bitPosition = bitIndex % BITS_PER_SEGMENT;
+            // bitIndex / BITS_PER_SEGMENT;
+            int segmentIndex = bitIndex >> 6;
+
+            // bitIndex % BITS_PER_SEGMENT;
+            int bitPosition = bitIndex & 63;
+
             ulong mask = 1UL << bitPosition;
 
-            fixed (ulong* bits = &_bits0)
+            ref ulong segment = ref Unsafe.Add(ref _bits0, segmentIndex);
+            if (value)
             {
-                if (value)
-                {
-                    bits[segmentIndex] |= mask;
-                }
-                else
-                {
-                    bits[segmentIndex] &= ~mask;
-                }
+                segment |= mask;
+            }
+            else
+            {
+                segment &= ~mask;
             }
         }
     }

--- a/source/MonoGame.Extended/ECS/ComponentManager.cs
+++ b/source/MonoGame.Extended/ECS/ComponentManager.cs
@@ -17,6 +17,8 @@ namespace MonoGame.Extended.ECS
 
     public class ComponentManager : UpdateSystem, IComponentMapperService, IEnumerable<ComponentMapper>
     {
+        private const int MAX_COMPONENT_TYPES = 256;
+
         public ComponentManager()
         {
             _componentMappers = new Bag<ComponentMapper>();
@@ -33,9 +35,8 @@ namespace MonoGame.Extended.ECS
             if (!type.IsClass)
                 throw new ArgumentException("Type must be a class type.", nameof(type));
 
-            // TODO: We can probably do better than this without a huge performance penalty by creating our own bit vector that grows after the first 32 bits.
-            if (componentTypeId >= 32)
-                throw new InvalidOperationException("Component type limit exceeded. We currently only allow 32 component types for performance reasons.");
+            if (componentTypeId >= MAX_COMPONENT_TYPES)
+                throw new InvalidOperationException($"Component type limit exceeded. Maximum of {MAX_COMPONENT_TYPES} component types are supported.");
 
             var mapperType = typeof(ComponentMapper<>).MakeGenericType(type);
             var mapper = Activator.CreateInstance(mapperType, args: new object[] { componentTypeId, ComponentsChanged });
@@ -46,9 +47,8 @@ namespace MonoGame.Extended.ECS
         private ComponentMapper<T> CreateMapperForType<T>(int componentTypeId)
             where T : class
         {
-            // TODO: We can probably do better than this without a huge performance penalty by creating our own bit vector that grows after the first 32 bits.
-            if (componentTypeId >= 32)
-                throw new InvalidOperationException("Component type limit exceeded. We currently only allow 32 component types for performance reasons.");
+            if (componentTypeId >= MAX_COMPONENT_TYPES)
+                throw new InvalidOperationException($"Component type limit exceeded. Maximum of {MAX_COMPONENT_TYPES} component types are supported.");
 
             var mapper = new ComponentMapper<T>(componentTypeId, ComponentsChanged);
             _componentMappers[componentTypeId] = mapper;
@@ -81,15 +81,13 @@ namespace MonoGame.Extended.ECS
             return id;
         }
 
-        public BitVector32 CreateComponentBits(int entityId)
+        public ComponentBits CreateComponentBits(int entityId)
         {
-            var componentBits = new BitVector32();
-            var mask = BitVector32.CreateMask();
+            var componentBits = new ComponentBits();
 
             for (var componentId = 0; componentId < _componentMappers.Count; componentId++)
             {
-                componentBits[mask] = _componentMappers[componentId]?.Has(entityId) ?? false;
-                mask = BitVector32.CreateMask(mask);
+                componentBits[componentId] = _componentMappers[componentId]?.Has(entityId) ?? false;
             }
 
             return componentBits;

--- a/source/MonoGame.Extended/ECS/Entity.cs
+++ b/source/MonoGame.Extended/ECS/Entity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Specialized;
 
 namespace MonoGame.Extended.ECS
 {
@@ -17,8 +16,8 @@ namespace MonoGame.Extended.ECS
         }
 
         public int Id { get; }
-        
-        public BitVector32 ComponentBits => _entityManager.GetComponentBits(Id);
+
+        public ComponentBits ComponentBits => _entityManager.GetComponentBits(Id);
 
         public void Attach<T>(T component)
             where T : class 

--- a/source/MonoGame.Extended/ECS/EntityManager.cs
+++ b/source/MonoGame.Extended/ECS/EntityManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Xna.Framework;
@@ -19,7 +18,7 @@ namespace MonoGame.Extended.ECS
             _addedEntities = new Bag<int>(_defaultBagSize);
             _removedEntities = new Bag<int>(_defaultBagSize);
             _changedEntities = new Bag<int>(_defaultBagSize);
-            _entityToComponentBits = new Bag<BitVector32>(_defaultBagSize);
+            _entityToComponentBits = new Bag<ComponentBits>(_defaultBagSize);
             _componentManager.ComponentsChanged += OnComponentsChanged;
 
             _entityBag = new Bag<Entity>(_defaultBagSize);
@@ -38,7 +37,7 @@ namespace MonoGame.Extended.ECS
         private readonly Bag<int> _addedEntities;
         private readonly Bag<int> _removedEntities;
         private readonly Bag<int> _changedEntities;
-        private readonly Bag<BitVector32> _entityToComponentBits;
+        private readonly Bag<ComponentBits> _entityToComponentBits;
 
         public event Action<int> EntityAdded;
         public event Action<int> EntityRemoved;
@@ -51,7 +50,7 @@ namespace MonoGame.Extended.ECS
             Debug.Assert(_entityBag[id] == null);
             _entityBag[id] = entity;
             _addedEntities.Add(id);
-            _entityToComponentBits[id] = new BitVector32(0);
+            _entityToComponentBits[id] = new ComponentBits();
             return entity;
         }
 
@@ -71,7 +70,7 @@ namespace MonoGame.Extended.ECS
             return _entityBag[entityId];
         }
 
-        public BitVector32 GetComponentBits(int entityId)
+        public ComponentBits GetComponentBits(int entityId)
         {
             return _entityToComponentBits[entityId];
         }
@@ -108,7 +107,7 @@ namespace MonoGame.Extended.ECS
                 var entity = _entityBag[entityId];
                 _entityBag[entityId] = null;
                 _componentManager.Destroy(entityId);
-                _entityToComponentBits[entityId] = default(BitVector32);
+                _entityToComponentBits[entityId] = default(ComponentBits);
                 ActiveCount--;
                 _entityPool.Free(entity);
             }

--- a/tests/MonoGame.Extended.Tests/ECS/AspectBuilderTests.cs
+++ b/tests/MonoGame.Extended.Tests/ECS/AspectBuilderTests.cs
@@ -62,9 +62,9 @@ namespace MonoGame.Extended.ECS.Tests
 
             var aspect = builder.Build(componentManager);
 
-            Assert.True(aspect.AllSet.Data != 0);
-            Assert.True(aspect.OneSet.Data != 0);
-            Assert.True(aspect.ExclusionSet.Data != 0);
+            Assert.False(aspect.AllSet.IsEmpty);
+            Assert.False(aspect.OneSet.IsEmpty);
+            Assert.False(aspect.ExclusionSet.IsEmpty);
         }
     }
 }

--- a/tests/MonoGame.Extended.Tests/ECS/AspectTests.cs
+++ b/tests/MonoGame.Extended.Tests/ECS/AspectTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Specialized;
-using MonoGame.Extended.Graphics;
+﻿using MonoGame.Extended.Graphics;
 using Xunit;
 
 namespace MonoGame.Extended.ECS.Tests
@@ -11,23 +10,23 @@ namespace MonoGame.Extended.ECS.Tests
     public class AspectTests
     {
         private readonly ComponentManager _componentManager;
-        private readonly BitVector32 _entityA;
-        private readonly BitVector32 _entityB;
+        private readonly ComponentBits _entityA;
+        private readonly ComponentBits _entityB;
 
         public AspectTests()
         {
             _componentManager = new ComponentManager();
-            _entityA = new BitVector32
-            {
-                [1 << _componentManager.GetComponentTypeId(typeof(Transform2))] = true,
-                [1 << _componentManager.GetComponentTypeId(typeof(Sprite))] = true,
-                [1 << _componentManager.GetComponentTypeId(typeof(DummyComponent))] = true
-            };
-            _entityB = new BitVector32
-            {
-                [1 << _componentManager.GetComponentTypeId(typeof(Transform2))] = true,
-                [1 << _componentManager.GetComponentTypeId(typeof(Sprite))] = true,
-            };
+
+            // EntityA has Transform2, Sprite, and DummyComponent
+            _entityA = new ComponentBits();
+            _entityA[_componentManager.GetComponentTypeId(typeof(Transform2))] = true;
+            _entityA[_componentManager.GetComponentTypeId(typeof(Sprite))] = true;
+            _entityA[_componentManager.GetComponentTypeId(typeof(DummyComponent))] = true;
+
+            // EntityB has Transform2 and Sprite only
+            _entityB = new ComponentBits();
+            _entityB[_componentManager.GetComponentTypeId(typeof(Transform2))] = true;
+            _entityB[_componentManager.GetComponentTypeId(typeof(Sprite))] = true;
         }
 
         [Fact]


### PR DESCRIPTION
## Description

Replaces the .NET `BitVector32` with a custom `ComponentBits` implementation to remove the 32 component type limitation in the ECS system.  This increases the maximum supported component types from 32 to 256

## Related Issues/Tickets

* Closes #1024 
* This was previously merged in #1061 but the branch it was merged to was deleted.  This is to revert that back into the 6.0.0 branch

## Changes Made

* Created `ComponentBits.cs` - A custom 256-bit vector implementation using 4 × 64-bit segments
* Updated `Aspect.cs` to use `ComponentBits` instead of `BitVector32` for `AllSet`, `ExclusionSet`, and `OneSet` fields
* Modified `Entity.cs` `ComponentBits` property to return `ComponentBits` instead of `BitVector32`
* Changed `Aspect.IsInterested()` method signature to accept `ComponentBits` parameter
* Updated `AspectBuilder.cs`, `ComponentManager.cs`, and `EntityManager.cs` to work with the new bit vector implementation
* Increased component type limit from 32 to 256 in `ComponentManager`
* Updated unit tests in `AspectTests.cs` and `AspectBuilderTests.cs` to use the new `ComponentBits` API

## Checklist

Please read and check the following items. Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
