### PR TITLE
Add external resource resolver support for tilemap parsers

### DIFF
--- a/source/MonoGame.Extended/Content/ExternalResourceResolver.cs
+++ b/source/MonoGame.Extended/Content/ExternalResourceResolver.cs
@@ -1,0 +1,16 @@
+using System.IO;
+
+namespace MonoGame.Extended.Content;
+
+/// <summary>
+/// Opens a stream for an external resource referenced by another asset.
+/// </summary>
+/// <param name="path">
+/// The resource path requested by the asset loader. The path may be absolute or relative,
+/// depending on the loader and resolver being used.
+/// </param>
+/// <returns>
+/// A readable stream positioned at the beginning of the resource. The asset loader that
+/// invokes the resolver is responsible for disposing the returned stream.
+/// </returns>
+public delegate Stream ExternalResourceResolver(string path);

--- a/source/MonoGame.Extended/Content/ExternalResourceResolvers.cs
+++ b/source/MonoGame.Extended/Content/ExternalResourceResolvers.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended.Content;
+
+/// <summary>
+/// Provides common external resource resolver implementations.
+/// </summary>
+public static class ExternalResourceResolvers
+{
+    /// <summary>
+    /// Opens a resource from the local file system.
+    /// </summary>
+    /// <param name="path">The absolute or relative file path to open.</param>
+    /// <returns>A readable stream for the file.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
+    public static Stream OpenFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return File.OpenRead(path);
+    }
+
+    /// <summary>
+    /// Opens a resource by using <see cref="TitleContainer"/>.
+    /// </summary>
+    /// <param name="path">The title-relative resource path to open.</param>
+    /// <returns>A readable stream for the resource.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is <see langword="null"/>.</exception>
+    public static Stream OpenTitleContainerStream(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return TitleContainer.OpenStream(path);
+    }
+}

--- a/source/MonoGame.Extended/Tilemaps/LDtk/LDtkJsonParser.cs
+++ b/source/MonoGame.Extended/Tilemaps/LDtk/LDtkJsonParser.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.Content;
 using MonoGame.Extended.Tilemaps.LDtk.Converters;
 using MonoGame.Extended.Tilemaps.LDtk.Document;
 using MonoGame.Extended.Tilemaps.Parsers;
@@ -24,6 +25,7 @@ public class LDtkJsonParser : ITilemapParser
     };
 
     private readonly string _baseDirectory;
+    private readonly ExternalResourceResolver _resourceResolver;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LDtkJsonParser"/> class.
@@ -33,9 +35,14 @@ public class LDtkJsonParser : ITilemapParser
     /// <see cref="ParseFromFile"/> will be resolved relative to this directory.
     /// If <see langword="null"/>, paths are resolved from the file's own location.
     /// </param>
-    public LDtkJsonParser(string baseDirectory = null)
+    /// <param name="resourceResolver">
+    /// Optional resolver used to open external resources referenced by the project. If
+    /// <see langword="null"/>, resources are opened from the local file system.
+    /// </param>
+    public LDtkJsonParser(string baseDirectory = null, ExternalResourceResolver resourceResolver = null)
     {
         _baseDirectory = baseDirectory;
+        _resourceResolver = resourceResolver ?? ExternalResourceResolvers.OpenFile;
     }
 
     /// <summary>
@@ -76,16 +83,15 @@ public class LDtkJsonParser : ITilemapParser
             ? Path.Combine(_baseDirectory, filePath)
             : filePath;
 
-        if (!File.Exists(fullPath))
-        {
-            throw new FileNotFoundException($"LDtk file not found: {fullPath}", fullPath);
-        }
-
         try
         {
-            using FileStream stream = File.OpenRead(fullPath);
+            using Stream stream = OpenProjectStream(fullPath);
             string directory = Path.GetDirectoryName(fullPath);
             return ParseFromStream(stream, graphicsDevice, directory);
+        }
+        catch (FileNotFoundException)
+        {
+            throw;
         }
         catch (TilemapParseException)
         {
@@ -166,11 +172,6 @@ public class LDtkJsonParser : ITilemapParser
             ? Path.Combine(_baseDirectory, filePath)
             : filePath;
 
-        if (!File.Exists(fullPath))
-        {
-            throw new FileNotFoundException($"LDtk file not found: {fullPath}", fullPath);
-        }
-
         try
         {
             string projectDirectory = Path.GetDirectoryName(fullPath);
@@ -183,6 +184,10 @@ public class LDtkJsonParser : ITilemapParser
             }
 
             return ConvertLevel(level, project, graphicsDevice, projectDirectory);
+        }
+        catch (FileNotFoundException)
+        {
+            throw;
         }
         catch (TilemapParseException)
         {
@@ -211,11 +216,6 @@ public class LDtkJsonParser : ITilemapParser
             ? Path.Combine(_baseDirectory, filePath)
             : filePath;
 
-        if (!File.Exists(fullPath))
-        {
-            throw new FileNotFoundException($"LDtk file not found: {fullPath}", fullPath);
-        }
-
         try
         {
             string projectDirectory = Path.GetDirectoryName(fullPath);
@@ -229,6 +229,10 @@ public class LDtkJsonParser : ITilemapParser
             }
 
             return tilemaps;
+        }
+        catch (FileNotFoundException)
+        {
+            throw;
         }
         catch (TilemapParseException)
         {
@@ -296,11 +300,6 @@ public class LDtkJsonParser : ITilemapParser
             ? Path.Combine(_baseDirectory, filePath)
             : filePath;
 
-        if (!File.Exists(fullPath))
-        {
-            throw new FileNotFoundException($"LDtk file not found: {fullPath}", fullPath);
-        }
-
         try
         {
             LDtkProject project = LoadProject(fullPath);
@@ -319,6 +318,10 @@ public class LDtkJsonParser : ITilemapParser
             }
 
             return toc;
+        }
+        catch (FileNotFoundException)
+        {
+            throw;
         }
         catch (TilemapParseException)
         {
@@ -349,11 +352,6 @@ public class LDtkJsonParser : ITilemapParser
         string fullPath = _baseDirectory != null
             ? Path.Combine(_baseDirectory, filePath)
             : filePath;
-
-        if (!File.Exists(fullPath))
-        {
-            throw new FileNotFoundException($"LDtk file not found: {fullPath}", fullPath);
-        }
 
         try
         {
@@ -396,6 +394,10 @@ public class LDtkJsonParser : ITilemapParser
         {
             throw;
         }
+        catch (FileNotFoundException)
+        {
+            throw;
+        }
         catch (InvalidOperationException)
         {
             throw;
@@ -421,11 +423,6 @@ public class LDtkJsonParser : ITilemapParser
             ? Path.Combine(_baseDirectory, filePath)
             : filePath;
 
-        if (!File.Exists(fullPath))
-        {
-            throw new FileNotFoundException($"LDtk file not found: {fullPath}", fullPath);
-        }
-
         try
         {
             LDtkProject project = LoadProject(fullPath);
@@ -440,6 +437,10 @@ public class LDtkJsonParser : ITilemapParser
 
             return new List<string>();
         }
+        catch (FileNotFoundException)
+        {
+            throw;
+        }
         catch (TilemapParseException)
         {
             throw;
@@ -450,10 +451,10 @@ public class LDtkJsonParser : ITilemapParser
         }
     }
 
-    private static LDtkProject LoadProject(string filePath)
+    private LDtkProject LoadProject(string filePath)
     {
-        string json = File.ReadAllText(filePath);
-        LDtkProject project = JsonSerializer.Deserialize<LDtkProject>(json, s_jsonOptions);
+        using Stream stream = OpenProjectStream(filePath);
+        LDtkProject project = JsonSerializer.Deserialize<LDtkProject>(stream, s_jsonOptions);
 
         if (project == null)
         {
@@ -463,7 +464,7 @@ public class LDtkJsonParser : ITilemapParser
         return project;
     }
 
-    private static Tilemap ConvertLevel(LDtkLevel level, LDtkProject project, GraphicsDevice graphicsDevice, string projectDirectory)
+    private Tilemap ConvertLevel(LDtkLevel level, LDtkProject project, GraphicsDevice graphicsDevice, string projectDirectory)
     {
         string baseDirectory = projectDirectory ?? Directory.GetCurrentDirectory();
 
@@ -471,15 +472,7 @@ public class LDtkJsonParser : ITilemapParser
         {
             string levelPath = Path.Combine(baseDirectory, level.ExternalRelPath);
 
-            if (!File.Exists(levelPath))
-            {
-                throw new TilemapParseException(
-                    $"Level '{level.Identifier}' references external file '{level.ExternalRelPath}' " +
-                    $"which could not be found. Expected at: {levelPath}");
-            }
-
-            string levelJson = File.ReadAllText(levelPath);
-            LDtkLevel externalLevel = JsonSerializer.Deserialize<LDtkLevel>(levelJson, s_jsonOptions);
+            LDtkLevel externalLevel = LoadExternalLevel(level, levelPath);
 
             if (externalLevel != null)
             {
@@ -488,6 +481,45 @@ public class LDtkJsonParser : ITilemapParser
         }
 
         TilemapData data = LDtkTilemapDataConverter.Convert(level, project);
-        return TilemapFactory.Build(data, graphicsDevice, baseDirectory);
+        return TilemapFactory.Build(data, graphicsDevice, baseDirectory, _resourceResolver);
+    }
+
+    private Stream OpenProjectStream(string filePath)
+    {
+        try
+        {
+            return _resourceResolver(filePath);
+        }
+        catch (FileNotFoundException)
+        {
+            throw;
+        }
+        catch (TilemapParseException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new TilemapParseException($"Failed to open LDtk file: {filePath}", ex);
+        }
+    }
+
+    private LDtkLevel LoadExternalLevel(LDtkLevel level, string levelPath)
+    {
+        try
+        {
+            using Stream stream = _resourceResolver(levelPath);
+            return JsonSerializer.Deserialize<LDtkLevel>(stream, s_jsonOptions);
+        }
+        catch (TilemapParseException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new TilemapParseException(
+                $"Level '{level.Identifier}' references external file '{level.ExternalRelPath}' " +
+                $"which could not be opened. Expected at: {levelPath}", ex);
+        }
     }
 }

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/Converters/OgmoTilemapDataConverter.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/Converters/OgmoTilemapDataConverter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using Microsoft.Xna.Framework;
-
+using MonoGame.Extended.Content;
 using MonoGame.Extended.Tilemaps.Ogmo.Document;
 
 namespace MonoGame.Extended.Tilemaps.Ogmo.Converters;
@@ -24,8 +24,15 @@ internal static class OgmoTilemapDataConverter
 
     public static TilemapData Convert(OgmoLevel level, OgmoProject project)
     {
+        return Convert(level, project, Directory.GetCurrentDirectory(), ExternalResourceResolvers.OpenFile);
+    }
+
+    public static TilemapData Convert(OgmoLevel level, OgmoProject project, string baseDirectory, ExternalResourceResolver resourceResolver)
+    {
         ArgumentNullException.ThrowIfNull(level);
         ArgumentNullException.ThrowIfNull(project);
+        ArgumentNullException.ThrowIfNull(baseDirectory);
+        ArgumentNullException.ThrowIfNull(resourceResolver);
 
         int gridSize = (int)(project.LayerGridDefaultSize?.X ?? 16);
         if (gridSize <= 0)
@@ -47,7 +54,7 @@ internal static class OgmoTilemapDataConverter
             data.BackgroundColor = OgmoColorParser.ParseColor(project.BackgroundColor);
         }
 
-        Dictionary<string, TilesetGidInfo> tilesetInfo = ConvertTilesets(project, data);
+        Dictionary<string, TilesetGidInfo> tilesetInfo = ConvertTilesets(project, data, baseDirectory, resourceResolver);
         ConvertLayers(level, project, data, tilesetInfo);
         ConvertLevelProperties(level, data);
 
@@ -56,7 +63,7 @@ internal static class OgmoTilemapDataConverter
 
     #region Tilesets
 
-    private static Dictionary<string, TilesetGidInfo> ConvertTilesets(OgmoProject project, TilemapData data)
+    private static Dictionary<string, TilesetGidInfo> ConvertTilesets(OgmoProject project, TilemapData data, string baseDirectory, ExternalResourceResolver resourceResolver)
     {
         Dictionary<string, TilesetGidInfo> tilesetInfo = new Dictionary<string, TilesetGidInfo>();
 
@@ -80,7 +87,7 @@ internal static class OgmoTilemapDataConverter
                 continue;
             }
 
-            Point imgSize = ReadImageDimensions(imagePath);
+            Point imgSize = ReadImageDimensions(imagePath, baseDirectory, resourceResolver);
             int columns = CalculateCount(imgSize.X, tilesetTemplate.TileWidth, tilesetTemplate.TileSeparationX);
             int rows = CalculateCount(imgSize.Y, tilesetTemplate.TileHeight, tilesetTemplate.TileSeparationY);
             int tileCount = columns * rows;
@@ -457,16 +464,11 @@ internal static class OgmoTilemapDataConverter
 
     #region Image Dimension Helpers
 
-    private static Point ReadImageDimensions(string imagePath)
+    private static Point ReadImageDimensions(string imagePath, string baseDirectory, ExternalResourceResolver resourceResolver)
     {
         if (imagePath.StartsWith("data:image", StringComparison.OrdinalIgnoreCase))
         {
             return ReadDimensionsFromDataUri(imagePath);
-        }
-
-        if (!File.Exists(imagePath))
-        {
-            return Point.Zero;
         }
 
         try
@@ -475,8 +477,12 @@ internal static class OgmoTilemapDataConverter
             // 16-19 = width (big-endian), 20-23 = height (big-endian).
             byte[] header = new byte[24];
 
-            using FileStream fs = File.OpenRead(imagePath);
-            int bytesRead = fs.Read(header, 0, 24);
+            string fullPath = Path.IsPathRooted(imagePath)
+                ? imagePath
+                : Path.Combine(baseDirectory, imagePath);
+
+            using Stream stream = resourceResolver(fullPath);
+            int bytesRead = stream.Read(header, 0, 24);
 
             if (bytesRead < 24)
             {

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/OgmoJsonParser.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/OgmoJsonParser.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.Content;
 using MonoGame.Extended.Tilemaps.Ogmo.Converters;
 using MonoGame.Extended.Tilemaps.Ogmo.Document;
 using MonoGame.Extended.Tilemaps.Parsers;
@@ -24,6 +25,7 @@ public sealed class OgmoJsonParser : ITilemapParser
 
     private readonly string _projectPath;
     private readonly string _baseDirectory;
+    private readonly ExternalResourceResolver _resourceResolver;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OgmoJsonParser"/> class.
@@ -33,18 +35,17 @@ public sealed class OgmoJsonParser : ITilemapParser
     /// Optional base directory for resolving relative level file paths. If not provided,
     /// the project file's directory will be used.
     /// </param>
-    /// <exception cref="FileNotFoundException">The project file does not exist.</exception>
-    public OgmoJsonParser(string projectPath, string baseDirectory = null)
+    /// <param name="resourceResolver">
+    /// Optional resolver used to open external resources referenced by the project. If
+    /// <see langword="null"/>, resources are opened from the local file system.
+    /// </param>
+    public OgmoJsonParser(string projectPath, string baseDirectory = null, ExternalResourceResolver resourceResolver = null)
     {
         ArgumentNullException.ThrowIfNull(projectPath);
 
-        if (!File.Exists(projectPath))
-        {
-            throw new FileNotFoundException($"Ogmo project file not found: {projectPath}", projectPath);
-        }
-
         _projectPath = projectPath;
-        _baseDirectory = baseDirectory ?? Path.GetDirectoryName(projectPath);
+        _baseDirectory = baseDirectory ?? GetDirectoryOrCurrent(projectPath);
+        _resourceResolver = resourceResolver ?? ExternalResourceResolvers.OpenFile;
     }
 
     /// <summary>
@@ -86,17 +87,12 @@ public sealed class OgmoJsonParser : ITilemapParser
 
         string fullPath = Path.Combine(_baseDirectory, filePath);
 
-        if (!File.Exists(fullPath))
-        {
-            throw new FileNotFoundException($"Ogmo level file not found: {fullPath}", fullPath);
-        }
-
         try
         {
             OgmoProject project = LoadProject(_projectPath);
             OgmoLevel level = LoadLevel(fullPath);
 
-            string projectDirectory = Path.GetDirectoryName(_projectPath);
+            string projectDirectory = GetDirectoryOrCurrent(_projectPath);
 
             return ConvertLevel(level, project, graphicsDevice, projectDirectory);
         }
@@ -141,7 +137,7 @@ public sealed class OgmoJsonParser : ITilemapParser
 
             OgmoProject project = LoadProject(_projectPath);
 
-            string resolvedBasePath = basePath ?? Path.GetDirectoryName(_projectPath);
+            string resolvedBasePath = basePath ?? GetDirectoryOrCurrent(_projectPath);
 
             return ConvertLevel(level, project, graphicsDevice, resolvedBasePath);
         }
@@ -159,17 +155,12 @@ public sealed class OgmoJsonParser : ITilemapParser
         }
     }
 
-    private static OgmoProject LoadProject(string projectPath)
+    private OgmoProject LoadProject(string projectPath)
     {
-        if (!File.Exists(projectPath))
-        {
-            throw new FileNotFoundException($"Ogmo project file not found: {projectPath}", projectPath);
-        }
-
         try
         {
-            string json = File.ReadAllText(projectPath);
-            OgmoProject project = JsonSerializer.Deserialize<OgmoProject>(json, s_jsonOptions);
+            using Stream stream = OpenProjectStream(projectPath);
+            OgmoProject project = JsonSerializer.Deserialize<OgmoProject>(stream, s_jsonOptions);
 
             if (project == null)
             {
@@ -184,10 +175,10 @@ public sealed class OgmoJsonParser : ITilemapParser
         }
     }
 
-    private static OgmoLevel LoadLevel(string levelPath)
+    private OgmoLevel LoadLevel(string levelPath)
     {
-        string json = File.ReadAllText(levelPath);
-        OgmoLevel level = JsonSerializer.Deserialize<OgmoLevel>(json, s_jsonOptions);
+        using Stream stream = OpenLevelStream(levelPath);
+        OgmoLevel level = JsonSerializer.Deserialize<OgmoLevel>(stream, s_jsonOptions);
 
         if (level == null)
         {
@@ -197,9 +188,61 @@ public sealed class OgmoJsonParser : ITilemapParser
         return level;
     }
 
-    private static Tilemap ConvertLevel(OgmoLevel level, OgmoProject project, GraphicsDevice graphicsDevice, string baseDirectory)
+    private Tilemap ConvertLevel(OgmoLevel level, OgmoProject project, GraphicsDevice graphicsDevice, string baseDirectory)
     {
-        TilemapData data = OgmoTilemapDataConverter.Convert(level, project);
-        return TilemapFactory.Build(data, graphicsDevice, baseDirectory);
+        TilemapData data = OgmoTilemapDataConverter.Convert(level, project, baseDirectory, _resourceResolver);
+        return TilemapFactory.Build(data, graphicsDevice, baseDirectory, _resourceResolver);
+    }
+
+    private Stream OpenProjectStream(string projectPath)
+    {
+        try
+        {
+            return _resourceResolver(projectPath);
+        }
+        catch (FileNotFoundException)
+        {
+            throw;
+        }
+        catch (TilemapParseException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new TilemapParseException($"Failed to open Ogmo project file: {projectPath}", ex);
+        }
+    }
+
+    private Stream OpenLevelStream(string levelPath)
+    {
+        try
+        {
+            return _resourceResolver(levelPath);
+        }
+        catch (FileNotFoundException)
+        {
+            throw;
+        }
+        catch (TilemapParseException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new TilemapParseException($"Failed to open Ogmo level file: {levelPath}", ex);
+        }
+    }
+
+    private static string GetDirectoryOrCurrent(string path)
+    {
+        string directory = Path.GetDirectoryName(path);
+
+        if (string.IsNullOrEmpty(directory))
+        {
+            return Directory.GetCurrentDirectory();
+        }
+
+        return directory;
     }
 }

--- a/source/MonoGame.Extended/Tilemaps/Tiled/TiledTmxParser.cs
+++ b/source/MonoGame.Extended/Tilemaps/Tiled/TiledTmxParser.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.Content;
 using MonoGame.Extended.Tilemaps.Parsers;
 using MonoGame.Extended.Tilemaps.Tiled.Converters;
 using MonoGame.Extended.Tilemaps.Tiled.Document;
@@ -16,6 +17,7 @@ namespace MonoGame.Extended.Tilemaps.Tiled;
 public class TiledTmxParser : ITilemapParser
 {
     private readonly string _baseDirectory;
+    private readonly ExternalResourceResolver _resourceResolver;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TiledTmxParser"/> class.
@@ -25,9 +27,14 @@ public class TiledTmxParser : ITilemapParser
     /// <see cref="ParseFromFile"/> will be resolved relative to this directory.
     /// If <see langword="null"/>, paths are resolved from the file's own location.
     /// </param>
-    public TiledTmxParser(string baseDirectory = null)
+    /// <param name="resourceResolver">
+    /// Optional resolver used to open external resources referenced by the map. If
+    /// <see langword="null"/>, resources are opened from the local file system.
+    /// </param>
+    public TiledTmxParser(string baseDirectory = null, ExternalResourceResolver resourceResolver = null)
     {
         _baseDirectory = baseDirectory;
+        _resourceResolver = resourceResolver ?? ExternalResourceResolvers.OpenFile;
     }
 
     /// <inheritdoc/>
@@ -74,7 +81,7 @@ public class TiledTmxParser : ITilemapParser
             LoadExternalTilesets(mapXml, baseDirectory);
 
             TilemapData data = TiledTilemapDataConverter.Convert(mapXml);
-            return TilemapFactory.Build(data, graphicsDevice, baseDirectory);
+            return TilemapFactory.Build(data, graphicsDevice, baseDirectory, _resourceResolver);
         }
         catch (TilemapParseException)
         {
@@ -111,7 +118,7 @@ public class TiledTmxParser : ITilemapParser
             LoadExternalTilesets(mapXml, baseDirectory);
 
             TilemapData data = TiledTilemapDataConverter.Convert(mapXml);
-            return TilemapFactory.Build(data, graphicsDevice, baseDirectory);
+            return TilemapFactory.Build(data, graphicsDevice, baseDirectory, _resourceResolver);
         }
         catch (TilemapParseException)
         {
@@ -147,7 +154,7 @@ public class TiledTmxParser : ITilemapParser
         }
     }
 
-    private static void LoadExternalTilesets(TiledMapXml mapXml, string baseDirectory)
+    private void LoadExternalTilesets(TiledMapXml mapXml, string baseDirectory)
     {
         if (mapXml.Tilesets == null)
         {
@@ -163,16 +170,9 @@ public class TiledTmxParser : ITilemapParser
 
             string tsxPath = Path.Combine(baseDirectory, tilesetRef.Source);
 
-            if (!File.Exists(tsxPath))
-            {
-                throw new TilemapParseException(
-                    $"External tileset '{tilesetRef.Source}' (firstgid={tilesetRef.FirstGlobalId}) " +
-                    $"could not be found. Expected at: {tsxPath}");
-            }
-
             TiledTilesetXml tilesetXml;
 
-            using (Stream stream = File.OpenRead(tsxPath))
+            using (Stream stream = OpenExternalTilesetStream(tilesetRef, tsxPath))
             {
                 try
                 {
@@ -197,6 +197,24 @@ public class TiledTmxParser : ITilemapParser
 
             tilesetXml.FirstGlobalId = tilesetRef.FirstGlobalId;
             tilesetRef.TilesetData = tilesetXml;
+        }
+    }
+
+    private Stream OpenExternalTilesetStream(TiledTilesetRefXml tilesetRef, string tsxPath)
+    {
+        try
+        {
+            return _resourceResolver(tsxPath);
+        }
+        catch (TilemapParseException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new TilemapParseException(
+                $"External tileset '{tilesetRef.Source}' (firstgid={tilesetRef.FirstGlobalId}) " +
+                $"could not be opened. Expected at: {tsxPath}", ex);
         }
     }
 }

--- a/source/MonoGame.Extended/Tilemaps/TilemapFactory.cs
+++ b/source/MonoGame.Extended/Tilemaps/TilemapFactory.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.Content;
 using MonoGame.Extended.Tilemaps.Parsers;
 
 namespace MonoGame.Extended.Tilemaps;
 
 /// <summary>
 /// Constructs a <see cref="Tilemap"/> from a <see cref="TilemapData"/> intermediate
-/// representation, loading textures from disk using the provided graphics device.
+/// representation, loading textures using the provided graphics device.
 /// </summary>
 public static class TilemapFactory
 {
@@ -23,9 +24,24 @@ public static class TilemapFactory
     /// <exception cref="TilemapParseException">Thrown when a texture cannot be loaded.</exception>
     public static Tilemap Build(TilemapData data, GraphicsDevice graphicsDevice, string baseDirectory)
     {
+        return Build(data, graphicsDevice, baseDirectory, ExternalResourceResolvers.OpenFile);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="Tilemap"/> from the given <see cref="TilemapData"/>.
+    /// </summary>
+    /// <param name="data">The tilemap data.</param>
+    /// <param name="graphicsDevice">The graphics device used to load textures.</param>
+    /// <param name="baseDirectory">The directory used to resolve relative texture paths.</param>
+    /// <param name="resourceResolver">The resolver used to open texture streams.</param>
+    /// <returns>The constructed tilemap.</returns>
+    /// <exception cref="TilemapParseException">Thrown when a texture cannot be loaded.</exception>
+    public static Tilemap Build(TilemapData data, GraphicsDevice graphicsDevice, string baseDirectory, ExternalResourceResolver resourceResolver)
+    {
         ArgumentNullException.ThrowIfNull(data);
         ArgumentNullException.ThrowIfNull(graphicsDevice);
         ArgumentNullException.ThrowIfNull(baseDirectory);
+        ArgumentNullException.ThrowIfNull(resourceResolver);
 
         Tilemap tilemap = new Tilemap(
             name: data.Name ?? "Untitled",
@@ -54,19 +70,19 @@ public static class TilemapFactory
                 continue;
             }
 
-            TilemapTileset tileset = BuildTileset(entry, graphicsDevice, baseDirectory);
+            TilemapTileset tileset = BuildTileset(entry, graphicsDevice, baseDirectory, resourceResolver);
             tilemap.Tilesets.Add(tileset);
         }
 
         foreach (TilemapLayerData layerData in data.Layers)
         {
-            FlattenLayers(layerData, string.Empty, data, graphicsDevice, baseDirectory, tilemap.Layers);
+            FlattenLayers(layerData, string.Empty, data, graphicsDevice, baseDirectory, resourceResolver, tilemap.Layers);
         }
 
         return tilemap;
     }
 
-    private static void FlattenLayers(TilemapLayerData layerData, string pathPrefix, TilemapData mapData, GraphicsDevice graphicsDevice, string baseDirectory, TilemapLayerCollection layers)
+    private static void FlattenLayers(TilemapLayerData layerData, string pathPrefix, TilemapData mapData, GraphicsDevice graphicsDevice, string baseDirectory, ExternalResourceResolver resourceResolver, TilemapLayerCollection layers)
     {
         if (layerData is TilemapGroupLayerData groupData)
         {
@@ -76,7 +92,7 @@ public static class TilemapFactory
 
             foreach (TilemapLayerData child in groupData.Layers)
             {
-                FlattenLayers(child, groupPath, mapData, graphicsDevice, baseDirectory, layers);
+                FlattenLayers(child, groupPath, mapData, graphicsDevice, baseDirectory, resourceResolver, layers);
             }
         }
         else
@@ -88,7 +104,7 @@ public static class TilemapFactory
                 layerData.Name = pathPrefix + "/" + (layerData.Name ?? string.Empty);
             }
 
-            TilemapLayer layer = BuildLayer(layerData, mapData, graphicsDevice, baseDirectory);
+            TilemapLayer layer = BuildLayer(layerData, mapData, graphicsDevice, baseDirectory, resourceResolver);
 
             if (layer != null)
             {
@@ -99,7 +115,7 @@ public static class TilemapFactory
 
     #region Tilesets
 
-    private static TilemapTileset BuildTileset(TilemapTilesetEntry entry, GraphicsDevice graphicsDevice, string baseDirectory)
+    private static TilemapTileset BuildTileset(TilemapTilesetEntry entry, GraphicsDevice graphicsDevice, string baseDirectory, ExternalResourceResolver resourceResolver)
     {
         TilemapTilesetData tilesetData = entry.InlineData;
         Texture2D texture = null;
@@ -108,7 +124,7 @@ public static class TilemapFactory
         {
             try
             {
-                texture = LoadTexture(tilesetData.TexturePath, graphicsDevice, baseDirectory);
+                texture = LoadTexture(tilesetData.TexturePath, graphicsDevice, baseDirectory, resourceResolver);
             }
             catch (TilemapParseException ex)
             {
@@ -135,14 +151,14 @@ public static class TilemapFactory
 
         foreach (TilemapTileEntryData tileEntry in tilesetData.Tiles)
         {
-            TilemapTileData tileData = BuildTileData(tileEntry, graphicsDevice, baseDirectory);
+            TilemapTileData tileData = BuildTileData(tileEntry, graphicsDevice, baseDirectory, resourceResolver);
             tileset.AddTileData(tileData);
         }
 
         return tileset;
     }
 
-    private static TilemapTileData BuildTileData(TilemapTileEntryData entryData, GraphicsDevice graphicsDevice, string baseDirectory)
+    private static TilemapTileData BuildTileData(TilemapTileEntryData entryData, GraphicsDevice graphicsDevice, string baseDirectory, ExternalResourceResolver resourceResolver)
     {
         TilemapTileData tileData = new TilemapTileData(entryData.LocalId);
         tileData.Class = entryData.Class ?? string.Empty;
@@ -154,7 +170,7 @@ public static class TilemapFactory
         {
             try
             {
-                tileData.CustomImage = LoadTexture(entryData.ImagePath, graphicsDevice, baseDirectory);
+                tileData.CustomImage = LoadTexture(entryData.ImagePath, graphicsDevice, baseDirectory, resourceResolver);
             }
             catch (TilemapParseException ex)
             {
@@ -193,7 +209,7 @@ public static class TilemapFactory
 
     #region Layers
 
-    private static TilemapLayer BuildLayer(TilemapLayerData layerData, TilemapData mapData, GraphicsDevice graphicsDevice, string baseDirectory)
+    private static TilemapLayer BuildLayer(TilemapLayerData layerData, TilemapData mapData, GraphicsDevice graphicsDevice, string baseDirectory, ExternalResourceResolver resourceResolver)
     {
         TilemapLayer layer;
 
@@ -208,7 +224,7 @@ public static class TilemapFactory
                 break;
 
             case TilemapImageLayerData imageLayerData:
-                layer = BuildImageLayer(imageLayerData, graphicsDevice, baseDirectory);
+                layer = BuildImageLayer(imageLayerData, graphicsDevice, baseDirectory, resourceResolver);
                 break;
 
             case TilemapDataLayerData dataLayerData:
@@ -278,7 +294,7 @@ public static class TilemapFactory
         return layer;
     }
 
-    private static TilemapImageLayer BuildImageLayer(TilemapImageLayerData data, GraphicsDevice graphicsDevice, string baseDirectory)
+    private static TilemapImageLayer BuildImageLayer(TilemapImageLayerData data, GraphicsDevice graphicsDevice, string baseDirectory, ExternalResourceResolver resourceResolver)
     {
         if (string.IsNullOrEmpty(data.TexturePath))
         {
@@ -289,7 +305,7 @@ public static class TilemapFactory
 
         try
         {
-            texture = LoadTexture(data.TexturePath, graphicsDevice, baseDirectory);
+            texture = LoadTexture(data.TexturePath, graphicsDevice, baseDirectory, resourceResolver);
         }
         catch (TilemapParseException ex)
         {
@@ -446,7 +462,7 @@ public static class TilemapFactory
 
     #region Texture Loading
 
-    private static Texture2D LoadTexture(string path, GraphicsDevice graphicsDevice, string baseDirectory)
+    private static Texture2D LoadTexture(string path, GraphicsDevice graphicsDevice, string baseDirectory, ExternalResourceResolver resourceResolver)
     {
         // Support Ogmo-style embedded tileset images stored as base64 data URIs.
         if (path.StartsWith("data:image", StringComparison.OrdinalIgnoreCase))
@@ -458,14 +474,9 @@ public static class TilemapFactory
             ? path
             : Path.Combine(baseDirectory, path);
 
-        if (!File.Exists(fullPath))
-        {
-            throw new TilemapParseException($"Texture file not found: {fullPath}");
-        }
-
         try
         {
-            using FileStream stream = File.OpenRead(fullPath);
+            using Stream stream = resourceResolver(fullPath);
             return Texture2D.FromStream(graphicsDevice, stream);
         }
         catch (Exception ex)

--- a/tests/MonoGame.Extended.Tests/Tilemaps/TiledTmxParserTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tilemaps/TiledTmxParserTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.Tests.Fixtures;
@@ -512,6 +514,71 @@ public class TiledTmxParserTests
         Assert.Contains("sky.png", ex.Message);
     }
 
+    [Fact]
+    public void ParseFromStream_WithExternalResourceResolver_LoadsExternalTileset()
+    {
+        string testDataPath = GetTestDataPath();
+        byte[] textureBytes = File.ReadAllBytes(Path.Combine(testDataPath, "test-tileset.png"));
+
+        string tmx = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<map version=""1.0"" orientation=""orthogonal"" renderorder=""right-down""
+     width=""1"" height=""1"" tilewidth=""32"" tileheight=""32"">
+ <tileset firstgid=""1"" source=""external.tsx""/>
+ <layer name=""Layer 1"" width=""1"" height=""1"">
+  <data encoding=""csv"">1</data>
+ </layer>
+</map>";
+
+        string tsx = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<tileset version=""1.0"" name=""ExternalTiles"" tilewidth=""32"" tileheight=""32"" tilecount=""9"" columns=""3"">
+ <image source=""test-tileset.png"" width=""104"" height=""104""/>
+</tileset>";
+
+        Dictionary<string, byte[]> resources = new Dictionary<string, byte[]>
+        {
+            ["external.tsx"] = Encoding.UTF8.GetBytes(tsx),
+            ["test-tileset.png"] = textureBytes
+        };
+
+        TiledTmxParser parser = new TiledTmxParser(resourceResolver: path => OpenResourceByFileName(resources, path));
+        using MemoryStream stream = CreateXmlStream(tmx);
+
+        Tilemap tilemap = parser.ParseFromStream(stream, _graphicsDevice, "virtual");
+
+        TilemapTileset tileset = Assert.Single(tilemap.Tilesets);
+        Assert.Equal("ExternalTiles", tileset.Name);
+        Assert.NotNull(tileset.Texture);
+    }
+
+    [Fact]
+    public void ParseFromStream_WithExternalResourceResolver_LoadsImageLayerTexture()
+    {
+        string testDataPath = GetTestDataPath();
+        byte[] textureBytes = File.ReadAllBytes(Path.Combine(testDataPath, "test-tileset.png"));
+
+        string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<map version=""1.0"" orientation=""orthogonal"" renderorder=""right-down""
+     width=""1"" height=""1"" tilewidth=""32"" tileheight=""32"">
+ <imagelayer name=""Background"">
+  <image source=""background.png"" width=""104"" height=""104""/>
+ </imagelayer>
+</map>";
+
+        Dictionary<string, byte[]> resources = new Dictionary<string, byte[]>
+        {
+            ["background.png"] = textureBytes
+        };
+
+        TiledTmxParser parser = new TiledTmxParser(resourceResolver: path => OpenResourceByFileName(resources, path));
+        using MemoryStream stream = CreateXmlStream(xml);
+
+        Tilemap tilemap = parser.ParseFromStream(stream, _graphicsDevice, "virtual");
+
+        TilemapImageLayer layer = Assert.IsType<TilemapImageLayer>(Assert.Single(tilemap.Layers));
+        Assert.Equal("Background", layer.Name);
+        Assert.NotNull(layer.Texture);
+    }
+
     // Added while investigating issue #1138:
     // https://github.com/MonoGame-Extended/Monogame-Extended/issues/1138
     [Fact]
@@ -587,5 +654,22 @@ public class TiledTmxParserTests
         }
 
         return testDataPath;
+    }
+
+    private static MemoryStream CreateXmlStream(string xml)
+    {
+        return new MemoryStream(Encoding.UTF8.GetBytes(xml));
+    }
+
+    private static Stream OpenResourceByFileName(Dictionary<string, byte[]> resources, string path)
+    {
+        string fileName = Path.GetFileName(path);
+
+        if (!resources.TryGetValue(fileName, out byte[] bytes))
+        {
+            throw new FileNotFoundException($"Resource not found: {path}", path);
+        }
+
+        return new MemoryStream(bytes, writable: false);
     }
 }


### PR DESCRIPTION
## Description

Adds a resolver based external resource loader for runtime tilemap parsers. This allows consumers to load tilemap dependencies from sources other than the local file system. This solves the issue where `ParseFromStream` could accept a stream for the root tilemap file but still required external dependencies, such as Tiled `.tsx` files and textures, to be available through direct file-system access.

## Related Issues/Tickets

* Closes #1141

## Changes Made

* Added `ExternalResourceResolver` delegate and built in resolver helpers for file system and `TitleContainer` loading.
* Updated `TiledTmxParser` to use the resolver for external `.tsx` tilesets and texture dependencies.
* Updated `LDtkJsonParser` to use the resolver for project files, external levels, and texture dependencies.
* Updated `OgmoJsonParser` and `OgmoTilemapDataConverter` to use the resolver for project files, level files, tileset image probing, and texture dependencies.
* Added resolver aware `TilemapFactory.Build` overload

## Checklist

Please read and check the following items. Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
