### PR TITLE
Fix/tilemap render clipping

### DIFF
--- a/source/MonoGame.Extended/Tilemaps/Rendering/TilemapSpriteBatchRenderer.cs
+++ b/source/MonoGame.Extended/Tilemaps/Rendering/TilemapSpriteBatchRenderer.cs
@@ -25,6 +25,7 @@ public sealed class TilemapSpriteBatchRenderer
 {
     private Tilemap _tilemap;
     private readonly List<TilemapTileData> _animatedTiles = new List<TilemapTileData>();
+    private TileRenderPadding _tileRenderPadding;
 
     /// <summary>
     /// Gets or sets the blend state used when drawing tiles.
@@ -74,6 +75,7 @@ public sealed class TilemapSpriteBatchRenderer
     {
         _tilemap = tilemap ?? throw new ArgumentNullException(nameof(tilemap));
         BuildAnimatedTilesList();
+        _tileRenderPadding = ComputeTileRenderPadding(tilemap);
     }
 
     /// <summary>
@@ -83,6 +85,7 @@ public sealed class TilemapSpriteBatchRenderer
     {
         _tilemap = null;
         _animatedTiles.Clear();
+        _tileRenderPadding = default;
     }
 
     /// <summary>
@@ -568,12 +571,40 @@ public sealed class TilemapSpriteBatchRenderer
         float worldLeft = parallaxOrigin.X + (camBounds.X - parallaxOrigin.X) * parallax.X - tileLayer.Offset.X;
         float worldTop = parallaxOrigin.Y + (camBounds.Y - parallaxOrigin.Y) * parallax.Y - tileLayer.Offset.Y;
 
-        int startX = Math.Max(0, (int)Math.Floor(worldLeft / tileLayer.TileWidth));
-        int startY = Math.Max(0, (int)Math.Floor(worldTop / tileLayer.TileHeight));
-        int endX = Math.Min(tileLayer.Width, (int)Math.Ceiling((worldLeft + camBounds.Width) / tileLayer.TileWidth));
-        int endY = Math.Min(tileLayer.Height, (int)Math.Ceiling((worldTop + camBounds.Height) / tileLayer.TileHeight));
+        // Oversized tiles can render outside their owning cell, especially image-collection
+        // tiles and tilesets with tile offsets. Expand the queried tile region by the maximum
+        // render overhang so partially visible tiles are not culled too early at the viewport edge.
+        // https://github.com/MonoGame-Extended/Monogame-Extended/issues/1139
+        int startX = Math.Max(0, (int)Math.Floor((worldLeft - _tileRenderPadding.Right) / tileLayer.TileWidth));
+        int startY = Math.Max(0, (int)Math.Floor((worldTop - _tileRenderPadding.Bottom) / tileLayer.TileHeight));
+        int endX = Math.Min(tileLayer.Width, (int)Math.Ceiling((worldLeft + camBounds.Width + _tileRenderPadding.Left) / tileLayer.TileWidth));
+        int endY = Math.Min(tileLayer.Height, (int)Math.Ceiling((worldTop + camBounds.Height + _tileRenderPadding.Top) / tileLayer.TileHeight));
 
         return new Rectangle(startX, startY, endX - startX, endY - startY);
+    }
+
+    // https://github.com/MonoGame-Extended/Monogame-Extended/issues/1139
+    private static TileRenderPadding ComputeTileRenderPadding(Tilemap tilemap)
+    {
+        float left = 0f;
+        float top = 0f;
+        float right = 0f;
+        float bottom = 0f;
+
+        foreach (TilemapTileset tileset in tilemap.Tilesets)
+        {
+            float tileLeft = tileset.TileOffset.X;
+            float tileTop = tileset.TileOffset.Y + tilemap.TileHeight - tileset.TileHeight;
+            float tileRight = tileset.TileOffset.X + tileset.TileWidth;
+            float tileBottom = tileset.TileOffset.Y + tilemap.TileHeight;
+
+            left = Math.Max(left, Math.Max(0f, -tileLeft));
+            top = Math.Max(top, Math.Max(0f, -tileTop));
+            right = Math.Max(right, Math.Max(0f, tileRight - tilemap.TileWidth));
+            bottom = Math.Max(bottom, Math.Max(0f, tileBottom - tilemap.TileHeight));
+        }
+
+        return new TileRenderPadding(left, top, right, bottom);
     }
 
     private static Color ComputeLayerColor(TilemapLayer layer)
@@ -675,4 +706,6 @@ public sealed class TilemapSpriteBatchRenderer
             throw new InvalidOperationException("No tilemap loaded. Call LoadTilemap first.");
         }
     }
+
+    private readonly record struct TileRenderPadding(float Left, float Top, float Right, float Bottom);
 }

--- a/tests/MonoGame.Extended.Tests/Tilemaps/Rendering/TilemapIntegrationTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tilemaps/Rendering/TilemapIntegrationTests.cs
@@ -588,6 +588,61 @@ public class TilemapIntegrationTests
         Assert.True(AnyPixelNotBlack(pixels));
     }
 
+    [Fact]
+    // Added while investigating issue #1139:
+    // https://github.com/MonoGame-Extended/Monogame-Extended/issues/1139
+    public void SbRenderer_WideImageCollectionTile_RemainsVisibleAtLeftEdge()
+    {
+        TilemapSpriteBatchRenderer renderer = new TilemapSpriteBatchRenderer();
+        Tilemap tilemap = CreateSingleImageCollectionTileMap(
+            mapWidth: 4,
+            mapHeight: 4,
+            tileX: 0,
+            tileY: 0,
+            imageWidth: TileSize * 2,
+            imageHeight: TileSize,
+            tileColor: Color.White);
+        renderer.LoadTilemap(tilemap);
+
+        var (pixels, width) = RenderToPixels(() =>
+        {
+            OrthographicCamera camera = new OrthographicCamera(_graphicsDevice);
+            camera.Position = new Vector2(TileSize + TileSize / 2f, 0f);
+            renderer.Draw(_spriteBatch, camera);
+        });
+
+        Assert.Equal(Color.White, GetPixel(pixels, width, 8, TileCenterY));
+    }
+
+    [Fact]
+    // Added while investigating issue #1139:
+    // https://github.com/MonoGame-Extended/Monogame-Extended/issues/1139
+    public void SbRenderer_TallImageCollectionTile_RemainsVisibleAtBottomEdge()
+    {
+        TilemapSpriteBatchRenderer renderer = new TilemapSpriteBatchRenderer();
+        int viewportHeight = _graphicsDevice.Viewport.Height;
+        int tileY = (int)Math.Ceiling(viewportHeight / (float)TileSize);
+
+        Tilemap tilemap = CreateSingleImageCollectionTileMap(
+            mapWidth: 4,
+            mapHeight: tileY + 2,
+            tileX: 0,
+            tileY: tileY,
+            imageWidth: TileSize,
+            imageHeight: TileSize * 2,
+            tileColor: Color.White);
+        renderer.LoadTilemap(tilemap);
+
+        var (pixels, width) = RenderToPixels(() =>
+        {
+            OrthographicCamera camera = new OrthographicCamera(_graphicsDevice);
+            renderer.Draw(_spriteBatch, camera);
+        });
+
+        int height = pixels.Length / width;
+        Assert.Equal(Color.White, GetPixel(pixels, width, TileCenterX, height - 8));
+    }
+
     // ---- Infrastructure ----
 
     private (Color[] Pixels, int Width) RenderToPixels(Action render)
@@ -757,6 +812,46 @@ public class TilemapIntegrationTests
             tileHeight: TileSize);
 
         layer.SetTile(0, 0, new TilemapTile(tileset.FirstGlobalId, flags));
+        tilemap.Layers.Add(layer);
+        return tilemap;
+    }
+
+    private Tilemap CreateSingleImageCollectionTileMap(int mapWidth, int mapHeight, int tileX, int tileY, int imageWidth, int imageHeight, Color tileColor)
+    {
+        Tilemap tilemap = new Tilemap(
+            name: "ImageCollectionMap",
+            width: mapWidth,
+            height: mapHeight,
+            tileWidth: TileSize,
+            tileHeight: TileSize,
+            orientation: TilemapOrientation.Orthogonal);
+
+        TilemapTileset tileset = new TilemapTileset(
+            name: "ImageCollectionTileset",
+            texture: null,
+            tileWidth: imageWidth,
+            tileHeight: imageHeight,
+            tileCount: 1,
+            columns: 0,
+            spacing: 0,
+            margin: 0);
+        tileset.FirstGlobalId = 1;
+
+        TilemapTileData tileData = new TilemapTileData(localId: 0)
+        {
+            CustomImage = CreateFilledTexture(imageWidth, imageHeight, tileColor)
+        };
+        tileset.AddTileData(tileData);
+        tilemap.Tilesets.Add(tileset);
+
+        TilemapTileLayer layer = new TilemapTileLayer(
+            name: "Layer",
+            width: mapWidth,
+            height: mapHeight,
+            tileWidth: TileSize,
+            tileHeight: TileSize);
+
+        layer.SetTile(tileX, tileY, new TilemapTile(tileset.FirstGlobalId));
         tilemap.Layers.Add(layer);
         return tilemap;
     }


### PR DESCRIPTION
## Description

Fixes a `TilemapSpriteBatchRenderer` culling bug where oversized tiles from image collection tilesets could disappear too early when partially visible near the left or bottom edge of the viewport.

## Related Issues/Tickets

* Closes #1139

## Changes Made

* Updated `TilemapSpriteBatchRenderer` visible region culling to account for tile render overhang beyond the logical cell bounds
* Added padding calculation based on tileset render bounds so oversized image collection tiles are still considered visible when part of their image overlaps the viewport.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
